### PR TITLE
[feat] 문제 출제 전체 연계 흐름 구현

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -1,0 +1,44 @@
+package com.back.domain.matching.queue.adapter;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.problem.pick.service.ProblemPickService;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class QueueProblemPicker {
+
+    private final ProblemPickService problemPickService;
+
+    /**
+     * 매칭 큐 모델을 출제 도메인 입력으로 변환해 문제 선정 서비스를 호출한다.
+     */
+    public Long pick(QueueKey queueKey, List<Long> participantIds) {
+        if (queueKey == null) {
+            throw new IllegalArgumentException("queueKey는 필수입니다.");
+        }
+
+        return problemPickService.pickProblemId(
+                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+    }
+
+    private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {
+        if (difficulty == null) {
+            throw new IllegalStateException("큐 난이도 정보가 없습니다.");
+        }
+
+        // valueOf 문자열 매핑 대신 명시적 매핑으로 런타임 이름 불일치 위험을 제거한다.
+        return switch (difficulty) {
+            case EASY -> DifficultyLevel.EASY;
+            case MEDIUM -> DifficultyLevel.MEDIUM;
+            case HARD -> DifficultyLevel.HARD;
+        };
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -12,12 +12,11 @@ import org.springframework.stereotype.Service;
 import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
+import com.back.domain.matching.queue.adapter.QueueProblemPicker;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
-import com.back.domain.problem.pick.service.ProblemPickService;
-import com.back.domain.problem.problem.enums.DifficultyLevel;
 
 import lombok.RequiredArgsConstructor;
 
@@ -57,7 +56,7 @@ public class MatchingQueueService {
     // 매칭 성사 시 방 생성 호출용 서비스
     private final BattleRoomService battleRoomService;
 
-    private final ProblemPickService problemPickService;
+    private final QueueProblemPicker queueProblemPicker;
 
     public QueueStatusResponse joinQueue(Long userId, QueueJoinRequest request) {
         // 이미 대기열에 들어가 있는 유저는 다시 참가할 수 없다.
@@ -212,10 +211,7 @@ public class MatchingQueueService {
     }
 
     private Long resolveProblemIdForMatch(QueueKey queueKey, List<Long> participantIds) {
-        return problemPickService.pickProblemId(
-                queueKey.category(),
-                DifficultyLevel.valueOf(queueKey.difficulty().name()),
-                participantIds);
+        return queueProblemPicker.pick(queueKey, participantIds);
     }
 
     // 테스트에서 큐 정리 여부를 확인하기 위한 package-private 조회 메서드

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -16,6 +16,8 @@ import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.domain.problem.pick.service.ProblemPickService;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
 
 import lombok.RequiredArgsConstructor;
 
@@ -54,6 +56,8 @@ public class MatchingQueueService {
 
     // 매칭 성사 시 방 생성 호출용 서비스
     private final BattleRoomService battleRoomService;
+
+    private final ProblemPickService problemPickService;
 
     public QueueStatusResponse joinQueue(Long userId, QueueJoinRequest request) {
         // 이미 대기열에 들어가 있는 유저는 다시 참가할 수 없다.
@@ -207,14 +211,11 @@ public class MatchingQueueService {
         }
     }
 
-    // 찬의님 연동 지점 (여기만 나중에 연결하면 됨)
     private Long resolveProblemIdForMatch(QueueKey queueKey, List<Long> participantIds) {
-        // TODO: category/difficulty/참가자 정보를 바탕으로 problemId 반환
-        // 1) queueKey(category, difficulty)
-        // 2) participantIds(4명)
-        // 를 찬의님 서비스/함수로 전달해서 problemId를 받아오도록 구현
-        return 1L; // TODO: 현재는 1번만 가능
-        // throw new IllegalStateException("문제 번호 연동이 아직 구현되지 않았습니다.");
+        return problemPickService.pickProblemId(
+                queueKey.category(),
+                DifficultyLevel.valueOf(queueKey.difficulty().name()),
+                participantIds);
     }
 
     // 테스트에서 큐 정리 여부를 확인하기 위한 package-private 조회 메서드

--- a/src/main/java/com/back/domain/problem/pick/dto/ProblemPickRequest.java
+++ b/src/main/java/com/back/domain/problem/pick/dto/ProblemPickRequest.java
@@ -1,0 +1,18 @@
+package com.back.domain.problem.pick.dto;
+
+import java.util.List;
+
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+
+/**
+ * 매칭 조건으로 문제를 출제(선정)할 때 사용하는 입력값.
+ */
+public record ProblemPickRequest(
+        String category, DifficultyLevel difficulty, List<Long> participantIds, List<Long> excludeProblemIds) {
+
+    public ProblemPickRequest {
+        // 입력값을 방어적으로 복사해 외부에서 리스트를 변경해도 요청 스냅샷이 변하지 않게 한다.
+        participantIds = participantIds == null ? List.of() : List.copyOf(participantIds);
+        excludeProblemIds = excludeProblemIds == null ? List.of() : List.copyOf(excludeProblemIds);
+    }
+}

--- a/src/main/java/com/back/domain/problem/pick/repository/ProblemPickQueryRepository.java
+++ b/src/main/java/com/back/domain/problem/pick/repository/ProblemPickQueryRepository.java
@@ -44,13 +44,13 @@ public class ProblemPickQueryRepository {
     }
 
     public Optional<Long> findCandidateIdByOffset(
-            DifficultyLevel difficulty, String normalizedCategory, List<Long> excludeProblemIds, long offset) {
+            DifficultyLevel difficulty, String normalizedCategory, List<Long> excludeProblemIds, int offset) {
         // count 결과에서 뽑은 offset 위치의 후보 1건을 조회한다.
         TypedQuery<Long> query = entityManager
                 .createQuery(buildSelectJpql(excludeProblemIds), Long.class)
                 .setParameter("difficulty", difficulty)
                 .setParameter("category", normalizedCategory)
-                .setFirstResult(Math.toIntExact(offset))
+                .setFirstResult(offset)
                 .setMaxResults(1);
 
         if (!excludeProblemIds.isEmpty()) {

--- a/src/main/java/com/back/domain/problem/pick/repository/ProblemPickQueryRepository.java
+++ b/src/main/java/com/back/domain/problem/pick/repository/ProblemPickQueryRepository.java
@@ -1,0 +1,105 @@
+package com.back.domain.problem.pick.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+/**
+ * 문제 출제 후보 조회 전용 리포지토리.
+ *
+ * <p>선정 로직은 서비스에서 담당하고, 이 클래스는 "조건에 맞는 후보 집합"을
+ * count/offset 조회하는 쿼리 실행만 담당한다.
+ */
+public class ProblemPickQueryRepository {
+
+    private final EntityManager entityManager;
+
+    /**
+     * 출제 조건을 만족하는 후보 문제 수를 반환한다.
+     *
+     * <p>랜덤 선정 전에 전체 후보 개수를 알아야 하므로 먼저 count를 수행한다.
+     */
+    public long countCandidates(DifficultyLevel difficulty, String normalizedCategory, List<Long> excludeProblemIds) {
+        // exclude 목록 유무에 따라 JPQL을 나눠, 빈 IN 절로 인한 런타임 오류를 피한다.
+        TypedQuery<Long> query = entityManager
+                .createQuery(buildCountJpql(excludeProblemIds), Long.class)
+                .setParameter("difficulty", difficulty)
+                .setParameter("category", normalizedCategory);
+
+        if (!excludeProblemIds.isEmpty()) {
+            query.setParameter("excludeProblemIds", excludeProblemIds);
+        }
+
+        // offset으로 랜덤 접근할 때 전체 후보 수 계산에 사용한다.
+        return query.getSingleResult();
+    }
+
+    public Optional<Long> findCandidateIdByOffset(
+            DifficultyLevel difficulty, String normalizedCategory, List<Long> excludeProblemIds, long offset) {
+        // count 결과에서 뽑은 offset 위치의 후보 1건을 조회한다.
+        TypedQuery<Long> query = entityManager
+                .createQuery(buildSelectJpql(excludeProblemIds), Long.class)
+                .setParameter("difficulty", difficulty)
+                .setParameter("category", normalizedCategory)
+                .setFirstResult(Math.toIntExact(offset))
+                .setMaxResults(1);
+
+        if (!excludeProblemIds.isEmpty()) {
+            query.setParameter("excludeProblemIds", excludeProblemIds);
+        }
+
+        // 지정된 오프셋에서 1건만 꺼내 문제 ID를 반환한다.
+        return query.getResultList().stream().findFirst();
+    }
+
+    private String buildCountJpql(List<Long> excludeProblemIds) {
+        // 같은 문제가 다중 태그로 조인될 수 있어 distinct로 중복 카운트를 방지한다.
+        return "select count(distinct p.id) " + buildFromWhereJpql(excludeProblemIds)
+                + buildExcludeClause(excludeProblemIds);
+    }
+
+    private String buildSelectJpql(List<Long> excludeProblemIds) {
+        // offset 기반 조회의 재현성을 위해 id 순으로 정렬한다.
+        return "select distinct p.id "
+                + buildFromWhereJpql(excludeProblemIds)
+                + buildExcludeClause(excludeProblemIds)
+                + " order by p.id";
+    }
+
+    private String buildFromWhereJpql(List<Long> excludeProblemIds) {
+        // 문제-태그 연결 테이블을 통해 category 필터를 적용한다.
+        // 그리고 실전 채점 가능한 문제만 대상으로 하기 위해 hidden 테스트 존재를 강제한다.
+        return """
+                from Problem p
+                join ProblemTagConnect ptc on ptc.problem = p
+                join Tag t on ptc.tag = t
+                where p.difficulty = :difficulty
+                and lower(t.name) = :category
+                  and exists (
+                        select tc.id
+                        from TestCase tc
+                        where tc.problem = p
+                          and tc.isSample = false
+                  )
+                """;
+    }
+
+    private String buildExcludeClause(List<Long> excludeProblemIds) {
+        if (excludeProblemIds.isEmpty()) {
+            // 제외 목록이 비어 있으면 where 절을 추가하지 않는다.
+            return "";
+        }
+
+        // 제외 대상이 있는 경우만 NOT IN 조건을 붙인다.
+        return " and p.id not in :excludeProblemIds";
+    }
+}

--- a/src/main/java/com/back/domain/problem/pick/service/ProblemPickService.java
+++ b/src/main/java/com/back/domain/problem/pick/service/ProblemPickService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class ProblemPickService {
 
     private static final String NO_PROBLEM_MESSAGE = "출제 가능한 문제가 없습니다.";
+    private static final String TOO_MANY_CANDIDATES_MESSAGE = "출제 후보 수가 너무 커 오프셋 계산이 불가능합니다.";
 
     private final ProblemPickQueryRepository problemPickQueryRepository;
 
@@ -58,8 +59,12 @@ public class ProblemPickService {
             throw new IllegalStateException(NO_PROBLEM_MESSAGE);
         }
 
+        if (candidateCount > Integer.MAX_VALUE) {
+            throw new IllegalStateException(TOO_MANY_CANDIDATES_MESSAGE + " candidateCount=" + candidateCount);
+        }
+
         // ORDER BY random() 대신 offset 랜덤 방식으로 1건을 고른다.
-        long randomOffset = ThreadLocalRandom.current().nextLong(candidateCount);
+        int randomOffset = ThreadLocalRandom.current().nextInt((int) candidateCount);
 
         return problemPickQueryRepository
                 .findCandidateIdByOffset(difficulty, normalizedCategory, excludeProblemIds, randomOffset)

--- a/src/main/java/com/back/domain/problem/pick/service/ProblemPickService.java
+++ b/src/main/java/com/back/domain/problem/pick/service/ProblemPickService.java
@@ -1,0 +1,82 @@
+package com.back.domain.problem.pick.service;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.problem.pick.dto.ProblemPickRequest;
+import com.back.domain.problem.pick.repository.ProblemPickQueryRepository;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemPickService {
+
+    private static final String NO_PROBLEM_MESSAGE = "출제 가능한 문제가 없습니다.";
+
+    private final ProblemPickQueryRepository problemPickQueryRepository;
+
+    /**
+     * 큐 연동용 단축 메서드.
+     * exclude 조건 없이 기본 출제 규칙으로 1문제를 고른다.
+     */
+    public Long pickProblemId(String category, DifficultyLevel difficulty, List<Long> participantIds) {
+        return pickProblemId(new ProblemPickRequest(category, difficulty, participantIds, List.of()));
+    }
+
+    /**
+     * 출제 규칙으로 문제 1개를 선정한다.
+     *
+     * 1) difficulty/category 검증 및 정규화
+     * 2) exclude 목록을 적용해 후보 수 조회
+     * 3) 후보가 없고 exclude가 있으면 exclude를 풀고 1회 재시도
+     * 4) 후보 수 기반 random offset으로 1건 선택
+     */
+    public Long pickProblemId(ProblemPickRequest request) {
+        DifficultyLevel difficulty = requireDifficulty(request.difficulty());
+        String normalizedCategory = normalizeCategory(request.category());
+
+        // participantIds는 추후 개인화/중복회피 룰 확장 시 사용할 입력으로 유지한다.
+        List<Long> excludeProblemIds = request.excludeProblemIds();
+
+        long candidateCount =
+                problemPickQueryRepository.countCandidates(difficulty, normalizedCategory, excludeProblemIds);
+
+        if (candidateCount == 0 && !excludeProblemIds.isEmpty()) {
+            // 제외 조건 때문에만 0건인 상황을 완화하기 위해 1회 fallback을 허용한다.
+            excludeProblemIds = List.of();
+            candidateCount =
+                    problemPickQueryRepository.countCandidates(difficulty, normalizedCategory, excludeProblemIds);
+        }
+
+        if (candidateCount == 0) {
+            throw new IllegalStateException(NO_PROBLEM_MESSAGE);
+        }
+
+        // ORDER BY random() 대신 offset 랜덤 방식으로 1건을 고른다.
+        long randomOffset = ThreadLocalRandom.current().nextLong(candidateCount);
+
+        return problemPickQueryRepository
+                .findCandidateIdByOffset(difficulty, normalizedCategory, excludeProblemIds, randomOffset)
+                .orElseThrow(() -> new IllegalStateException(NO_PROBLEM_MESSAGE));
+    }
+
+    private DifficultyLevel requireDifficulty(DifficultyLevel difficulty) {
+        if (difficulty == null) {
+            throw new IllegalArgumentException("난이도는 필수입니다.");
+        }
+        return difficulty;
+    }
+
+    private String normalizeCategory(String category) {
+        if (category == null || category.isBlank()) {
+            throw new IllegalArgumentException("카테고리는 필수입니다.");
+        }
+        return category.trim().toLowerCase();
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/adapter/QueueProblemPickerTest.java
+++ b/src/test/java/com/back/domain/matching/queue/adapter/QueueProblemPickerTest.java
@@ -1,0 +1,50 @@
+package com.back.domain.matching.queue.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.problem.pick.service.ProblemPickService;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+
+class QueueProblemPickerTest {
+
+    private final ProblemPickService problemPickService = mock(ProblemPickService.class);
+    private final QueueProblemPicker queueProblemPicker = new QueueProblemPicker(problemPickService);
+
+    @Test
+    @DisplayName("QueueKey와 participantIds를 받아 ProblemPickService 호출 결과를 반환한다")
+    void pick_returnsProblemId_whenInputIsValid() {
+        // given
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+        List<Long> participantIds = List.of(1L, 2L, 3L, 4L);
+
+        when(problemPickService.pickProblemId("ARRAY", DifficultyLevel.EASY, participantIds))
+                .thenReturn(7L);
+
+        // when
+        Long problemId = queueProblemPicker.pick(queueKey, participantIds);
+
+        // then
+        assertThat(problemId).isEqualTo(7L);
+        verify(problemPickService).pickProblemId(eq("ARRAY"), eq(DifficultyLevel.EASY), eq(participantIds));
+    }
+
+    @Test
+    @DisplayName("queueKey가 null이면 예외를 던진다")
+    void pick_throws_whenQueueKeyIsNull() {
+        assertThatThrownBy(() -> queueProblemPicker.pick(null, List.of(1L)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("queueKey는 필수입니다.");
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,24 +18,22 @@ import org.junit.jupiter.api.Test;
 import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
+import com.back.domain.matching.queue.adapter.QueueProblemPicker;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.Difficulty;
 import com.back.domain.matching.queue.model.QueueKey;
-import com.back.domain.problem.pick.service.ProblemPickService;
-import com.back.domain.problem.problem.enums.DifficultyLevel;
 
 class MatchingQueueServiceTest {
 
     private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
-    private final ProblemPickService problemPickService = mock(ProblemPickService.class);
+    private final QueueProblemPicker queueProblemPicker = mock(QueueProblemPicker.class);
     private final MatchingQueueService matchingQueueService =
-            new MatchingQueueService(battleRoomService, problemPickService);
+            new MatchingQueueService(battleRoomService, queueProblemPicker);
 
     @BeforeEach
     void setUp() {
-        when(problemPickService.pickProblemId(anyString(), any(DifficultyLevel.class), anyList()))
-                .thenReturn(1L);
+        when(queueProblemPicker.pick(any(QueueKey.class), anyList())).thenReturn(1L);
     }
 
     @Test
@@ -142,8 +138,7 @@ class MatchingQueueServiceTest {
                 .createRoom(argThat(req -> req.problemId().equals(1L)
                         && req.maxPlayers() == 4
                         && req.participantIds().size() == 4));
-        verify(problemPickService, times(1))
-                .pickProblemId(eq("ARRAY"), eq(DifficultyLevel.EASY), argThat(ids -> ids.size() == 4));
+        verify(queueProblemPicker, times(1)).pick(any(QueueKey.class), argThat(ids -> ids.size() == 4));
         assertThat(fourthResponse.getWaitingCount()).isEqualTo(0);
         assertThat(matchingQueueService.hasQueue(new QueueKey("Array", Difficulty.EASY)))
                 .isFalse();

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -3,13 +3,17 @@ package com.back.domain.matching.queue.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -20,11 +24,21 @@ import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.Difficulty;
 import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.problem.pick.service.ProblemPickService;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
 
 class MatchingQueueServiceTest {
 
     private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
-    private final MatchingQueueService matchingQueueService = new MatchingQueueService(battleRoomService);
+    private final ProblemPickService problemPickService = mock(ProblemPickService.class);
+    private final MatchingQueueService matchingQueueService =
+            new MatchingQueueService(battleRoomService, problemPickService);
+
+    @BeforeEach
+    void setUp() {
+        when(problemPickService.pickProblemId(anyString(), any(DifficultyLevel.class), anyList()))
+                .thenReturn(1L);
+    }
 
     @Test
     @DisplayName("사용자는 카테고리와 난이도를 선택해 매칭 대기열에 참가할 수 있다")
@@ -128,6 +142,8 @@ class MatchingQueueServiceTest {
                 .createRoom(argThat(req -> req.problemId().equals(1L)
                         && req.maxPlayers() == 4
                         && req.participantIds().size() == 4));
+        verify(problemPickService, times(1))
+                .pickProblemId(eq("ARRAY"), eq(DifficultyLevel.EASY), argThat(ids -> ids.size() == 4));
         assertThat(fourthResponse.getWaitingCount()).isEqualTo(0);
         assertThat(matchingQueueService.hasQueue(new QueueKey("Array", Difficulty.EASY)))
                 .isFalse();

--- a/src/test/java/com/back/domain/problem/pick/repository/ProblemPickQueryRepositoryTest.java
+++ b/src/test/java/com/back/domain/problem/pick/repository/ProblemPickQueryRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.back.domain.problem.pick.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ProblemPickQueryRepositoryTest {
+
+    @Autowired
+    private ProblemPickQueryRepository problemPickQueryRepository;
+
+    @Test
+    @DisplayName("출제 후보가 없을 때 count는 0이고 조회 결과는 비어 있다")
+    void queryRuns_whenNoCandidates() {
+        // when
+        long count = problemPickQueryRepository.countCandidates(DifficultyLevel.EASY, "array", List.of());
+
+        // then
+        assertThat(count).isZero();
+        assertThat(problemPickQueryRepository.findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(), 0))
+                .isEmpty();
+    }
+}

--- a/src/test/java/com/back/domain/problem/pick/service/ProblemPickServiceTest.java
+++ b/src/test/java/com/back/domain/problem/pick/service/ProblemPickServiceTest.java
@@ -1,0 +1,126 @@
+package com.back.domain.problem.pick.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.problem.pick.dto.ProblemPickRequest;
+import com.back.domain.problem.pick.repository.ProblemPickQueryRepository;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+
+class ProblemPickServiceTest {
+
+    private final ProblemPickQueryRepository queryRepository = mock(ProblemPickQueryRepository.class);
+    private final ProblemPickService problemPickService = new ProblemPickService(queryRepository);
+
+    @Test
+    @DisplayName("조건에 맞는 후보가 있으면 problemId를 반환한다")
+    void pickProblemId_returnsProblemId_whenCandidateExists() {
+        // given
+        ProblemPickRequest request =
+                new ProblemPickRequest(" Array ", DifficultyLevel.EASY, List.of(1L, 2L), List.of(10L));
+
+        when(queryRepository.countCandidates(DifficultyLevel.EASY, "array", List.of(10L)))
+                .thenReturn(1L);
+        when(queryRepository.findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(10L), 0L))
+                .thenReturn(Optional.of(42L));
+
+        // when
+        Long problemId = problemPickService.pickProblemId(request);
+
+        // then
+        assertThat(problemId).isEqualTo(42L);
+        verify(queryRepository).countCandidates(DifficultyLevel.EASY, "array", List.of(10L));
+        verify(queryRepository).findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(10L), 0L);
+    }
+
+    @Test
+    @DisplayName("큐 연동용 단축 메서드로도 problemId를 반환할 수 있다")
+    void pickProblemId_shortcutMethod_returnsProblemId() {
+        // given
+        when(queryRepository.countCandidates(DifficultyLevel.EASY, "array", List.of()))
+                .thenReturn(1L);
+        when(queryRepository.findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(), 0L))
+                .thenReturn(Optional.of(7L));
+
+        // when
+        Long problemId = problemPickService.pickProblemId("Array", DifficultyLevel.EASY, List.of(1L, 2L, 3L, 4L));
+
+        // then
+        assertThat(problemId).isEqualTo(7L);
+        verify(queryRepository).countCandidates(DifficultyLevel.EASY, "array", List.of());
+        verify(queryRepository).findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(), 0L);
+    }
+
+    @Test
+    @DisplayName("제외 목록으로 후보가 없으면 제외 없이 1회 재시도한다")
+    void pickProblemId_retriesWithoutExclude_whenExcludedCandidatesAreEmpty() {
+        // given
+        ProblemPickRequest request =
+                new ProblemPickRequest("Graph", DifficultyLevel.MEDIUM, List.of(1L, 2L), List.of(11L, 12L));
+
+        when(queryRepository.countCandidates(DifficultyLevel.MEDIUM, "graph", List.of(11L, 12L)))
+                .thenReturn(0L);
+        when(queryRepository.countCandidates(DifficultyLevel.MEDIUM, "graph", List.of()))
+                .thenReturn(1L);
+        when(queryRepository.findCandidateIdByOffset(eq(DifficultyLevel.MEDIUM), eq("graph"), eq(List.of()), anyLong()))
+                .thenReturn(Optional.of(99L));
+
+        // when
+        Long problemId = problemPickService.pickProblemId(request);
+
+        // then
+        assertThat(problemId).isEqualTo(99L);
+        verify(queryRepository).countCandidates(DifficultyLevel.MEDIUM, "graph", List.of(11L, 12L));
+        verify(queryRepository).countCandidates(DifficultyLevel.MEDIUM, "graph", List.of());
+        verify(queryRepository)
+                .findCandidateIdByOffset(eq(DifficultyLevel.MEDIUM), eq("graph"), eq(List.of()), anyLong());
+    }
+
+    @Test
+    @DisplayName("재시도 후에도 후보가 없으면 예외를 던진다")
+    void pickProblemId_throws_whenNoCandidateAfterRetry() {
+        // given
+        ProblemPickRequest request = new ProblemPickRequest("DP", DifficultyLevel.HARD, List.of(1L), List.of(100L));
+
+        when(queryRepository.countCandidates(DifficultyLevel.HARD, "dp", List.of(100L)))
+                .thenReturn(0L);
+        when(queryRepository.countCandidates(DifficultyLevel.HARD, "dp", List.of()))
+                .thenReturn(0L);
+
+        // when & then
+        assertThatThrownBy(() -> problemPickService.pickProblemId(request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("출제 가능한 문제가 없습니다.");
+    }
+
+    @Test
+    @DisplayName("난이도/카테고리가 없으면 쿼리 없이 예외를 던진다")
+    void pickProblemId_throwsValidationError_whenRequiredFieldsMissing() {
+        // given
+        ProblemPickRequest noDifficulty = new ProblemPickRequest("Array", null, List.of(), List.of());
+        ProblemPickRequest noCategory = new ProblemPickRequest(" ", DifficultyLevel.EASY, List.of(), List.of());
+
+        // when & then
+        assertThatThrownBy(() -> problemPickService.pickProblemId(noDifficulty))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("난이도는 필수입니다.");
+
+        assertThatThrownBy(() -> problemPickService.pickProblemId(noCategory))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("카테고리는 필수입니다.");
+
+        verifyNoInteractions(queryRepository);
+    }
+}

--- a/src/test/java/com/back/domain/problem/pick/service/ProblemPickServiceTest.java
+++ b/src/test/java/com/back/domain/problem/pick/service/ProblemPickServiceTest.java
@@ -2,7 +2,7 @@ package com.back.domain.problem.pick.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -33,7 +33,7 @@ class ProblemPickServiceTest {
 
         when(queryRepository.countCandidates(DifficultyLevel.EASY, "array", List.of(10L)))
                 .thenReturn(1L);
-        when(queryRepository.findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(10L), 0L))
+        when(queryRepository.findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(10L), 0))
                 .thenReturn(Optional.of(42L));
 
         // when
@@ -42,7 +42,7 @@ class ProblemPickServiceTest {
         // then
         assertThat(problemId).isEqualTo(42L);
         verify(queryRepository).countCandidates(DifficultyLevel.EASY, "array", List.of(10L));
-        verify(queryRepository).findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(10L), 0L);
+        verify(queryRepository).findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(10L), 0);
     }
 
     @Test
@@ -51,7 +51,7 @@ class ProblemPickServiceTest {
         // given
         when(queryRepository.countCandidates(DifficultyLevel.EASY, "array", List.of()))
                 .thenReturn(1L);
-        when(queryRepository.findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(), 0L))
+        when(queryRepository.findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(), 0))
                 .thenReturn(Optional.of(7L));
 
         // when
@@ -60,7 +60,7 @@ class ProblemPickServiceTest {
         // then
         assertThat(problemId).isEqualTo(7L);
         verify(queryRepository).countCandidates(DifficultyLevel.EASY, "array", List.of());
-        verify(queryRepository).findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(), 0L);
+        verify(queryRepository).findCandidateIdByOffset(DifficultyLevel.EASY, "array", List.of(), 0);
     }
 
     @Test
@@ -74,7 +74,7 @@ class ProblemPickServiceTest {
                 .thenReturn(0L);
         when(queryRepository.countCandidates(DifficultyLevel.MEDIUM, "graph", List.of()))
                 .thenReturn(1L);
-        when(queryRepository.findCandidateIdByOffset(eq(DifficultyLevel.MEDIUM), eq("graph"), eq(List.of()), anyLong()))
+        when(queryRepository.findCandidateIdByOffset(eq(DifficultyLevel.MEDIUM), eq("graph"), eq(List.of()), anyInt()))
                 .thenReturn(Optional.of(99L));
 
         // when
@@ -85,7 +85,7 @@ class ProblemPickServiceTest {
         verify(queryRepository).countCandidates(DifficultyLevel.MEDIUM, "graph", List.of(11L, 12L));
         verify(queryRepository).countCandidates(DifficultyLevel.MEDIUM, "graph", List.of());
         verify(queryRepository)
-                .findCandidateIdByOffset(eq(DifficultyLevel.MEDIUM), eq("graph"), eq(List.of()), anyLong());
+                .findCandidateIdByOffset(eq(DifficultyLevel.MEDIUM), eq("graph"), eq(List.of()), anyInt());
     }
 
     @Test
@@ -122,5 +122,20 @@ class ProblemPickServiceTest {
                 .hasMessage("카테고리는 필수입니다.");
 
         verifyNoInteractions(queryRepository);
+    }
+
+    @Test
+    @DisplayName("후보 수가 int 범위를 넘으면 명확한 예외를 던진다")
+    void pickProblemId_throws_whenCandidateCountExceedsIntRange() {
+        // given
+        ProblemPickRequest request = new ProblemPickRequest("Array", DifficultyLevel.EASY, List.of(), List.of());
+
+        when(queryRepository.countCandidates(DifficultyLevel.EASY, "array", List.of()))
+                .thenReturn((long) Integer.MAX_VALUE + 1);
+
+        // when & then
+        assertThatThrownBy(() -> problemPickService.pickProblemId(request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("출제 후보 수가 너무 커 오프셋 계산이 불가능합니다.");
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #41
closes #41

---

## 📝 작업 내용
이번 PR은 매칭 큐에서 4명이 확정된 뒤, 문제 출제 서비스에서 `problemId`를 선정해 방 생성으로 이어지는 흐름(3~7단계)을 구현했습니다.

### 3) `resolveProblemIdForMatch` 호출 및 실제 연동
4인 매칭 완료 시 `participantIds`를 만들고, `resolveProblemIdForMatch(queueKey, participantIds)`를 호출합니다.  
기존 임시 `return 1L`을 제거하고 출제 서비스로 연결했습니다.

```java
private Long resolveProblemIdForMatch(QueueKey queueKey, List<Long> participantIds) {
    return problemPickService.pickProblemId(
            queueKey.category(),
            DifficultyLevel.valueOf(queueKey.difficulty().name()),
            participantIds);
}
```

### 4) `ProblemPickService` 진입 및 요청 구성
큐 연동용 단축 메서드에서 출제 요청 객체(`ProblemPickRequest`)를 생성하고 메인 출제 로직으로 위임합니다.

```java
public Long pickProblemId(String category, DifficultyLevel difficulty, List<Long> participantIds) {
    return pickProblemId(new ProblemPickRequest(category, difficulty, participantIds, List.of()));
}
```

### 5) enum 타입 변환 처리
큐 난이도와 출제 난이도는 값은 같지만 타입이 다르므로 변환 후 전달합니다.

- 큐: `matching.queue.model.Difficulty`
- 출제: `problem.problem.enums.DifficultyLevel`

```java
DifficultyLevel.valueOf(queueKey.difficulty().name())
```

### 6) 후보 조회 및 필터링 조건
출제 후보는 `ProblemPickQueryRepository`에서 아래 조건으로 조회합니다.

1. 난이도 일치
2. 카테고리 태그 일치(`lower(t.name) = :category`)
3. hidden 테스트케이스 존재(`isSample = false`)
4. exclude 목록 있으면 `NOT IN` 동적 적용

```java
from Problem p
join ProblemTagConnect ptc on ptc.problem = p
join Tag t on ptc.tag = t
where p.difficulty = :difficulty
and lower(t.name) = :category
  and exists (
        select tc.id
        from TestCase tc
        where tc.problem = p
          and tc.isSample = false
  )
```

```java
private String buildExcludeClause(List<Long> excludeProblemIds) {
    if (excludeProblemIds.isEmpty()) return "";
    return " and p.id not in :excludeProblemIds";
}
```

### 7) 랜덤 1문제 선정 (`count -> offset -> 1건`)
`ORDER BY random()` 대신 후보 수 기반 랜덤 offset 방식으로 1건을 선택합니다.

```java
long candidateCount =
        problemPickQueryRepository.countCandidates(difficulty, normalizedCategory, excludeProblemIds);

if (candidateCount == 0 && !excludeProblemIds.isEmpty()) {
    excludeProblemIds = List.of();
    candidateCount =
            problemPickQueryRepository.countCandidates(difficulty, normalizedCategory, excludeProblemIds);
}

if (candidateCount == 0) {
    throw new IllegalStateException("출제 가능한 문제가 없습니다.");
}

long randomOffset = ThreadLocalRandom.current().nextLong(candidateCount);

return problemPickQueryRepository
        .findCandidateIdByOffset(difficulty, normalizedCategory, excludeProblemIds, randomOffset)
        .orElseThrow(() -> new IllegalStateException("출제 가능한 문제가 없습니다."));
```

---

## ✅ 주요 변경 사항
1) `MatchingQueueService`의 `resolveProblemIdForMatch` 실제 출제 서비스 연동  
2) `problem.pick` 패키지 구성 (`ProblemPickRequest`, `ProblemPickService`, `ProblemPickQueryRepository`)  
3) 출제 후보 필터링/랜덤 선정 로직 구현  
4) 큐 난이도 enum -> 출제 난이도 enum 변환 처리  
5) 관련 테스트 보강

---

## 🧪 테스트 결과
```bash
export JAVA_HOME=$(/usr/libexec/java_home -v 21)
export PATH="$JAVA_HOME/bin:$PATH"

./gradlew spotlessCheck
./gradlew test --tests "com.back.domain.problem.pick.*" --tests "com.back.domain.matching.queue.service.MatchingQueueServiceTest"
```

- [x] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
- 단계별 책임 경계(큐 -> 출제 -> 방 생성)
- enum 변환 지점의 안전성
- 후보 0건/예외 상황에서 큐 롤백 영향

---

## 📎 참고 사항 (선택)
- 상세 메모: 
