### PR TITLE
[feat] 코드 제출 api && 브로드캐스트

### DIFF
--- a/src/main/java/com/back/domain/problem/submission/controller/SubmissionController.java
+++ b/src/main/java/com/back/domain/problem/submission/controller/SubmissionController.java
@@ -1,0 +1,28 @@
+package com.back.domain.problem.submission.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.problem.submission.dto.SubmissionResponse;
+import com.back.domain.problem.submission.dto.SubmitRequest;
+import com.back.domain.problem.submission.service.SubmissionService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/submissions")
+@RequiredArgsConstructor
+public class SubmissionController {
+
+    private final SubmissionService submissionService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SubmissionResponse submit(@RequestBody SubmitRequest request) {
+        return submissionService.submit(request);
+    }
+}

--- a/src/main/java/com/back/domain/problem/submission/dto/SubmissionResponse.java
+++ b/src/main/java/com/back/domain/problem/submission/dto/SubmissionResponse.java
@@ -1,0 +1,11 @@
+package com.back.domain.problem.submission.dto;
+
+import com.back.domain.problem.submission.entity.Submission;
+
+public record SubmissionResponse(Long submissionId, String result, int passedCount, int totalCount) {
+
+    public static SubmissionResponse from(Submission submission) {
+        return new SubmissionResponse(
+                submission.getId(), submission.getResult(), submission.getPassedCount(), submission.getTotalCount());
+    }
+}

--- a/src/main/java/com/back/domain/problem/submission/dto/SubmitRequest.java
+++ b/src/main/java/com/back/domain/problem/submission/dto/SubmitRequest.java
@@ -1,0 +1,7 @@
+package com.back.domain.problem.submission.dto;
+
+/**
+ * 임시: Security 미연동 상태에서 memberId를 body로 받음
+ * TODO: Security 연동 후 @AuthenticationPrincipal로 교체
+ */
+public record SubmitRequest(Long roomId, Long memberId, String code, String language) {}

--- a/src/main/java/com/back/domain/problem/submission/entity/Submission.java
+++ b/src/main/java/com/back/domain/problem/submission/entity/Submission.java
@@ -34,4 +34,19 @@ public class Submission extends BaseEntity {
     private String result; // AC, WA, TLE 등
     private Integer passedCount;
     private Integer totalCount;
+
+    public static Submission create(BattleRoom battleRoom, Member member, String code, String language) {
+        Submission submission = new Submission();
+        submission.battleRoom = battleRoom;
+        submission.member = member;
+        submission.code = code;
+        submission.language = language;
+        return submission;
+    }
+
+    public void applyJudgeResult(String result, int passedCount, int totalCount) {
+        this.result = result;
+        this.passedCount = passedCount;
+        this.totalCount = totalCount;
+    }
 }

--- a/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
+++ b/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
@@ -56,10 +56,14 @@ public class SubmissionService {
                 .findById(request.memberId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        // 3. BattleParticipant 조회
+        // 3. BattleParticipant 조회 + 제출 가능 상태 검증
         BattleParticipant participant = battleParticipantRepository
                 .findByBattleRoomAndMember(room, member)
                 .orElseThrow(() -> new IllegalArgumentException("해당 방의 참여자가 아닙니다."));
+
+        if (participant.getStatus() != BattleParticipantStatus.PLAYING) {
+            throw new IllegalStateException("제출할 수 없는 상태입니다. 현재 상태: " + participant.getStatus());
+        }
 
         // 4. Submission 생성 후 저장
         Submission submission = Submission.create(room, member, request.code(), request.language());
@@ -75,6 +79,10 @@ public class SubmissionService {
         submission.applyJudgeResult(result, passedCount, totalCount);
 
         // 7. WebSocket 브로드캐스트 - 제출 결과 전파
+        // TODO: 리팩토링 - 트랜잭션 커밋 전 메시지 전송 문제
+        //   현재 @Transactional 안에서 convertAndSend 호출 시 커밋 전에 메시지가 전송됨
+        //   수신자가 DB 조회 시 아직 반영되지 않은 상태를 볼 수 있음
+        //   → TransactionSynchronizationManager.registerSynchronization의 afterCommit()으로 개선 필요
         messagingTemplate.convertAndSend(
                 "/topic/room/" + room.getId(),
                 Map.of(

--- a/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
+++ b/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
@@ -1,0 +1,111 @@
+package com.back.domain.problem.submission.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.submission.dto.SubmissionResponse;
+import com.back.domain.problem.submission.dto.SubmitRequest;
+import com.back.domain.problem.submission.entity.Submission;
+import com.back.domain.problem.submission.repository.SubmissionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubmissionService {
+
+    private final BattleRoomRepository battleRoomRepository;
+    private final BattleParticipantRepository battleParticipantRepository;
+    private final MemberRepository memberRepository;
+    private final SubmissionRepository submissionRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Transactional
+    public SubmissionResponse submit(SubmitRequest request) {
+
+        // 1. BattleRoom 조회 + PLAYING 상태 검증 + 타이머 만료 검증
+        BattleRoom room = battleRoomRepository
+                .findById(request.roomId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+
+        // 1-1. PLAYING 상태 검증
+        if (room.getStatus() != BattleRoomStatus.PLAYING) {
+            throw new IllegalStateException("진행 중인 배틀이 아닙니다. 현재 상태: " + room.getStatus());
+        }
+
+        // 1-2. 타이머 만료 검증
+        if (room.isExpired()) {
+            throw new IllegalStateException("배틀 시간이 종료되었습니다.");
+        }
+
+        // 2. Member 조회
+        Member member = memberRepository
+                .findById(request.memberId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        // 3. BattleParticipant 조회
+        BattleParticipant participant = battleParticipantRepository
+                .findByBattleRoomAndMember(room, member)
+                .orElseThrow(() -> new IllegalArgumentException("해당 방의 참여자가 아닙니다."));
+
+        // 4. Submission 생성 후 저장
+        Submission submission = Submission.create(room, member, request.code(), request.language());
+        submissionRepository.save(submission);
+
+        // 5. 채점 실행 (Mock - 항상 AC 반환)
+        // TODO: 실제 Judge API 연동으로 교체
+        String result = "AC";
+        int totalCount = room.getProblem().getTestCases().size();
+        int passedCount = totalCount;
+
+        // 6. 채점 결과 저장
+        submission.applyJudgeResult(result, passedCount, totalCount);
+
+        // 7. WebSocket 브로드캐스트 - 제출 결과 전파
+        messagingTemplate.convertAndSend(
+                "/topic/room/" + room.getId(),
+                Map.of(
+                        "type", "SUBMISSION",
+                        "userId", member.getId(),
+                        "result", result,
+                        "passedCount", passedCount,
+                        "totalCount", totalCount));
+
+        // 8. AC이면 참여자 완료 처리
+        if ("AC".equals(result)) {
+            participant.complete(LocalDateTime.now());
+
+            // 현재 완료된 참여자 수를 rank로 사용
+            List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
+            long completedCount = allParticipants.stream()
+                    .filter(p -> p.getStatus() == BattleParticipantStatus.EXIT)
+                    .count();
+
+            messagingTemplate.convertAndSend(
+                    "/topic/room/" + room.getId(),
+                    Map.of("type", "PARTICIPANT_DONE", "userId", member.getId(), "rank", completedCount));
+
+            // 9. 모든 참여자 완료 시 결과 정산 트리거
+            boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.EXIT);
+
+            if (allFinished) {
+                // TODO: Step7 BattleResultService.settle(room.getId()) 호출
+            }
+        }
+
+        return SubmissionResponse.from(submission);
+    }
+}

--- a/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
+++ b/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
@@ -96,7 +96,10 @@ public class SubmissionService {
         if ("AC".equals(result)) {
             participant.complete(LocalDateTime.now());
 
-            // 현재 완료된 참여자 수를 rank로 사용
+            // TODO: 리팩토링 - 현재 참여자 수가 최대 4명으로 고정이라 성능 문제 없으나,
+            //   추후 참여자 수 확장 시 DB 집계 쿼리로 교체 필요
+            //   → BattleParticipantRepository에 countByBattleRoomAndStatus 추가 후
+            //      completedCount = repo.countByBattleRoomAndStatus(room, EXIT) 으로 변경
             List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
             long completedCount = allParticipants.stream()
                     .filter(p -> p.getStatus() == BattleParticipantStatus.EXIT)


### PR DESCRIPTION
### 새 파일 5개

- SubmitRequest.java { roomId, code, language }
- SubmissionResponse.java { submissionId, result, passedCount, totalCount }
- SubmissionService.java 제출 핵심 로직
- SubmissionController.java `POST /api/v1/submissions`

### 수정 파일 1개

- Submission.java create(), applyJudgeResult() 팩토리/메서드 추가

### 핵심 흐름

`POST /api/v1/submissions`

```java
{ roomId, memberId(임시), code, language }
       ↓
1. BattleRoom 조회 → status=PLAYING 검증 + 타이머 만료 검증
2. Member 조회
3. BattleParticipant 조회 (room + member)
4. Submission.create(room, member, code, language) → DB 저장
       ↓
5. 채점 실행 (Mock)
   → result="AC", passedCount=5, totalCount=5 고정 반환
       ↓
6. submission.applyJudgeResult(result, passedCount, totalCount) → DB 저장
7. WebSocket 브로드캐스트
   /topic/room/{roomId}
   { type: "SUBMISSION", userId, result, passedCount, totalCount }
       ↓
8. result == "AC" 이면:
   participant.complete(LocalDateTime.now())
   WebSocket 브로드캐스트
   { type: "PARTICIPANT_DONE", userId, rank: 0 }  ← rank는 정산 전이라 임시
       ↓
9. 모든 참여자 EXIT이면 → 결과 정산 트리거 (아직 구현안됨)
       ↓
SubmissionResponse 반환
```

### 확인할 사항

- 채점은 Mock으로 처리함 → 실제 Judge0 API 연동은 나중에 교체 (현재는 항상 AC 반환하거나 랜덤)
- Submission 엔티티에 현재 create(), applyJudgeResult() 없으면 추가 필요
- memberId는 join과 동일하게 임시로 body로 받는 방식
- 정산 로직은 아직 없으니 isAllFinished() 체크 후 TODO 주석만