### PR TITLE
[feat] 방 생성 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ out/
 
 ### custom ###
 .env
-
+*.md
 .DS_Store

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.postgresql:postgresql")

--- a/src/main/java/com/back/BackApplication.java
+++ b/src/main/java/com/back/BackApplication.java
@@ -3,9 +3,11 @@ package com.back;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BackApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
@@ -29,7 +29,9 @@ public class BattleParticipant extends BaseEntity {
     @JoinColumn(name = "user_id")
     private Member member;
 
-    private String status; // READY, PLAYING, EXIT
+    @Enumerated(EnumType.STRING)
+    private BattleParticipantStatus status; // READY, PLAYING, EXIT
+
     private Integer finalRank;
     private Long scoreDelta; // 이 판으로 변동된 점수
 

--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
@@ -30,10 +30,32 @@ public class BattleParticipant extends BaseEntity {
     private Member member;
 
     @Enumerated(EnumType.STRING)
-    private BattleParticipantStatus status; // READY, PLAYING, EXIT
+    private BattleParticipantStatus status;
 
     private Integer finalRank;
     private Long scoreDelta; // 이 판으로 변동된 점수
-
     private LocalDateTime finishTime; // 문제를 다 푼 시각
+
+    public static BattleParticipant create(BattleRoom battleRoom, Member member) {
+        BattleParticipant participant = new BattleParticipant();
+        participant.battleRoom = battleRoom;
+        participant.member = member;
+        participant.status = BattleParticipantStatus.READY;
+        participant.scoreDelta = 0L;
+        return participant;
+    }
+
+    public void join() {
+        this.status = BattleParticipantStatus.PLAYING;
+    }
+
+    public void complete(LocalDateTime finishTime) {
+        this.status = BattleParticipantStatus.EXIT;
+        this.finishTime = finishTime;
+    }
+
+    public void applyResult(int rank, long delta) {
+        this.finalRank = rank;
+        this.scoreDelta = delta;
+    }
 }

--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipantStatus.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipantStatus.java
@@ -1,0 +1,7 @@
+package com.back.domain.battle.battleparticipant.entity;
+
+public enum BattleParticipantStatus {
+    READY,
+    PLAYING,
+    EXIT
+}

--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -1,0 +1,17 @@
+package com.back.domain.battle.battleparticipant.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.member.member.entity.Member;
+
+public interface BattleParticipantRepository extends JpaRepository<BattleParticipant, Long> {
+
+    List<BattleParticipant> findByBattleRoom(BattleRoom battleRoom);
+
+    Optional<BattleParticipant> findByBattleRoomAndMember(BattleRoom battleRoom, Member member);
+}

--- a/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
+++ b/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
@@ -1,0 +1,28 @@
+package com.back.domain.battle.battleroom.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
+import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
+import com.back.domain.battle.battleroom.service.BattleRoomService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/battle/rooms")
+@RequiredArgsConstructor
+public class BattleRoomController {
+
+    private final BattleRoomService battleRoomService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CreateRoomResponse createRoom(@RequestBody CreateRoomRequest request) {
+        return battleRoomService.createRoom(request);
+    }
+}

--- a/src/main/java/com/back/domain/battle/battleroom/dto/CreateRoomRequest.java
+++ b/src/main/java/com/back/domain/battle/battleroom/dto/CreateRoomRequest.java
@@ -1,0 +1,8 @@
+package com.back.domain.battle.battleroom.dto;
+
+import java.util.List;
+
+/**
+ * problemId, participantIds, maxPlayers를 받는 record
+ */
+public record CreateRoomRequest(Long problemId, List<Long> participantIds, int maxPlayers) {}

--- a/src/main/java/com/back/domain/battle/battleroom/dto/CreateRoomResponse.java
+++ b/src/main/java/com/back/domain/battle/battleroom/dto/CreateRoomResponse.java
@@ -1,0 +1,13 @@
+package com.back.domain.battle.battleroom.dto;
+
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+
+/**
+ * roomId와 status를 반환하는 record
+ */
+public record CreateRoomResponse(Long roomId, String status) {
+
+    public static CreateRoomResponse from(BattleRoom room) {
+        return new CreateRoomResponse(room.getId(), room.getStatus().name());
+    }
+}

--- a/src/main/java/com/back/domain/battle/battleroom/entity/BattleRoom.java
+++ b/src/main/java/com/back/domain/battle/battleroom/entity/BattleRoom.java
@@ -1,10 +1,8 @@
 package com.back.domain.battle.battleroom.entity;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
-import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.global.jpa.entity.BaseEntity;
 
@@ -18,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BattleRoom extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "battle_room_seq_gen")
     @SequenceGenerator(name = "battle_room_seq_gen", sequenceName = "battle_room_id_seq", allocationSize = 50)
@@ -27,10 +26,37 @@ public class BattleRoom extends BaseEntity {
     @JoinColumn(name = "problem_id")
     private Problem problem;
 
-    private String status; // WAITING, PROGRESS, FINISHED
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BattleRoomStatus status;
+
     private Integer maxPlayers;
     private LocalDateTime timerEnd;
 
-    @OneToMany(mappedBy = "battleRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<BattleParticipant> participants = new ArrayList<>();
+    /**
+     * 방은 waiting 상태로 먼저 생성된다. (아무도 입장 안한 상태)
+     * 참여자는 READY 상태 (입장 대기 중)
+     * timerEnd는 null (모두 입장 후 세팅됨)
+     */
+    public static BattleRoom create(Problem problem, int maxPlayers) {
+        BattleRoom room = new BattleRoom();
+        room.problem = problem;
+        room.maxPlayers = maxPlayers;
+        room.status = BattleRoomStatus.WAITING;
+
+        return room;
+    }
+
+    public void startBattle(Duration duration) {
+        this.status = BattleRoomStatus.PLAYING;
+        this.timerEnd = LocalDateTime.now().plus(duration);
+    }
+
+    public void finish() {
+        this.status = BattleRoomStatus.FINISHED;
+    }
+
+    public boolean isExpired() {
+        return timerEnd != null && LocalDateTime.now().isAfter(timerEnd);
+    }
 }

--- a/src/main/java/com/back/domain/battle/battleroom/entity/BattleRoomStatus.java
+++ b/src/main/java/com/back/domain/battle/battleroom/entity/BattleRoomStatus.java
@@ -1,0 +1,7 @@
+package com.back.domain.battle.battleroom.entity;
+
+public enum BattleRoomStatus {
+    WAITING,
+    PLAYING,
+    FINISHED
+}

--- a/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
+++ b/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
@@ -1,0 +1,14 @@
+package com.back.domain.battle.battleroom.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+
+public interface BattleRoomRepository extends JpaRepository<BattleRoom, Long> {
+
+    // 타이머 만료된 진행중 방 조회 (스케줄러용)
+    List<BattleRoom> findByStatusAndTimerEndBefore(String status, LocalDateTime now);
+}

--- a/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
+++ b/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
@@ -6,9 +6,10 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 
 public interface BattleRoomRepository extends JpaRepository<BattleRoom, Long> {
 
     // 타이머 만료된 진행중 방 조회 (스케줄러용)
-    List<BattleRoom> findByStatusAndTimerEndBefore(String status, LocalDateTime now);
+    List<BattleRoom> findByStatusAndTimerEndBefore(BattleRoomStatus status, LocalDateTime now);
 }

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -1,0 +1,56 @@
+package com.back.domain.battle.battleroom.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
+import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.repository.ProblemRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BattleRoomService {
+
+    private final BattleRoomRepository battleRoomRepository;
+    private final BattleParticipantRepository battleParticipantRepository;
+    private final ProblemRepository problemRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public CreateRoomResponse createRoom(CreateRoomRequest request) {
+
+        // 1. problemId=1 로 문제 조회, 없으면 예외
+        Problem problem = problemRepository
+                .findById(request.problemId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 문제입니다."));
+
+        // 2. BattleRoom 생성 후 저장
+        BattleRoom room = BattleRoom.create(problem, request.maxPlayers());
+        battleRoomRepository.save(room);
+
+        // 3. 참여자 목록 조회
+        List<Member> members = memberRepository.findAllById(request.participantIds());
+        if (members.size() != request.participantIds().size()) {
+            throw new IllegalArgumentException("존재하지 않는 참여자가 포함되어 있습니다.");
+        }
+
+        // 4. BattleParticipant 4개 생성 후 저장 (4명으로 고정이니까)
+        // TODO: battleParticipantRepository::save를 효율적으로 바꿔야할지도 모름
+        members.stream()
+                .map(member -> BattleParticipant.create(room, member))
+                .forEach(battleParticipantRepository::save);
+
+        return CreateRoomResponse.from(room);
+    }
+}

--- a/src/main/java/com/back/domain/problem/problem/entity/Problem.java
+++ b/src/main/java/com/back/domain/problem/problem/entity/Problem.java
@@ -21,13 +21,19 @@ public class Problem extends BaseEntity {
     @SequenceGenerator(name = "problem_seq_gen", sequenceName = "problem_id_seq", allocationSize = 50)
     private Long id;
 
+    @Column(nullable = false)
     private String title;
+
+    @Column(nullable = false)
     private String difficulty;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @Column(nullable = false)
     private Long timeLimitMs;
+
+    @Column(nullable = false)
     private Long memoryLimitMb;
 
     @OneToMany(mappedBy = "problem")

--- a/src/main/java/com/back/domain/problem/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/back/domain/problem/problem/repository/ProblemRepository.java
@@ -1,0 +1,7 @@
+package com.back.domain.problem.problem.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.problem.problem.entity.Problem;
+
+public interface ProblemRepository extends JpaRepository<Problem, Long> {}

--- a/src/main/java/com/back/domain/problem/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/back/domain/problem/submission/repository/SubmissionRepository.java
@@ -1,0 +1,16 @@
+package com.back.domain.problem.submission.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.problem.submission.entity.Submission;
+
+public interface SubmissionRepository extends JpaRepository<Submission, Long> {
+
+    List<Submission> findByBattleRoom(BattleRoom battleRoom);
+
+    List<Submission> findByBattleRoomAndMember(BattleRoom battleRoom, Member member);
+}

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.back.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * 임시 security config입니다.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/back/global/websocket/WebSocketConfig.java
+++ b/src/main/java/com/back/global/websocket/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.back.global.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 서버 → 클라이언트 구독 prefix
+        registry.enableSimpleBroker("/topic");
+        // 클라이언트 → 서버 전송 prefix
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // WebSocket 연결 엔드포인트 (SockJS 폴백 포함)
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## 📝 작업 내용

방 생성 api

---

## ✅ 주요 변경 사항
# 방 생성

파일 구조

```java
CreateRoomRequest (DTO)
        ↓
BattleRoomController  →  BattleRoomService  →  DB 저장
```

### 방 생성 동작 흐름

요청

```java
POST /api/v1/battle/rooms
  {
    "problemId": 1,
    "participantIds": [1, 2, 3, 4],
    "maxPlayers": 4
  }
```

`CreateRoomRequest` 가 이 JSON을 받는다.

`BattleRoomService.createRoom()`

```java
1. Problem 조회
Problem problem = problemRepository.findById(request.problemId())
// problemId=1 로 문제 조회, 없으면 예외

2. BattleRoom 생성 후 저장
BattleRoom room = BattleRoom.create(problem, maxPlayers);
// status=WAITING, problem 세팅
battleRoomRepository.save(room);

3. 참여자 목록 조회
List<Member> members = memberRepository.findAllById(participantIds);
// [1,2,3,4] → Member 4명 한 번에 조회
// 조회된 수가 요청한 수와 다르면 예외 (존재하지 않는 유저 포함된 경우)

4. BattleParticipant 4개 생성 후 저장
members.stream()
    .map(member -> BattleParticipant.create(room, member))
    .forEach(battleParticipantRepository::save);
// 각 참여자마다 status=READY, scoreDelta=0으로 생성

5. 응답 반환
return new CreateRoomResponse(room.getId(), "WAITING");

```
---

## 🧪 테스트 결과
테스트코드 없음, postman만 해봄