### PR TITLE
[feat] 카테고리/난이도 기반 매칭 시작 기능 구현

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueController.java
+++ b/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueController.java
@@ -1,0 +1,29 @@
+package com.back.domain.matching.queue.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStatusResponse;
+import com.back.domain.matching.queue.service.MatchingQueueService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/queue")
+@RequiredArgsConstructor
+public class MatchingQueueController {
+
+    private final MatchingQueueService matchingQueueService;
+
+    /**
+     * 매칭 시작 요청
+     *
+     * 지금은 테스트를 위해 userId를 요청 파라미터로 받는다.
+     * 나중에는 JWT에서 userId를 꺼내도록 바꿀 수 있다.
+     */
+    @PostMapping("/join")
+    public QueueStatusResponse joinQueue(@RequestParam Long userId, @Valid @RequestBody QueueJoinRequest request) {
+        return matchingQueueService.joinQueue(userId, request);
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/dto/QueueJoinRequest.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/QueueJoinRequest.java
@@ -4,11 +4,12 @@ import com.back.domain.matching.queue.model.Difficulty;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 큐 참가 요청 DTO
+ * 매칭 시작 요청 DTO
  *
  * 예:
  * {
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class QueueJoinRequest {
 
     @NotBlank(message = "카테고리는 필수입니다.") private String category;

--- a/src/main/java/com/back/domain/matching/queue/dto/QueueJoinRequest.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/QueueJoinRequest.java
@@ -1,0 +1,26 @@
+package com.back.domain.matching.queue.dto;
+
+import com.back.domain.matching.queue.model.Difficulty;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 큐 참가 요청 DTO
+ *
+ * 예:
+ * {
+ *   "category": "Array",
+ *   "difficulty": "EASY"
+ * }
+ */
+@Getter
+@NoArgsConstructor
+public class QueueJoinRequest {
+
+    @NotBlank(message = "카테고리는 필수입니다.") private String category;
+
+    @NotNull(message = "난이도는 필수입니다.") private Difficulty difficulty;
+}

--- a/src/main/java/com/back/domain/matching/queue/dto/QueueStatusResponse.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/QueueStatusResponse.java
@@ -1,0 +1,39 @@
+package com.back.domain.matching.queue.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 매칭 시작 요청 결과를 프론트에 전달하는 응답 DTO
+ *
+ * 예를 들어 사용자가 매칭 시작 버튼을 눌렀을 때,
+ * 백엔드는 대기열 등록 결과와 현재 대기 인원 수를 이 객체에 담아 응답한다.
+ */
+@Getter
+@AllArgsConstructor
+public class QueueStatusResponse {
+
+    /**
+     * 처리 결과 메시지
+     * 예: "매칭 대기열에 참가했습니다."
+     */
+    private String message;
+
+    /**
+     * 사용자가 참가한 카테고리
+     * 내부적으로는 정규화된 값이 들어갈 수 있다.
+     * 예: "ARRAY"
+     */
+    private String category;
+
+    /**
+     * 사용자가 참가한 문제 난이도
+     * 예: "EASY"
+     */
+    private String difficulty;
+
+    /**
+     * 해당 카테고리 + 난이도 큐에서 현재 대기 중인 인원 수
+     */
+    private int waitingCount;
+}

--- a/src/main/java/com/back/domain/matching/queue/model/Difficulty.java
+++ b/src/main/java/com/back/domain/matching/queue/model/Difficulty.java
@@ -1,0 +1,10 @@
+package com.back.domain.matching.queue.model;
+
+/**
+ * 사용자가 큐에 들어갈 때 선택하는 문제 난이도
+ */
+public enum Difficulty {
+    EASY,
+    MEDIUM,
+    HARD
+}

--- a/src/main/java/com/back/domain/matching/queue/model/QueueKey.java
+++ b/src/main/java/com/back/domain/matching/queue/model/QueueKey.java
@@ -1,0 +1,14 @@
+package com.back.domain.matching.queue.model;
+
+/**
+ * 어떤 대기열(큐)에 들어가는지를 구분하는 키
+ *
+ * category + difficulty 조합으로 하나의 큐를 식별한다.
+ */
+public record QueueKey(String category, Difficulty difficulty) {
+
+    public QueueKey {
+        // 카테고리 공백 제거 + 대소문자 차이 줄이기
+        category = category == null ? null : category.trim().toUpperCase();
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/model/WaitingUser.java
+++ b/src/main/java/com/back/domain/matching/queue/model/WaitingUser.java
@@ -3,28 +3,55 @@ package com.back.domain.matching.queue.model;
 import java.time.LocalDateTime;
 
 /**
- * 현재 대기열에서 기다리고 있는 사용자 정보
+ * 현재 매칭 대기열에서 기다리고 있는 사용자 정보를 저장하는 객체
+ *
+ * 이 객체는 DB에 저장되는 엔티티가 아니라,
+ * 서버 메모리의 대기열 안에서만 사용되는 매칭용 모델이다.
  */
 public class WaitingUser {
 
+    // 대기 중인 사용자의 고유 ID
     private final Long userId;
+
+    /**
+     * 사용자가 어떤 조건의 큐에 들어갔는지 나타내는 값
+     * 예: (ARRAY, EASY)
+     */
     private final QueueKey queueKey;
+
+    /**
+     * 사용자가 대기열에 들어온 시각
+     *
+     * 나중에 먼저 들어온 사용자를 우선 매칭하거나,
+     * 대기 시간을 계산할 때 활용할 수 있다.
+     */
     private final LocalDateTime joinedAt;
 
+    /**
+     * WaitingUser 생성자
+     *
+     * 사용자가 매칭 시작 요청을 보내면
+     * 해당 userId와 queueKey를 기반으로 대기 사용자 객체를 만든다.
+     *
+     * joinedAt은 객체가 생성되는 현재 시각으로 자동 저장한다.
+     */
     public WaitingUser(Long userId, QueueKey queueKey) {
         this.userId = userId;
         this.queueKey = queueKey;
         this.joinedAt = LocalDateTime.now();
     }
 
+    // 대기 중인 사용자의 ID 반환
     public Long getUserId() {
         return userId;
     }
 
+    // 사용자가 속한 큐 정보 반환
     public QueueKey getQueueKey() {
         return queueKey;
     }
 
+    // 사용자가 대기열에 참가한 시각 반환
     public LocalDateTime getJoinedAt() {
         return joinedAt;
     }

--- a/src/main/java/com/back/domain/matching/queue/model/WaitingUser.java
+++ b/src/main/java/com/back/domain/matching/queue/model/WaitingUser.java
@@ -1,0 +1,31 @@
+package com.back.domain.matching.queue.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * 현재 대기열에서 기다리고 있는 사용자 정보
+ */
+public class WaitingUser {
+
+    private final Long userId;
+    private final QueueKey queueKey;
+    private final LocalDateTime joinedAt;
+
+    public WaitingUser(Long userId, QueueKey queueKey) {
+        this.userId = userId;
+        this.queueKey = queueKey;
+        this.joinedAt = LocalDateTime.now();
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public QueueKey getQueueKey() {
+        return queueKey;
+    }
+
+    public LocalDateTime getJoinedAt() {
+        return joinedAt;
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -15,6 +15,7 @@ import com.back.domain.matching.queue.model.WaitingUser;
 @Service
 public class MatchingQueueService {
 
+    // TODO: 지금 현재 인메모리 방식임 redis로 전환하면 좋음 MVP 이기 때문
     /**
      * 카테고리 + 난이도별 대기열
      *

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -45,11 +45,12 @@ public class MatchingQueueService {
      */
     public QueueStatusResponse joinQueue(Long userId, QueueJoinRequest request) {
         // 이미 대기열에 들어가 있는 유저는 다시 참가할 수 없다.
-        if (userQueueMap.containsKey(userId)) {
+        QueueKey queueKey = new QueueKey(request.getCategory(), request.getDifficulty());
+
+        // putIfAbsent를 사용하여 중복 참가를 원자적으로 방지합니다.
+        if (userQueueMap.putIfAbsent(userId, queueKey) != null) {
             throw new IllegalStateException("이미 매칭 대기열에 참가 중인 사용자입니다.");
         }
-
-        QueueKey queueKey = new QueueKey(request.getCategory(), request.getDifficulty());
 
         // 해당 큐가 없으면 새로 만들고, 있으면 기존 큐를 가져온다.
         Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
@@ -58,9 +59,6 @@ public class MatchingQueueService {
 
         // 큐의 맨 뒤에 추가
         queue.addLast(waitingUser);
-
-        // 유저가 어느 큐에 들어갔는지 기록
-        userQueueMap.put(userId, queueKey);
 
         return new QueueStatusResponse(
                 "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -1,0 +1,67 @@
+package com.back.domain.matching.queue.service;
+
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import org.springframework.stereotype.Service;
+
+import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStatusResponse;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.WaitingUser;
+
+@Service
+public class MatchingQueueService {
+
+    /**
+     * 카테고리 + 난이도별 대기열
+     *
+     * 예:
+     * ARRAY + EASY -> [1번 유저, 7번 유저]
+     * GRAPH + HARD -> [3번 유저]
+     */
+    private final Map<QueueKey, Deque<WaitingUser>> waitingQueues = new ConcurrentHashMap<>();
+
+    /**
+     * 특정 유저가 이미 대기열에 들어가 있는지 빠르게 확인하기 위한 맵
+     *
+     * 예:
+     * 1L -> (ARRAY, EASY)
+     * 7L -> (ARRAY, EASY)
+     */
+    private final Map<Long, QueueKey> userQueueMap = new ConcurrentHashMap<>();
+
+    /**
+     * 매칭 시작 요청 처리
+     *
+     * 1. 이미 대기열에 참가 중인지 확인
+     * 2. category + difficulty 로 QueueKey 생성
+     * 3. 해당 QueueKey의 큐가 없으면 생성
+     * 4. 유저를 대기열에 추가
+     * 5. userQueueMap에도 기록
+     */
+    public QueueStatusResponse joinQueue(Long userId, QueueJoinRequest request) {
+        // 이미 대기열에 들어가 있는 유저는 다시 참가할 수 없다.
+        if (userQueueMap.containsKey(userId)) {
+            throw new IllegalStateException("이미 매칭 대기열에 참가 중인 사용자입니다.");
+        }
+
+        QueueKey queueKey = new QueueKey(request.getCategory(), request.getDifficulty());
+
+        // 해당 큐가 없으면 새로 만들고, 있으면 기존 큐를 가져온다.
+        Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
+
+        WaitingUser waitingUser = new WaitingUser(userId, queueKey);
+
+        // 큐의 맨 뒤에 추가
+        queue.addLast(waitingUser);
+
+        // 유저가 어느 큐에 들어갔는지 기록
+        userQueueMap.put(userId, queueKey);
+
+        return new QueueStatusResponse(
+                "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -3,8 +3,6 @@ package com.back.domain.matching.queue.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.lang.reflect.Field;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +16,7 @@ class MatchingQueueServiceTest {
 
     @Test
     @DisplayName("사용자는 카테고리와 난이도를 선택해 매칭 대기열에 참가할 수 있다")
-    void joinQueue_success() throws Exception {
+    void joinQueue_success() {
         // given
         Long userId = 1L;
         QueueJoinRequest request = createRequest("Array", Difficulty.EASY);
@@ -35,7 +33,7 @@ class MatchingQueueServiceTest {
 
     @Test
     @DisplayName("이미 대기열에 참가 중인 사용자는 중복 참가할 수 없다")
-    void joinQueue_fail_whenAlreadyJoined() throws Exception {
+    void joinQueue_fail_whenAlreadyJoined() {
         // given
         Long userId = 1L;
         QueueJoinRequest request = createRequest("Array", Difficulty.EASY);
@@ -48,21 +46,7 @@ class MatchingQueueServiceTest {
                 .hasMessage("이미 매칭 대기열에 참가 중인 사용자입니다.");
     }
 
-    /**
-     * QueueJoinRequest는 현재 기본 생성자만 있고 setter가 없으므로
-     * 테스트에서는 reflection으로 필드 값을 넣는다.
-     */
-    private QueueJoinRequest createRequest(String category, Difficulty difficulty) throws Exception {
-        QueueJoinRequest request = new QueueJoinRequest();
-
-        Field categoryField = QueueJoinRequest.class.getDeclaredField("category");
-        categoryField.setAccessible(true);
-        categoryField.set(request, category);
-
-        Field difficultyField = QueueJoinRequest.class.getDeclaredField("difficulty");
-        difficultyField.setAccessible(true);
-        difficultyField.set(request, difficulty);
-
-        return request;
+    private QueueJoinRequest createRequest(String category, Difficulty difficulty) {
+        return new QueueJoinRequest(category, difficulty);
     }
 }

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -1,0 +1,68 @@
+package com.back.domain.matching.queue.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStatusResponse;
+import com.back.domain.matching.queue.model.Difficulty;
+
+class MatchingQueueServiceTest {
+
+    private final MatchingQueueService matchingQueueService = new MatchingQueueService();
+
+    @Test
+    @DisplayName("사용자는 카테고리와 난이도를 선택해 매칭 대기열에 참가할 수 있다")
+    void joinQueue_success() throws Exception {
+        // given
+        Long userId = 1L;
+        QueueJoinRequest request = createRequest("Array", Difficulty.EASY);
+
+        // when
+        QueueStatusResponse response = matchingQueueService.joinQueue(userId, request);
+
+        // then
+        assertThat(response.getMessage()).isEqualTo("매칭 대기열에 참가했습니다.");
+        assertThat(response.getCategory()).isEqualTo("ARRAY");
+        assertThat(response.getDifficulty()).isEqualTo("EASY");
+        assertThat(response.getWaitingCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("이미 대기열에 참가 중인 사용자는 중복 참가할 수 없다")
+    void joinQueue_fail_whenAlreadyJoined() throws Exception {
+        // given
+        Long userId = 1L;
+        QueueJoinRequest request = createRequest("Array", Difficulty.EASY);
+
+        matchingQueueService.joinQueue(userId, request);
+
+        // when & then
+        assertThatThrownBy(() -> matchingQueueService.joinQueue(userId, request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 매칭 대기열에 참가 중인 사용자입니다.");
+    }
+
+    /**
+     * QueueJoinRequest는 현재 기본 생성자만 있고 setter가 없으므로
+     * 테스트에서는 reflection으로 필드 값을 넣는다.
+     */
+    private QueueJoinRequest createRequest(String category, Difficulty difficulty) throws Exception {
+        QueueJoinRequest request = new QueueJoinRequest();
+
+        Field categoryField = QueueJoinRequest.class.getDeclaredField("category");
+        categoryField.setAccessible(true);
+        categoryField.set(request, category);
+
+        Field difficultyField = QueueJoinRequest.class.getDeclaredField("difficulty");
+        difficultyField.setAccessible(true);
+        difficultyField.set(request, difficulty);
+
+        return request;
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #20 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #20 

---
<hr>

<h2>📝 작업 내용</h2>
<p>
이번 PR은 사용자가 <strong>카테고리와 난이도</strong>를 선택해 매칭 대기열에 들어가는
<strong>매칭 시작 기능</strong>을 구현한 내용입니다.
</p>

<p>
단순히 요청만 받는 수준이 아니라,
서버 내부에서 <strong>카테고리 + 난이도 조합별로 대기열을 분리</strong>하고,
<strong>같은 사용자의 중복 참가를 방지</strong>하며,
프론트가 바로 활용할 수 있도록 <strong>현재 대기 인원 수까지 응답</strong>하도록 구성했습니다.
</p>

<h3>추가된 파일</h3>
<ul>
<li><code>MatchingQueueController.java</code> - 매칭 시작 API 진입점</li>
<li><code>QueueJoinRequest.java</code> - 매칭 시작 요청 DTO</li>
<li><code>QueueStatusResponse.java</code> - 대기열 등록 결과 응답 DTO</li>
<li><code>Difficulty.java</code> - 큐에서 사용하는 난이도 enum</li>
<li><code>QueueKey.java</code> - 카테고리 + 난이도 조합 키</li>
<li><code>WaitingUser.java</code> - 대기열 참가 사용자 모델</li>
<li><code>MatchingQueueService.java</code> - 대기열 등록 및 중복 참가 방지 서비스</li>
<li><code>MatchingQueueServiceTest.java</code> - 서비스 단위 테스트</li>
</ul>

<hr>

<h2>1. 매칭 시작 API 추가</h2>
<p>
사용자가 매칭 시작 버튼을 누르면 서버가 카테고리/난이도 조건을 받아
해당 대기열에 등록할 수 있도록 API를 추가했습니다.
</p>

<pre><code class="language-java">@PostMapping("/join")
public QueueStatusResponse joinQueue(@RequestParam Long userId,
                                     @Valid @RequestBody QueueJoinRequest request) {
    return matchingQueueService.joinQueue(userId, request);
}</code></pre>

<h3>요청 방식</h3>
<ul>
<li><code>POST /api/v1/queue/join</code></li>
<li>현재는 테스트 편의를 위해 <code>userId</code>를 요청 파라미터로 받습니다.</li>
<li>향후에는 JWT에서 사용자 식별 정보를 꺼내는 방식으로 변경할 수 있도록 주석을 남겨두었습니다.</li>
</ul>

<h3>요청 예시</h3>
<pre><code class="language-json">{
  "category": "Array",
  "difficulty": "EASY"
}</code></pre>

<hr>

<h2>2. 요청 DTO 및 난이도 모델 추가</h2>
<p>
매칭 시작 요청을 명확히 받기 위해 DTO를 만들고,
큐 도메인에서 사용할 난이도 enum을 분리했습니다.
</p>

<pre><code class="language-java">@Getter
@NoArgsConstructor
@AllArgsConstructor
public class QueueJoinRequest {

    @NotBlank(message = "카테고리는 필수입니다.")
    private String category;

    @NotNull(message = "난이도는 필수입니다.")
    private Difficulty difficulty;
}</code></pre>

<p>
검증 조건은 아래처럼 적용했습니다.
</p>
<ul>
<li><code>category</code>는 공백 불가</li>
<li><code>difficulty</code>는 null 불가</li>
</ul>

<pre><code class="language-java">public enum Difficulty {
    EASY,
    MEDIUM,
    HARD
}</code></pre>

<p>
초기에는 기본 생성자만 있었지만,
마지막 수정에서 <code>@AllArgsConstructor</code>를 추가해
테스트 코드가 리플렉션 없이 DTO를 생성할 수 있도록 개선했습니다.
</p>

<hr>

<h2>3. 카테고리 + 난이도별 대기열 분리</h2>
<p>
매칭 큐는 하나의 공용 리스트가 아니라,
<strong>카테고리 + 난이도 조합마다 별도 큐</strong>로 관리되도록 구성했습니다.
</p>

<pre><code class="language-java">private final Map&lt;QueueKey, Deque&lt;WaitingUser&gt;&gt; waitingQueues = new ConcurrentHashMap&lt;&gt;();</code></pre>

<p>
여기서 핵심은 <code>QueueKey</code>입니다.
같은 카테고리/난이도 조합이면 같은 큐로 들어가고,
조합이 다르면 서로 다른 큐로 분리됩니다.
</p>

<pre><code class="language-java">public record QueueKey(String category, Difficulty difficulty) {

    public QueueKey {
        category = category == null ? null : category.trim().toUpperCase();
    }
}</code></pre>

<h3>이렇게 처리한 이유</h3>
<ul>
<li><code>Array</code>, <code> array </code>, <code>ARRAY</code>처럼 입력 형식이 달라도 같은 카테고리로 취급하기 위해서입니다.</li>
<li>대기열 키 생성 시 공백 제거 + 대문자 정규화를 수행해 동일 조건 큐로 묶이도록 했습니다.</li>
</ul>

<h3>예시</h3>
<pre><code class="language-java">ARRAY + EASY  -&gt; 하나의 대기열
GRAPH + HARD  -&gt; 별도의 대기열</code></pre>

<hr>

<h2>4. 대기 사용자 모델 추가</h2>
<p>
큐 안에 단순히 userId만 넣는 대신,
대기열 참가 시점과 소속 큐 정보를 함께 갖는 <code>WaitingUser</code> 모델을 추가했습니다.
</p>

<pre><code class="language-java">public class WaitingUser {

    private final Long userId;
    private final QueueKey queueKey;
    private final LocalDateTime joinedAt;

    public WaitingUser(Long userId, QueueKey queueKey) {
        this.userId = userId;
        this.queueKey = queueKey;
        this.joinedAt = LocalDateTime.now();
    }
}</code></pre>

<h3>포함된 정보</h3>
<ul>
<li><code>userId</code> - 대기 중인 사용자 식별자</li>
<li><code>queueKey</code> - 어떤 조건의 큐에 들어갔는지</li>
<li><code>joinedAt</code> - 언제 대기열에 참가했는지</li>
</ul>

<p>
현재 단계에서는 등록용 모델이지만,
이후 <strong>선입선출 매칭</strong>, <strong>대기 시간 계산</strong>, <strong>타임아웃 처리</strong> 같은 로직으로 확장하기 쉬운 구조입니다.
</p>

<hr>

<h2>5. 매칭 시작 서비스 구현</h2>
<p>
실제 대기열 등록 로직은 <code>MatchingQueueService</code>에서 처리하도록 구현했습니다.
</p>

<pre><code class="language-java">public QueueStatusResponse joinQueue(Long userId, QueueJoinRequest request) {
    QueueKey queueKey = new QueueKey(request.getCategory(), request.getDifficulty());

    if (userQueueMap.putIfAbsent(userId, queueKey) != null) {
        throw new IllegalStateException("이미 매칭 대기열에 참가 중인 사용자입니다.");
    }

    Deque&lt;WaitingUser&gt; queue =
            waitingQueues.computeIfAbsent(queueKey, key -&gt; new ConcurrentLinkedDeque&lt;&gt;());

    WaitingUser waitingUser = new WaitingUser(userId, queueKey);
    queue.addLast(waitingUser);

    return new QueueStatusResponse(
            "매칭 대기열에 참가했습니다.",
            queueKey.category(),
            queueKey.difficulty().name(),
            queue.size());
}</code></pre>

<h3>동작 순서</h3>
<ol>
<li>요청값으로 <code>QueueKey(category, difficulty)</code> 생성</li>
<li><code>userQueueMap</code>에서 해당 사용자가 이미 큐에 있는지 확인</li>
<li>중복이 아니면 해당 조건의 큐를 조회하거나 새로 생성</li>
<li><code>WaitingUser</code>를 만들어 큐 뒤쪽에 추가</li>
<li>메시지/카테고리/난이도/현재 대기 인원 수를 응답</li>
</ol>

<hr>

<h2>6. 중복 참가 방지 로직 보완</h2>
<p>
이 브랜치에서 중요한 수정 포인트 중 하나는
<strong>중복 참가 체크를 원자적으로 바꾼 것</strong>입니다.
</p>

<p>
초기 구현은 아래처럼 동작했습니다.
</p>

<pre><code class="language-java">if (userQueueMap.containsKey(userId)) {
    throw new IllegalStateException(...);
}
...
userQueueMap.put(userId, queueKey);</code></pre>

<p>
하지만 이 방식은 동시에 거의 같은 시점에 요청이 들어오면,
두 요청 모두 <code>containsKey</code>를 통과한 뒤 각각 <code>put</code>할 수 있는 여지가 있습니다.
즉, 경쟁 상황에서 같은 사용자가 중복 등록될 가능성이 있습니다.
</p>

<p>
그래서 최종적으로 아래처럼 수정했습니다.
</p>

<pre><code class="language-java">if (userQueueMap.putIfAbsent(userId, queueKey) != null) {
    throw new IllegalStateException("이미 매칭 대기열에 참가 중인 사용자입니다.");
}</code></pre>

<h3>변경 효과</h3>
<ul>
<li>중복 체크와 기록을 한 번에 처리</li>
<li>경쟁 상황에서도 같은 사용자의 중복 참가를 원자적으로 차단</li>
<li>매칭 시작 API가 동시에 여러 번 눌리는 상황에 더 안전하게 동작</li>
</ul>

<hr>

<h2>7. 응답 DTO 구성</h2>
<p>
프론트가 대기열 등록 결과를 즉시 표시할 수 있도록
응답 DTO에 현재 대기 인원 수를 포함했습니다.
</p>

<pre><code class="language-java">@Getter
@AllArgsConstructor
public class QueueStatusResponse {
    private String message;
    private String category;
    private String difficulty;
    private int waitingCount;
}</code></pre>

<h3>응답 예시</h3>
<pre><code class="language-json">{
  "message": "매칭 대기열에 참가했습니다.",
  "category": "ARRAY",
  "difficulty": "EASY",
  "waitingCount": 1
}</code></pre>

<p>
여기서 카테고리는 내부 정규화 결과가 그대로 내려가므로
입력값이 <code>Array</code>여도 응답은 <code>ARRAY</code>로 반환됩니다.
</p>

<hr>

<h2>8. 테스트 추가 및 개선</h2>
<p>
매칭 시작 서비스에 대해 기본 동작과 예외 케이스를 검증하는 단위 테스트를 추가했습니다.
</p>

<h3>검증한 시나리오</h3>
<ol>
<li>정상적으로 대기열에 참가할 수 있는지</li>
<li>이미 참가 중인 사용자가 다시 요청하면 예외가 발생하는지</li>
</ol>

<pre><code class="language-java">@Test
@DisplayName("사용자는 카테고리와 난이도를 선택해 매칭 대기열에 참가할 수 있다")
void joinQueue_success() {
    Long userId = 1L;
    QueueJoinRequest request = new QueueJoinRequest("Array", Difficulty.EASY);

    QueueStatusResponse response = matchingQueueService.joinQueue(userId, request);

    assertThat(response.getMessage()).isEqualTo("매칭 대기열에 참가했습니다.");
    assertThat(response.getCategory()).isEqualTo("ARRAY");
    assertThat(response.getDifficulty()).isEqualTo("EASY");
    assertThat(response.getWaitingCount()).isEqualTo(1);
}</code></pre>

<pre><code class="language-java">@Test
@DisplayName("이미 대기열에 참가 중인 사용자는 중복 참가할 수 없다")
void joinQueue_fail_whenAlreadyJoined() {
    Long userId = 1L;
    QueueJoinRequest request = new QueueJoinRequest("Array", Difficulty.EASY);

    matchingQueueService.joinQueue(userId, request);

    assertThatThrownBy(() -&gt; matchingQueueService.joinQueue(userId, request))
            .isInstanceOf(IllegalStateException.class)
            .hasMessage("이미 매칭 대기열에 참가 중인 사용자입니다.");
}</code></pre>

<h3>테스트 코드 개선</h3>
<p>
초기 테스트는 DTO에 생성자가 없어 리플렉션으로 필드를 주입하고 있었는데,
마지막 수정에서 생성자를 추가하면서
테스트 코드도 일반 객체 생성 방식으로 정리했습니다.
</p>

<p>
즉,
</p>
<ul>
<li>이전: 기본 생성자 + reflection으로 필드 주입</li>
<li>변경 후: <code>new QueueJoinRequest(category, difficulty)</code></li>
</ul>

<p>
테스트 가독성이 좋아지고 DTO 사용 방식도 더 자연스러워졌습니다.
</p>

<hr>

<h2>9. 전체 흐름</h2>
<pre><code class="language-java">[사용자]
카테고리, 난이도 선택 후 매칭 시작
      ↓
POST /api/v1/queue/join?userId=1
{
  "category": "Array",
  "difficulty": "EASY"
}
      ↓
[MatchingQueueController]
요청 수신 후 MatchingQueueService 호출
      ↓
[MatchingQueueService]
1. QueueKey("ARRAY", EASY) 생성
2. userQueueMap.putIfAbsent(userId, queueKey) 로 중복 참가 방지
3. waitingQueues.computeIfAbsent(...) 로 큐 확보
4. WaitingUser 생성 후 addLast()
5. 현재 대기 인원 수 포함 응답 생성
      ↓
[응답]
{
  "message": "매칭 대기열에 참가했습니다.",
  "category": "ARRAY",
  "difficulty": "EASY",
  "waitingCount": 1
}</code></pre>

<hr>

<h2>10. 현재 구현의 성격</h2>
<ul>
<li>대기열 저장소는 현재 <strong>인메모리</strong> 기반입니다.</li>
<li>서비스 코드에 추후 <strong>Redis 전환 가능성</strong>을 고려한 TODO를 남겨두었습니다.</li>
<li>이번 PR의 범위는 <strong>매칭 시작 요청 수신 + 큐 등록 + 중복 방지 + 응답 반환</strong>까지입니다.</li>
<li>실제 4인 매칭 성사, 방 생성, 큐 이탈, 타임아웃 처리 등은 다음 단계 작업에서 확장할 수 있는 구조로 잡았습니다.</li>
</ul>

<hr>

<h2>11. 테스트 메모</h2>
<p>
로컬에서 대상 테스트를 실행하려고 했지만,
현재 환경에서는 Gradle wrapper lock 파일 상위 디렉터리 생성 권한 문제로 자동 실행까지는 확인하지 못했습니다.
다만 브랜치에 포함된 테스트 코드는 위 두 시나리오를 기준으로 작성되어 있습니다.
</p>

</body>
</html>
