### PR TITLE
[Feat] 4인 매칭 성사 시 배틀룸 생성 연동 서비스 로직 추가

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -72,10 +72,18 @@ public class MatchingQueueService {
         // 큐의 맨 뒤에 추가
         queue.addLast(waitingUser);
 
-        // 4명 매칭 시 방 생성 시도
+        // 1차 빠른 체크: 4명 미만이면 굳이 매칭 함수까지 안 들어감
+        if (queue.size() < 4) {
+            return new QueueStatusResponse(
+                    "매칭 대기열에 참가했습니다.",
+                    queueKey.category(),
+                    queueKey.difficulty().name(),
+                    queue.size());
+        }
+
+        // 4명 이상일 때만 실제 매칭 시도
         CreateRoomResponse room = tryMatchAndCreateRoom(queueKey, queue);
 
-        // 방 생성 성공이면 성공 메시지 반환
         if (room != null) {
             return new QueueStatusResponse(
                     "매칭 성사 및 방 생성 완료 (roomId=" + room.roomId() + ")",
@@ -128,15 +136,20 @@ public class MatchingQueueService {
 
     // 4인 매칭 + 방 생성
     private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey, Deque<WaitingUser> queue) {
-        // 같은 큐에 대한 동시 접근(join/cancel) 충돌 방지
+
+        List<WaitingUser> matchedUsers;
+
+        // 락 안에서는 4명 확인 + 4명 추출까지만 수행
         synchronized (queue) {
-            // 1) 4명 미만이면 아직 매칭 불가
+            // 2차 체크: 바깥에서 4명 이상이었더라도
+            // 이 시점에는 다른 스레드가 먼저 가져갔을 수 있으므로 다시 확인 필요
+            // 4명 미만이면 매칭 X
             if (queue.size() < 4) {
                 return null;
             }
 
-            // 2) FIFO 순서대로 앞에서 4명 추출
-            List<WaitingUser> matchedUsers = new ArrayList<>(4);
+            // FIFO 순서대로 앞에서 4명 추출
+            matchedUsers = new ArrayList<>(4);
             for (int i = 0; i < 4; i++) {
                 WaitingUser user = queue.pollFirst();
                 if (user != null) {
@@ -144,41 +157,41 @@ public class MatchingQueueService {
                 }
             }
 
-            // 3) 비정상 안전장치: 추출 인원이 4명 미만이면 원상복구 후 중단
+            // 비정상 안전장치: 추출 인원이 4명 미만이면 원상복구 후 중단
             if (matchedUsers.size() < 4) {
                 for (int i = matchedUsers.size() - 1; i >= 0; i--) {
                     queue.addFirst(matchedUsers.get(i));
                 }
                 return null;
             }
+        }
 
-            // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
-            List<Long> participantIds =
-                    matchedUsers.stream().map(WaitingUser::getUserId).toList();
+        // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
+        List<Long> participantIds =
+                matchedUsers.stream().map(WaitingUser::getUserId).toList();
 
-            try {
-                // 5) 문제 번호는 외부(찬의님 파트) 연동 함수에서 결정
-                Long problemId = resolveProblemIdForMatch(queueKey, participantIds);
+        try {
+            // 5) 문제 번호는 외부(찬의님 파트) 연동 함수에서 결정
+            Long problemId = resolveProblemIdForMatch(queueKey, participantIds);
 
-                // 6) 배틀룸 생성 요청 (MVP: maxPlayers=4 고정)
-                CreateRoomResponse response =
-                        battleRoomService.createRoom(new CreateRoomRequest(problemId, participantIds, 4));
+            // 6) 배틀룸 생성 요청 (MVP: maxPlayers=4 고정)
+            CreateRoomResponse response =
+                    battleRoomService.createRoom(new CreateRoomRequest(problemId, participantIds, 4));
 
-                // 7) 방 생성 성공 시에만 "유저-큐 맵"에서 매칭된 유저 제거
-                //    (실패했는데 먼저 제거하면 상태 꼬임 발생)
-                matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
+            // 7) 방 생성 성공 시에만 "유저-큐 맵"에서 매칭된 유저 제거
+            //    (실패했는데 먼저 제거하면 상태 꼬임 발생)
+            matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
 
-                // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
-                waitingQueues.computeIfPresent(queueKey, (k, q) -> q.isEmpty() ? null : q);
+            // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
+            waitingQueues.computeIfPresent(queueKey, (k, q) -> q.isEmpty() ? null : q);
 
-                return response;
-            } catch (RuntimeException e) {
-                // 9) 생성 실패 시 큐 원복: 뽑았던 4명을 원래 순서대로 되돌리기
-                for (int i = matchedUsers.size() - 1; i >= 0; i--) {
-                    queue.addFirst(matchedUsers.get(i));
-                }
-                throw e;
+            return response;
+        } catch (RuntimeException e) {
+            // 9) 생성 실패 시 큐 원복: 뽑았던 4명을 원래 순서대로 되돌리기
+            for (int i = matchedUsers.size() - 1; i >= 0; i--) {
+                queue.addFirst(matchedUsers.get(i));
             }
+            throw e;
         }
     }
 

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -1,18 +1,26 @@
 package com.back.domain.matching.queue.service;
 
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.springframework.stereotype.Service;
 
+import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
+import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
+import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class MatchingQueueService {
 
     // TODO: 지금 현재 인메모리 방식임 redis로 전환하면 좋음 MVP 이기 때문
@@ -43,6 +51,10 @@ public class MatchingQueueService {
      * 4. 유저를 대기열에 추가
      * 5. userQueueMap에도 기록
      */
+
+    // 매칭 성사 시 방 생성 호출용 서비스
+    private final BattleRoomService battleRoomService;
+
     public QueueStatusResponse joinQueue(Long userId, QueueJoinRequest request) {
         // 이미 대기열에 들어가 있는 유저는 다시 참가할 수 없다.
         QueueKey queueKey = new QueueKey(request.getCategory(), request.getDifficulty());
@@ -60,6 +72,19 @@ public class MatchingQueueService {
         // 큐의 맨 뒤에 추가
         queue.addLast(waitingUser);
 
+        // 4명 매칭 시 방 생성 시도
+        CreateRoomResponse room = tryMatchAndCreateRoom(queueKey, queue);
+
+        // 방 생성 성공이면 성공 메시지 반환
+        if (room != null) {
+            return new QueueStatusResponse(
+                    "매칭 성사 및 방 생성 완료 (roomId=" + room.roomId() + ")",
+                    queueKey.category(),
+                    queueKey.difficulty().name(),
+                    queue.size());
+        }
+
+        // 아직 인원 부족이면 대기 상태 응답
         return new QueueStatusResponse(
                 "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
     }
@@ -99,6 +124,72 @@ public class MatchingQueueService {
         // 9. 응답 반환
         return new QueueStatusResponse(
                 "매칭 대기열에서 취소되었습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
+    }
+
+    // 4인 매칭 + 방 생성
+    private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey, Deque<WaitingUser> queue) {
+        // 같은 큐에 대한 동시 접근(join/cancel) 충돌 방지
+        synchronized (queue) {
+            // 1) 4명 미만이면 아직 매칭 불가
+            if (queue.size() < 4) {
+                return null;
+            }
+
+            // 2) FIFO 순서대로 앞에서 4명 추출
+            List<WaitingUser> matchedUsers = new ArrayList<>(4);
+            for (int i = 0; i < 4; i++) {
+                WaitingUser user = queue.pollFirst();
+                if (user != null) {
+                    matchedUsers.add(user);
+                }
+            }
+
+            // 3) 비정상 안전장치: 추출 인원이 4명 미만이면 원상복구 후 중단
+            if (matchedUsers.size() < 4) {
+                for (int i = matchedUsers.size() - 1; i >= 0; i--) {
+                    queue.addFirst(matchedUsers.get(i));
+                }
+                return null;
+            }
+
+            // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
+            List<Long> participantIds =
+                    matchedUsers.stream().map(WaitingUser::getUserId).toList();
+
+            try {
+                // 5) 문제 번호는 외부(찬의님 파트) 연동 함수에서 결정
+                Long problemId = resolveProblemIdForMatch(queueKey, participantIds);
+
+                // 6) 배틀룸 생성 요청 (MVP: maxPlayers=4 고정)
+                CreateRoomResponse response =
+                        battleRoomService.createRoom(new CreateRoomRequest(problemId, participantIds, 4));
+
+                // 7) 방 생성 성공 시에만 "유저-큐 맵"에서 매칭된 유저 제거
+                //    (실패했는데 먼저 제거하면 상태 꼬임 발생)
+                matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
+
+                // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
+                waitingQueues.computeIfPresent(queueKey, (k, q) -> q.isEmpty() ? null : q);
+
+                return response;
+            } catch (RuntimeException e) {
+                // 9) 생성 실패 시 큐 원복: 뽑았던 4명을 원래 순서대로 되돌리기
+                for (int i = matchedUsers.size() - 1; i >= 0; i--) {
+                    queue.addFirst(matchedUsers.get(i));
+                }
+                throw e;
+            }
+        }
+    }
+
+    // 찬의님 연동 지점 (여기만 나중에 연결하면 됨)
+    private Long resolveProblemIdForMatch(QueueKey queueKey, List<Long> participantIds) {
+        // TODO: category/difficulty/참가자 정보를 바탕으로 problemId 반환
+        // 1) queueKey(category, difficulty)
+        // 2) participantIds(4명)
+        // 를 찬의님 서비스/함수로 전달해서 problemId를 받아오도록 구현
+        return 1L; // TODO: 현재는 1번만 가능
+        // throw new IllegalStateException("문제 번호 연동이 아직 구현되지 않았습니다.");
     }
 
     // 테스트에서 큐 정리 여부를 확인하기 위한 package-private 조회 메서드

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -70,10 +70,13 @@ public class MatchingQueueService {
         WaitingUser waitingUser = new WaitingUser(userId, queueKey);
 
         // 큐의 맨 뒤에 추가
-        queue.addLast(waitingUser);
-
+        int currentSize;
+        synchronized (queue) {
+            queue.addLast(waitingUser);
+            currentSize = queue.size();
+        }
         // 1차 빠른 체크: 4명 미만이면 굳이 매칭 함수까지 안 들어감
-        if (queue.size() < 4) {
+        if (currentSize < 4) {
             return new QueueStatusResponse(
                     "매칭 대기열에 참가했습니다.",
                     queueKey.category(),
@@ -115,15 +118,21 @@ public class MatchingQueueService {
             throw new IllegalStateException("대기열 정보를 찾을 수 없습니다.");
         }
 
-        // 5. 큐에서 해당 userId를 가진 WaitingUser 제거
-        boolean removed = queue.removeIf(waitingUser -> waitingUser.getUserId().equals(userId));
+        int currentSize;
+        boolean removed;
 
-        // 6. userQueueMap에서도 제거
-        userQueueMap.remove(userId);
+        synchronized (queue) {
+            // 5. 큐에서 해당 userId를 가진 WaitingUser 제거
+            removed = queue.removeIf(waitingUser -> waitingUser.getUserId().equals(userId));
 
-        // 7. 큐에서 제거 실패 시 예외
-        if (!removed) {
-            throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
+            // 7. 큐에서 제거 실패 시 예외
+            if (!removed) {
+                throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
+            }
+
+            // 6. userQueueMap에서도 제거
+            userQueueMap.remove(userId);
+            currentSize = queue.size();
         }
 
         // 8. 해당 큐가 비어 있으면 삭제하고, 안 비어 있으면 그대로 둬라
@@ -131,7 +140,7 @@ public class MatchingQueueService {
 
         // 9. 응답 반환
         return new QueueStatusResponse(
-                "매칭 대기열에서 취소되었습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
+                "매칭 대기열에서 취소되었습니다.", queueKey.category(), queueKey.difficulty().name(), currentSize);
     }
 
     // 4인 매칭 + 방 생성

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -187,9 +187,12 @@ public class MatchingQueueService {
 
             return response;
         } catch (RuntimeException e) {
-            // 9) 생성 실패 시 큐 원복: 뽑았던 4명을 원래 순서대로 되돌리기
-            for (int i = matchedUsers.size() - 1; i >= 0; i--) {
-                queue.addFirst(matchedUsers.get(i));
+            // 생성 실패 시 큐 원복: 뽑았던 4명을 원래 순서대로 되돌리기
+            // 롤백도 큐 변경이므로 같은 락으로 보호
+            synchronized (queue) {
+                for (int i = matchedUsers.size() - 1; i >= 0; i--) {
+                    queue.addFirst(matchedUsers.get(i));
+                }
             }
             throw e;
         }

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -2,10 +2,20 @@ package com.back.domain.matching.queue.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
+import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
+import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.Difficulty;
@@ -13,7 +23,8 @@ import com.back.domain.matching.queue.model.QueueKey;
 
 class MatchingQueueServiceTest {
 
-    private final MatchingQueueService matchingQueueService = new MatchingQueueService();
+    private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
+    private final MatchingQueueService matchingQueueService = new MatchingQueueService(battleRoomService);
 
     @Test
     @DisplayName("사용자는 카테고리와 난이도를 선택해 매칭 대기열에 참가할 수 있다")
@@ -96,6 +107,117 @@ class MatchingQueueServiceTest {
 
         // then
         assertThat(matchingQueueService.hasQueue(queueKey)).isFalse();
+    }
+
+    @Test
+    @DisplayName("4번째 사용자가 참가하면 방 생성이 1회 호출되고 큐는 비워진다")
+    void joinQueue_createsRoom_whenFourthUserJoins() {
+        // given
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        // when
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+        QueueStatusResponse fourthResponse =
+                matchingQueueService.joinQueue(4L, createRequest("Array", Difficulty.EASY));
+
+        // then
+        verify(battleRoomService, times(1))
+                .createRoom(argThat(req -> req.problemId().equals(1L)
+                        && req.maxPlayers() == 4
+                        && req.participantIds().size() == 4));
+        assertThat(fourthResponse.getWaitingCount()).isEqualTo(0);
+        assertThat(matchingQueueService.hasQueue(new QueueKey("Array", Difficulty.EASY)))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("5번째 사용자는 다음 매칭을 위해 대기열에 남는다")
+    void joinQueue_keepsFifthUserWaiting_afterRoomCreated() {
+        // given
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(101L, "WAITING"));
+
+        // when
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(4L, createRequest("Array", Difficulty.EASY));
+        QueueStatusResponse fifthResponse = matchingQueueService.joinQueue(5L, createRequest("Array", Difficulty.EASY));
+
+        // then
+        verify(battleRoomService, times(1)).createRoom(any(CreateRoomRequest.class));
+        assertThat(fifthResponse.getWaitingCount()).isEqualTo(1);
+        assertThat(matchingQueueService.hasQueue(new QueueKey("Array", Difficulty.EASY)))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("방 생성에 실패하면 추출된 4명은 큐로 원복된다")
+    void joinQueue_rollsBackQueue_whenCreateRoomFails() {
+        // given
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenThrow(new RuntimeException("room create failed"));
+
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+
+        // when & then (4번째에서 방 생성 시도 -> 실패)
+        assertThatThrownBy(() -> matchingQueueService.joinQueue(4L, createRequest("Array", Difficulty.EASY)))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("room create failed");
+
+        // 원복 확인: 1번 사용자를 취소하면 4명 중 1명만 빠져 3명이 남아야 한다.
+        QueueStatusResponse cancelResponse = matchingQueueService.cancelQueue(1L);
+        assertThat(cancelResponse.getWaitingCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("카테고리/난이도가 다른 큐끼리는 교차 매칭되지 않는다")
+    void joinQueue_doesNotCrossMatch_betweenDifferentQueueKeys() {
+        // when
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(4L, createRequest("Graph", Difficulty.EASY));
+
+        // then
+        verifyNoInteractions(battleRoomService);
+        assertThat(matchingQueueService.hasQueue(new QueueKey("Array", Difficulty.EASY)))
+                .isTrue();
+        assertThat(matchingQueueService.hasQueue(new QueueKey("Graph", Difficulty.EASY)))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("각 큐가 4명을 채우면 서로 독립적으로 방이 생성된다")
+    void joinQueue_createsRoomsIndependently_perQueueKey() {
+        // given
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(201L, "WAITING"))
+                .thenReturn(new CreateRoomResponse(202L, "WAITING"));
+
+        // Array + EASY 4명
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(4L, createRequest("Array", Difficulty.EASY));
+
+        // Graph + EASY 4명
+        matchingQueueService.joinQueue(11L, createRequest("Graph", Difficulty.EASY));
+        matchingQueueService.joinQueue(12L, createRequest("Graph", Difficulty.EASY));
+        matchingQueueService.joinQueue(13L, createRequest("Graph", Difficulty.EASY));
+        matchingQueueService.joinQueue(14L, createRequest("Graph", Difficulty.EASY));
+
+        // then
+        verify(battleRoomService, times(2)).createRoom(any(CreateRoomRequest.class));
+        assertThat(matchingQueueService.hasQueue(new QueueKey("Array", Difficulty.EASY)))
+                .isFalse();
+        assertThat(matchingQueueService.hasQueue(new QueueKey("Graph", Difficulty.EASY)))
+                .isFalse();
     }
 
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #34 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #34 

---

<p>refs #34<br>closes #34</p>
<hr>

<h2>📝 작업 내용</h2>
<p>
이번 PR은 <strong>매칭 큐 동시성 처리 안정화</strong>를 목표로,
같은 큐에 대한 <strong>join / cancel / match</strong> 연산이 서로 다른 타이밍에 섞이면서 발생할 수 있는
경쟁 상태를 줄이고, <strong>외부 서비스 호출로 인해 큐 락을 오래 잡고 있던 구조</strong>를 개선했습니다.
</p>

<p>
기존 구현은 <code>tryMatchAndCreateRoom()</code> 내부에서 <code>synchronized(queue)</code>를 잡은 상태로
문제 선정 및 방 생성 로직까지 수행하고 있었고,
<code>joinQueue()</code> / <code>cancelQueue()</code> 쪽은 동일한 락 전략이 아니어서
같은 큐에 대한 변경이 완전히 일관되게 보호되지 않는 문제가 있었습니다.
</p>

<h3>개선한 핵심 포인트</h3>
<ul>
  <li>큐 변경 연산에 동일한 락 전략 적용</li>
  <li>외부 서비스 호출을 큐 락 바깥으로 분리</li>
  <li>실패 시 롤백도 같은 큐 락으로 보호</li>
  <li>4명 미만일 때는 매칭 로직 진입 자체를 줄이는 빠른 체크 추가</li>
</ul>

<hr>

<h2>1. joinQueue에서 동일한 큐 락으로 addLast 보호</h2>
<p>
기존에는 <code>queue.addLast(waitingUser)</code>가 락 없이 수행된 뒤 바로 매칭 로직으로 넘어갔습니다.
이 경우 다른 스레드의 <code>cancel</code>, <code>match</code> 와 타이밍이 겹치면
복합 연산이 섞일 수 있어 상태 불일치 가능성이 있었습니다.
</p>

<p>
이번 변경에서는 <code>addLast()</code>와 현재 큐 크기 확인을
<strong>같은 <code>synchronized(queue)</code> 블록 안</strong>에서 처리하도록 바꿨습니다.
</p>

<pre><code class="language-java">int currentSize;
synchronized (queue) {
    queue.addLast(waitingUser);
    currentSize = queue.size();
}</code></pre>

<p>
이렇게 하면 같은 큐에 대한 추가/제거/매칭 추출이 모두 같은 락 기준으로 보호되므로
큐 상태를 더 일관되게 유지할 수 있습니다.
</p>

<h3>추가한 빠른 체크</h3>
<p>
유저를 넣은 직후 큐 크기가 4명 미만이면, 굳이 매칭 함수까지 들어가지 않고 바로 대기 응답을 반환하도록 했습니다.
불필요한 매칭 진입을 줄이기 위한 1차 최적화입니다.
</p>

<pre><code class="language-java">if (currentSize &lt; 4) {
    return new QueueStatusResponse(
            "매칭 대기열에 참가했습니다.",
            queueKey.category(),
            queueKey.difficulty().name(),
            queue.size());
}</code></pre>

<hr>

<h2>2. cancelQueue도 동일한 락 전략으로 통일</h2>
<p>
기존에는 큐 제거 연산과 <code>userQueueMap</code> 제거가 락 밖에서 분리되어 있었기 때문에,
같은 큐에서 동시에 매칭 추출이 일어나는 경우 타이밍 충돌 여지가 있었습니다.
</p>

<p>
이번 변경에서는 <code>removeIf()</code>, 제거 성공 여부 확인, <code>userQueueMap.remove()</code>,
현재 큐 크기 계산까지를 같은 락 안에서 처리하도록 정리했습니다.
</p>

<pre><code class="language-java">int currentSize;
boolean removed;

synchronized (queue) {
    removed = queue.removeIf(waitingUser -&gt; waitingUser.getUserId().equals(userId));

    if (!removed) {
        throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
    }

    userQueueMap.remove(userId);
    currentSize = queue.size();
}</code></pre>

<p>
즉, <strong>같은 큐에 대한 상태 변경은 모두 같은 큐 락으로 보호</strong>하도록 맞췄습니다.
</p>

<hr>

<h2>3. tryMatchAndCreateRoom에서 락 범위 축소</h2>
<p>
가장 큰 변경점은 <code>tryMatchAndCreateRoom()</code>의 락 범위입니다.
기존 구현은 아래 작업들을 모두 <code>synchronized(queue)</code> 안에서 처리했습니다.
</p>

<ul>
  <li>4명 확인</li>
  <li>4명 poll</li>
  <li>문제 ID 결정</li>
  <li>배틀룸 생성</li>
  <li>예외 시 롤백</li>
</ul>

<p>
이 구조는 <code>battleRoomService.createRoom(...)</code> 같은 외부 호출까지 큐 락을 잡고 있게 되어,
잠금 보유 시간이 길어지고 같은 큐를 사용하는 다른 스레드가 불필요하게 대기하게 만드는 문제가 있었습니다.
</p>

<p>
이번 변경에서는 <strong>락 안에서는 오직 “4명 확인 + 4명 추출”까지만 수행</strong>하고,
문제 선정 및 배틀룸 생성은 락 바깥에서 처리하도록 바꿨습니다.
</p>

<pre><code class="language-java">List&lt;WaitingUser&gt; matchedUsers;

synchronized (queue) {
    if (queue.size() &lt; 4) {
        return null;
    }

    matchedUsers = new ArrayList&lt;&gt;(4);
    for (int i = 0; i &lt; 4; i++) {
        WaitingUser user = queue.pollFirst();
        if (user != null) {
            matchedUsers.add(user);
        }
    }

    if (matchedUsers.size() &lt; 4) {
        for (int i = matchedUsers.size() - 1; i &gt;= 0; i--) {
            queue.addFirst(matchedUsers.get(i));
        }
        return null;
    }
}</code></pre>

<p>
그 뒤 참가자 ID를 만들고, 문제 선정 및 방 생성은 락 없이 수행합니다.
</p>

<pre><code class="language-java">List&lt;Long&gt; participantIds =
        matchedUsers.stream().map(WaitingUser::getUserId).toList();

Long problemId = resolveProblemIdForMatch(queueKey, participantIds);

CreateRoomResponse response =
        battleRoomService.createRoom(new CreateRoomRequest(problemId, participantIds, 4));</code></pre>

<h3>왜 중요한가</h3>
<ul>
  <li>외부 서비스 호출 때문에 큐 락을 오래 점유하지 않음</li>
  <li>같은 큐에 대한 다른 join/cancel 요청 지연을 줄일 수 있음</li>
  <li>락 보유 중 외부 로직과 얽히는 구조를 피해서 교착 위험을 낮춤</li>
</ul>

<hr>

<h2>4. 2차 인원 체크 유지</h2>
<p>
<code>joinQueue()</code>에서 이미 1차로 <code>currentSize &gt;= 4</code>를 확인하더라도,
실제로 매칭 함수에 들어가는 시점에는 다른 스레드가 먼저 큐를 변경했을 수 있습니다.
그래서 <code>tryMatchAndCreateRoom()</code> 안에서 다시 한 번 4명 이상인지 검사하는 방식을 유지했습니다.
</p>

<pre><code class="language-java">if (queue.size() &lt; 4) {
    return null;
}</code></pre>

<p>
즉,
</p>
<ul>
  <li><strong>1차 체크</strong>: 불필요한 매칭 함수 진입 방지</li>
  <li><strong>2차 체크</strong>: 실제 매칭 직전 동시성 안전장치</li>
</ul>

<hr>

<h2>5. 롤백도 같은 큐 락으로 보호</h2>
<p>
방 생성 중 예외가 발생하면, 앞에서 poll 해둔 4명을 다시 큐 앞쪽으로 원복해야 합니다.
기존 문제 상황에서는 롤백 역시 다른 큐 변경과 충돌할 수 있는 여지가 있었는데,
이번 변경에서는 롤백도 동일하게 <code>synchronized(queue)</code> 안에서 수행하도록 했습니다.
</p>

<pre><code class="language-java">catch (RuntimeException e) {
    synchronized (queue) {
        for (int i = matchedUsers.size() - 1; i &gt;= 0; i--) {
            queue.addFirst(matchedUsers.get(i));
        }
    }
    throw e;
}</code></pre>

<p>
이렇게 해서 <strong>큐에서 꺼내기 / 되돌리기</strong> 모두 같은 락 규칙 아래 동작하도록 맞췄습니다.
</p>

<hr>

<h2>6. 전체 동작 흐름</h2>
<pre><code class="language-java">[사용자 join 요청]
  ↓
QueueKey 기준 큐 조회 or 생성
  ↓
synchronized(queue) {
    addLast(waitingUser)
    currentSize 확인
}
  ↓
currentSize &lt; 4
  → 대기 상태 응답

currentSize &gt;= 4
  ↓
tryMatchAndCreateRoom()
  ↓
synchronized(queue) {
    다시 4명 이상인지 확인
    FIFO 기준 4명 poll
}
  ↓
락 해제
  ↓
participantIds 생성
problemId 결정
battleRoomService.createRoom(...) 호출
  ↓
성공 시 userQueueMap 정리 + 빈 큐 제거
  ↓
실패 시 synchronized(queue) {
    poll 했던 4명 원복
}</code></pre>

<hr>

<h2>7. 기대 효과</h2>
<ul>
  <li>같은 큐에 대한 join / cancel / match 연산의 동기화 기준이 일관돼 상태 불일치 가능성을 줄임</li>
  <li>배틀룸 생성 같은 외부 호출이 큐 락 안에서 수행되지 않아 잠금 보유 시간이 짧아짐</li>
  <li>매칭 실패 시 롤백도 동일한 락으로 보호해 큐 순서 복구 안정성을 높임</li>
  <li>4명 미만 상황에서 빠르게 반환해 불필요한 매칭 시도를 줄임</li>
</ul>
