### PR TITLE
[feat] 29 매칭 대기열 취소 기능 구현

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueController.java
+++ b/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueController.java
@@ -26,4 +26,9 @@ public class MatchingQueueController {
     public QueueStatusResponse joinQueue(@RequestParam Long userId, @Valid @RequestBody QueueJoinRequest request) {
         return matchingQueueService.joinQueue(userId, request);
     }
+
+    @DeleteMapping("/cancel")
+    public QueueStatusResponse cancelQueue(@RequestParam Long userId) {
+        return matchingQueueService.cancelQueue(userId);
+    }
 }

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -63,4 +63,43 @@ public class MatchingQueueService {
         return new QueueStatusResponse(
                 "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
     }
+
+    public QueueStatusResponse cancelQueue(Long userId) {
+        // 1. 유저가 어느 큐에 들어가 있는지 찾는다.
+        QueueKey queueKey = userQueueMap.get(userId);
+
+        // 2. 대기열에 없는 유저면 예외 발생
+        if (queueKey == null) {
+            throw new IllegalStateException("현재 매칭 대기열에 참가 중이 아닙니다.");
+        }
+
+        // 3. 해당 큐를 가져온다.
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        // 4. 큐 자체가 없으면 비정상 상태
+        if (queue == null) {
+            userQueueMap.remove(userId);
+            throw new IllegalStateException("대기열 정보를 찾을 수 없습니다.");
+        }
+
+        // 5. 큐에서 해당 userId를 가진 WaitingUser 제거
+        boolean removed = queue.removeIf(waitingUser -> waitingUser.getUserId().equals(userId));
+
+        // 6. userQueueMap에서도 제거
+        userQueueMap.remove(userId);
+
+        // 7. 큐에서 제거 실패 시 예외
+        if (!removed) {
+            throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
+        }
+
+        // 8. 큐가 비었으면 waitingQueues에서도 제거
+        if (queue.isEmpty()) {
+            waitingQueues.remove(queueKey);
+        }
+
+        // 9. 응답 반환
+        return new QueueStatusResponse(
+                "매칭 대기열에서 취소되었습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
+    }
 }

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -93,10 +93,8 @@ public class MatchingQueueService {
             throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
         }
 
-        // 8. 큐가 비었으면 waitingQueues에서도 제거
-        if (queue.isEmpty()) {
-            waitingQueues.remove(queueKey);
-        }
+        // 8. 해당 큐가 비어 있으면 삭제하고, 안 비어 있으면 그대로 둬라
+        waitingQueues.computeIfPresent(queueKey, (key, q) -> q.isEmpty() ? null : q);
 
         // 9. 응답 반환
         return new QueueStatusResponse(

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -102,4 +102,9 @@ public class MatchingQueueService {
         return new QueueStatusResponse(
                 "매칭 대기열에서 취소되었습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
     }
+
+    // 테스트에서 큐 정리 여부를 확인하기 위한 package-private 조회 메서드
+    boolean hasQueue(QueueKey queueKey) {
+        return waitingQueues.containsKey(queueKey);
+    }
 }

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -46,6 +46,37 @@ class MatchingQueueServiceTest {
                 .hasMessage("이미 매칭 대기열에 참가 중인 사용자입니다.");
     }
 
+    @Test
+    @DisplayName("대기열에 참가 중인 사용자는 큐 취소를 할 수 있다")
+    void cancelQueue_success() {
+        // given
+        Long userId = 1L;
+        QueueJoinRequest request = createRequest("Array", Difficulty.EASY);
+
+        matchingQueueService.joinQueue(userId, request);
+
+        // when
+        QueueStatusResponse response = matchingQueueService.cancelQueue(userId);
+
+        // then
+        assertThat(response.getMessage()).isEqualTo("매칭 대기열에서 취소되었습니다.");
+        assertThat(response.getCategory()).isEqualTo("ARRAY");
+        assertThat(response.getDifficulty()).isEqualTo("EASY");
+        assertThat(response.getWaitingCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("대기열에 참가 중이 아닌 사용자는 큐 취소를 할 수 없다")
+    void cancelQueue_fail_whenUserNotInQueue() {
+        // given
+        Long userId = 99L;
+
+        // when & then
+        assertThatThrownBy(() -> matchingQueueService.cancelQueue(userId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("현재 매칭 대기열에 참가 중이 아닙니다.");
+    }
+
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {
         return new QueueJoinRequest(category, difficulty);
     }

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.QueueKey;
 
 class MatchingQueueServiceTest {
 
@@ -75,6 +76,26 @@ class MatchingQueueServiceTest {
         assertThatThrownBy(() -> matchingQueueService.cancelQueue(userId))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("현재 매칭 대기열에 참가 중이 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("마지막 한 명이 큐를 취소하면 해당 큐는 waitingQueues에서 제거된다")
+    void cancelQueue_removesEmptyQueue() {
+        // given
+        Long userId = 1L;
+        QueueJoinRequest request = createRequest("Array", Difficulty.EASY);
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+
+        matchingQueueService.joinQueue(userId, request);
+
+        // 사전 확인
+        assertThat(matchingQueueService.hasQueue(queueKey)).isTrue();
+
+        // when
+        matchingQueueService.cancelQueue(userId);
+
+        // then
+        assertThat(matchingQueueService.hasQueue(queueKey)).isFalse();
     }
 
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #29 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #29 

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
큐 취소

---

## ✅ 주요 변경 사항 

- 큐 취소 기능 추가

### 파일 구조

```text
QueueStatusResponse (DTO)
        ↓
MatchingQueueController
        ↓
MatchingQueueService
        ↓
인메모리 대기열 자료구조 수정
```

큐 취소 동작 흐름

요청
DELETE /api/v1/queue/cancel?userId=1

현재는 테스트 및 MVP 단계이므로 userId를 요청 파라미터로 받는다.
추후 JWT 인증이 붙으면 로그인한 사용자 정보에서 userId를 꺼내는 방식으로 변경할 수 있다.

1) 매칭 대기열 취소 서비스 로직 구현
2) 큐 취소 API 엔드포인트 추가
3) 취소 성공 / 미참가 예외 / 마지막 인원 취소 시 큐 정리 테스트 추가

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
```bash
# 예) ./gradlew test --tests "com.back.domain.email.scheduler.DdayEmailSchedulerTest"
```

- [x] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
