### PR TITLE
[feat] 내 큐 상태 조회 api 추가

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueController.java
+++ b/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueController.java
@@ -3,6 +3,7 @@ package com.back.domain.matching.queue.controller;
 import org.springframework.web.bind.annotation.*;
 
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStateResponse;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.service.MatchingQueueService;
 
@@ -22,6 +23,11 @@ public class MatchingQueueController {
      * 지금은 테스트를 위해 userId를 요청 파라미터로 받는다.
      * 나중에는 JWT에서 userId를 꺼내도록 바꿀 수 있다.
      */
+    @GetMapping("/me")
+    public QueueStateResponse getMyQueueState(@RequestParam Long userId) {
+        return matchingQueueService.getMyQueueState(userId);
+    }
+
     @PostMapping("/join")
     public QueueStatusResponse joinQueue(@RequestParam Long userId, @Valid @RequestBody QueueJoinRequest request) {
         return matchingQueueService.joinQueue(userId, request);

--- a/src/main/java/com/back/domain/matching/queue/dto/QueueStateResponse.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/QueueStateResponse.java
@@ -1,0 +1,3 @@
+package com.back.domain.matching.queue.dto;
+
+public record QueueStateResponse(boolean inQueue, String category, String difficulty, int waitingCount) {}

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -13,6 +13,7 @@ import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStateResponse;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
@@ -205,6 +206,25 @@ public class MatchingQueueService {
             }
             throw e;
         }
+    }
+
+    public QueueStateResponse getMyQueueState(Long userId) {
+        QueueKey queueKey = userQueueMap.get(userId);
+
+        // 현재 어떤 큐에도 들어가 있지 않으면 false 반환
+        if (queueKey == null) {
+            return new QueueStateResponse(false, null, null, 0);
+        }
+
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        // 맵에는 있는데 실제 큐가 없으면 비정상 상태지만, 조회는 안전하게 false 처리
+        if (queue == null) {
+            return new QueueStateResponse(false, null, null, 0);
+        }
+
+        return new QueueStateResponse(
+                true, queueKey.category(), queueKey.difficulty().name(), queue.size());
     }
 
     // 찬의님 연동 지점 (여기만 나중에 연결하면 됨)

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -222,7 +222,15 @@ public class MatchingQueueService {
         Deque<WaitingUser> queue = waitingQueues.get(queueKey);
 
         // 맵에는 있는데 실제 큐가 없으면 비정상 상태지만, 조회는 안전하게 false 처리
+        // 불일치 발견: userQueueMap에는 있으나 실제 대기열(waitingQueues)에는 없음
         if (queue == null) {
+            // 원자적으로 제거 (내가 확인했던 그 queueKey일 때만 제거하여 동시성 이슈 방지)
+            userQueueMap.remove(userId, queueKey);
+
+            // 로그를 남겨 추적 가능하게 함
+            // log.warn("Inconsistency detected: User {} was in userQueueMap but queue {} was missing. Cleaned up.",
+            // userId, queueKey);
+
             return new QueueStateResponse(false, null, null, 0);
         }
 

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -17,6 +17,7 @@ import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStateResponse;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.Difficulty;
 import com.back.domain.matching.queue.model.QueueKey;
@@ -222,5 +223,56 @@ class MatchingQueueServiceTest {
 
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {
         return new QueueJoinRequest(category, difficulty);
+    }
+
+    @Test
+    @DisplayName("큐에 없는 사용자는 inQueue=false를 반환한다")
+    void getMyQueueState_returnsFalse_whenUserNotInQueue() {
+        // given
+        Long userId = 99L;
+
+        // when
+        QueueStateResponse response = matchingQueueService.getMyQueueState(userId);
+
+        // then
+        assertThat(response.inQueue()).isFalse();
+        assertThat(response.category()).isNull();
+        assertThat(response.difficulty()).isNull();
+        assertThat(response.waitingCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("큐에 있는 사용자는 현재 큐 정보를 반환한다")
+    void getMyQueueState_returnsQueueInfo_whenUserInQueue() {
+        // given
+        Long userId = 1L;
+        matchingQueueService.joinQueue(userId, createRequest("Array", Difficulty.EASY));
+
+        // when
+        QueueStateResponse response = matchingQueueService.getMyQueueState(userId);
+
+        // then
+        assertThat(response.inQueue()).isTrue();
+        assertThat(response.category()).isEqualTo("ARRAY");
+        assertThat(response.difficulty()).isEqualTo("EASY");
+        assertThat(response.waitingCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("큐 취소 후 다시 조회하면 inQueue=false를 반환한다")
+    void getMyQueueState_returnsFalse_afterCancel() {
+        // given
+        Long userId = 1L;
+        matchingQueueService.joinQueue(userId, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.cancelQueue(userId);
+
+        // when
+        QueueStateResponse response = matchingQueueService.getMyQueueState(userId);
+
+        // then
+        assertThat(response.inQueue()).isFalse();
+        assertThat(response.category()).isNull();
+        assertThat(response.difficulty()).isNull();
+        assertThat(response.waitingCount()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #45 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #45 

---

<html>
<body>
<h1>내 큐 상태 조회 API</h1>

<p>이번 PR은 매칭 큐에서 사용자가 <strong>현재 어떤 큐에 들어가 있는지 조회할 수 있는 API</strong>를 추가한 작업입니다.</p>
<p>기존의 큐 참가/취소 API는 유지하고, 조회 전용 DTO와 서비스 메서드를 분리해 <code>/api/v1/queue/me</code> 경로로 현재 상태를 반환하도록 구현했습니다.</p>

<hr>

<h3>무엇을 추가했는가</h3>
<ol>
<li>조회 전용 응답 DTO <code>QueueStateResponse</code> 추가</li>
<li><code>GET /api/v1/queue/me</code> 컨트롤러 엔드포인트 추가</li>
<li><code>MatchingQueueService#getMyQueueState(Long userId)</code> 구현</li>
<li>서비스 테스트 3건 추가</li>
</ol>

<hr>

<h3>전체 흐름</h3>
<pre><code class="language-java">클라이언트
GET /api/v1/queue/me?userId=1
        ↓
MatchingQueueController.getMyQueueState(userId)
        ↓
MatchingQueueService.getMyQueueState(userId)
        ↓
1. userQueueMap 에서 userId 기준 queueKey 조회
2. queueKey 없으면 inQueue=false 반환
3. queueKey 있으면 waitingQueues 에서 실제 큐 조회
4. QueueStateResponse(inQueue, category, difficulty, waitingCount) 반환
</code></pre>

<hr>

<h3>1. 조회 전용 DTO 추가</h3>
<p>참가/취소 응답과 현재 상태 조회 응답의 역할을 분리하기 위해 <code>QueueStateResponse</code>를 새로 만들었습니다.</p>

<pre><code class="language-java">public record QueueStateResponse(
        boolean inQueue,
        String category,
        String difficulty,
        int waitingCount) {}
</code></pre>

<p>의미는 아래와 같습니다.</p>
<ul>
<li><code>inQueue</code>: 현재 사용자가 큐에 들어가 있는지 여부</li>
<li><code>category</code>: 참가 중인 카테고리</li>
<li><code>difficulty</code>: 참가 중인 난이도</li>
<li><code>waitingCount</code>: 해당 큐의 현재 대기 인원 수</li>
</ul>

<hr>

<h3>2. 컨트롤러에 <code>/me</code> 엔드포인트 추가</h3>
<p>기존 <code>MatchingQueueController</code>에 내 큐 상태를 조회하는 API를 추가했습니다.</p>
<p>현재는 Security 미연동 상태이므로 <code>userId</code>를 요청 파라미터로 받습니다.</p>

<pre><code class="language-java">@GetMapping("/me")
public QueueStateResponse getMyQueueState(@RequestParam Long userId) {
    return matchingQueueService.getMyQueueState(userId);
}
</code></pre>

<p>최종 경로는 아래와 같습니다.</p>
<pre><code>GET /api/v1/queue/me?userId=1</code></pre>

<hr>

<h3>3. 서비스 조회 로직 구현</h3>
<p><code>MatchingQueueService</code>에서는 먼저 <code>userQueueMap</code>에서 사용자의 현재 큐 키를 조회합니다.</p>
<p>큐에 없는 사용자는 바로 <code>inQueue=false</code>를 반환하고, 큐에 있는 사용자는 실제 큐를 찾아 현재 상태를 응답으로 조합합니다.</p>

<pre><code class="language-java">public QueueStateResponse getMyQueueState(Long userId) {
    QueueKey queueKey = userQueueMap.get(userId);

    if (queueKey == null) {
        return new QueueStateResponse(false, null, null, 0);
    }

    Deque&lt;WaitingUser&gt; queue = waitingQueues.get(queueKey);

    if (queue == null) {
        return new QueueStateResponse(false, null, null, 0);
    }

    return new QueueStateResponse(
            true, queueKey.category(), queueKey.difficulty().name(), queue.size());
}
</code></pre>

<hr>

<h3>4. 비정상 상태도 안전하게 처리</h3>
<p>정상 흐름이라면 <code>userQueueMap</code>에 값이 있으면 <code>waitingQueues</code>에도 큐가 있어야 합니다.</p>
<p>하지만 조회 시점에 정리 타이밍이 겹치거나 예외적인 상태가 생길 수 있으므로, 큐를 찾지 못한 경우 예외 대신 <code>inQueue=false</code>를 반환하도록 했습니다.</p>

<pre><code class="language-java">if (queue == null) {
    return new QueueStateResponse(false, null, null, 0);
}
</code></pre>

<p>즉, 조회 API는 상태 확인용이므로 최대한 안전하게 응답하도록 설계했습니다.</p>

<hr>

<h3>5. 테스트 추가</h3>
<p><code>MatchingQueueServiceTest</code>에 아래 3가지 시나리오를 추가했습니다.</p>

<ol>
<li>큐에 없는 사용자는 <code>inQueue=false</code> 반환</li>
<li>큐에 있는 사용자는 현재 큐 정보 반환</li>
<li>큐 취소 후 다시 조회하면 <code>inQueue=false</code> 반환</li>
</ol>

<pre><code class="language-java">@Test
@DisplayName("큐에 없는 사용자는 inQueue=false를 반환한다")
void getMyQueueState_returnsFalse_whenUserNotInQueue() {
    QueueStateResponse response = matchingQueueService.getMyQueueState(99L);

    assertThat(response.inQueue()).isFalse();
    assertThat(response.category()).isNull();
    assertThat(response.difficulty()).isNull();
    assertThat(response.waitingCount()).isEqualTo(0);
}
</code></pre>

<pre><code class="language-java">@Test
@DisplayName("큐에 있는 사용자는 현재 큐 정보를 반환한다")
void getMyQueueState_returnsQueueInfo_whenUserInQueue() {
    matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));

    QueueStateResponse response = matchingQueueService.getMyQueueState(1L);

    assertThat(response.inQueue()).isTrue();
    assertThat(response.category()).isEqualTo("ARRAY");
    assertThat(response.difficulty()).isEqualTo("EASY");
    assertThat(response.waitingCount()).isEqualTo(1);
}
</code></pre>

<pre><code class="language-java">@Test
@DisplayName("큐 취소 후 다시 조회하면 inQueue=false를 반환한다")
void getMyQueueState_returnsFalse_afterCancel() {
    matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
    matchingQueueService.cancelQueue(1L);

    QueueStateResponse response = matchingQueueService.getMyQueueState(1L);

    assertThat(response.inQueue()).isFalse();
    assertThat(response.category()).isNull();
    assertThat(response.difficulty()).isNull();
    assertThat(response.waitingCount()).isEqualTo(0);
}
</code></pre>

<hr>

<h3>정리</h3>
<ul>
<li>기존 큐 참가/취소 API는 유지</li>
<li>새 조회 API <code>GET /api/v1/queue/me</code> 추가</li>
<li>조회 전용 DTO <code>QueueStateResponse</code> 추가</li>
<li>큐 미참가 / 참가 중 / 취소 후 조회 시나리오 테스트 추가</li>
</ul>

<p>즉, 이번 PR은 <strong>사용자가 현재 큐에 들어가 있는지 확인할 수 있는 최소 조회 기능</strong>을 추가한 작업입니다.</p>
</body>
</html>
