### PR TITLE
feat: 실시간 코드 공유, 순위 계산, 점수 반영, 결과 저장

### DIFF
--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -14,4 +14,7 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
     List<BattleParticipant> findByBattleRoom(BattleRoom battleRoom);
 
     Optional<BattleParticipant> findByBattleRoomAndMember(BattleRoom battleRoom, Member member);
+
+    // 방별 참여자 수 조회 (N+1 방지용 - 전체 로드 없이 COUNT만 조회)
+    long countByBattleRoom(BattleRoom battleRoom);
 }

--- a/src/main/java/com/back/domain/battle/battleroom/entity/BattleRoom.java
+++ b/src/main/java/com/back/domain/battle/battleroom/entity/BattleRoom.java
@@ -32,6 +32,7 @@ public class BattleRoom extends BaseEntity {
 
     private Integer maxPlayers;
     private LocalDateTime timerEnd;
+    private LocalDateTime startedAt;
 
     /**
      * 방은 waiting 상태로 먼저 생성된다. (아무도 입장 안한 상태)
@@ -49,7 +50,8 @@ public class BattleRoom extends BaseEntity {
 
     public void startBattle(Duration duration) {
         this.status = BattleRoomStatus.PLAYING;
-        this.timerEnd = LocalDateTime.now().plus(duration);
+        this.startedAt = LocalDateTime.now();
+        this.timerEnd = this.startedAt.plus(duration);
     }
 
     public void finish() {

--- a/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
+++ b/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
@@ -12,4 +12,7 @@ public interface BattleRoomRepository extends JpaRepository<BattleRoom, Long> {
 
     // 타이머 만료된 진행중 방 조회 (스케줄러용)
     List<BattleRoom> findByStatusAndTimerEndBefore(BattleRoomStatus status, LocalDateTime now);
+
+    // 특정 상태의 방 목록 조회 (관전용)
+    List<BattleRoom> findByStatus(BattleRoomStatus status);
 }

--- a/src/main/java/com/back/domain/battle/result/controller/BattleResultController.java
+++ b/src/main/java/com/back/domain/battle/result/controller/BattleResultController.java
@@ -1,0 +1,34 @@
+package com.back.domain.battle.result.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.battle.result.dto.BattleResultResponse;
+import com.back.domain.battle.result.dto.RoomListResponse;
+import com.back.domain.battle.result.service.BattleResultService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/battle")
+@RequiredArgsConstructor
+public class BattleResultController {
+
+    private final BattleResultService battleResultService;
+
+    // 최종 결과 조회
+    @GetMapping("/rooms/{roomId}/result")
+    public BattleResultResponse getResult(@PathVariable Long roomId) {
+        return battleResultService.getResult(roomId);
+    }
+
+    // 진행중인 방 목록 조회 (관전용)
+    @GetMapping("/rooms")
+    public List<RoomListResponse> getRoomList() {
+        return battleResultService.getRoomList();
+    }
+}

--- a/src/main/java/com/back/domain/battle/result/dto/BattleResultResponse.java
+++ b/src/main/java/com/back/domain/battle/result/dto/BattleResultResponse.java
@@ -1,0 +1,47 @@
+package com.back.domain.battle.result.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.problem.submission.entity.Submission;
+
+public record BattleResultResponse(Long roomId, String problemTitle, List<ParticipantResult> participants) {
+
+    public record ParticipantResult(
+            Long userId,
+            String nickname,
+            int finalRank,
+            long scoreDelta,
+            String result,
+            int passedCount,
+            int totalCount,
+            LocalDateTime finishTime) {
+
+        /**
+         * @param bestSubmission AC 제출 우선, 없으면 passedCount 가장 높은 제출, 제출 없으면 null
+         */
+        public static ParticipantResult from(BattleParticipant participant, Submission bestSubmission) {
+            return new ParticipantResult(
+                    participant.getMember().getId(),
+                    participant.getMember().getNickname(),
+                    participant.getFinalRank(),
+                    participant.getScoreDelta(),
+                    bestSubmission != null && bestSubmission.getResult() != null
+                            ? bestSubmission.getResult().name()
+                            : null,
+                    bestSubmission != null && bestSubmission.getPassedCount() != null
+                            ? bestSubmission.getPassedCount()
+                            : 0,
+                    bestSubmission != null && bestSubmission.getTotalCount() != null
+                            ? bestSubmission.getTotalCount()
+                            : 0,
+                    participant.getFinishTime());
+        }
+    }
+
+    public static BattleResultResponse from(BattleRoom room, List<ParticipantResult> participants) {
+        return new BattleResultResponse(room.getId(), room.getProblem().getTitle(), participants);
+    }
+}

--- a/src/main/java/com/back/domain/battle/result/dto/RoomListResponse.java
+++ b/src/main/java/com/back/domain/battle/result/dto/RoomListResponse.java
@@ -1,0 +1,15 @@
+package com.back.domain.battle.result.dto;
+
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+
+public record RoomListResponse(Long roomId, String status, String problemTitle, int currentPlayers, int maxPlayers) {
+
+    public static RoomListResponse from(BattleRoom room, int currentPlayers) {
+        return new RoomListResponse(
+                room.getId(),
+                room.getStatus().name(),
+                room.getProblem().getTitle(),
+                currentPlayers,
+                room.getMaxPlayers());
+    }
+}

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -1,0 +1,167 @@
+package com.back.domain.battle.result.service;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.dto.BattleResultResponse;
+import com.back.domain.battle.result.dto.BattleResultResponse.ParticipantResult;
+import com.back.domain.battle.result.dto.RoomListResponse;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.submission.entity.Submission;
+import com.back.domain.problem.submission.entity.SubmissionResult;
+import com.back.domain.problem.submission.repository.SubmissionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BattleResultService {
+
+    // 점수 정책: 1등 +100, 2등 +70, 3등 +40, 4등 +20, 미통과 +0
+    // TODO: 점수 정책 추후 협의 후 조정 가능
+    private static final long[] SCORE_TABLE = {100L, 70L, 40L, 20L};
+
+    // 오답 패널티: WA 1회당 20초
+    private static final long WA_PENALTY_SECONDS = 20L;
+
+    private final BattleRoomRepository battleRoomRepository;
+    private final BattleParticipantRepository battleParticipantRepository;
+    private final SubmissionRepository submissionRepository;
+    private final MemberRepository memberRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Transactional
+    public void settle(Long roomId) {
+
+        // 1. BattleRoom 조회 + 중복 정산 방지
+        BattleRoom room =
+                battleRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+
+        // 중복 정산 방지
+        if (room.getStatus() == BattleRoomStatus.FINISHED) {
+            return;
+        }
+
+        // 2. 모든 참여자 조회
+        List<BattleParticipant> participants = battleParticipantRepository.findByBattleRoom(room);
+
+        // 3. 순위 정렬
+        //    AC 참여자: score = 소요시간(초) + WA 패널티(회 * 20초) → 낮을수록 좋음
+        //    미통과 참여자: score = Long.MAX_VALUE → 항상 뒤로 밀림
+        List<BattleParticipant> sorted = participants.stream()
+                .sorted(Comparator.comparingLong((BattleParticipant p) -> calcScore(p, room))
+                        .thenComparing(
+                                p -> p.getFinishTime() != null ? p.getFinishTime() : java.time.LocalDateTime.MAX))
+                .toList();
+
+        // 4. 등수 & 점수 부여
+        int rank = 1;
+        for (BattleParticipant participant : sorted) {
+            boolean isAC = participant.getStatus() == BattleParticipantStatus.EXIT;
+            long scoreDelta = isAC ? SCORE_TABLE[Math.min(rank - 1, SCORE_TABLE.length - 1)] : 0L;
+
+            participant.applyResult(rank, scoreDelta);
+
+            // 5. Member.score 갱신
+            participant.getMember().applyScore(scoreDelta);
+
+            rank++;
+        }
+
+        // 6. BattleRoom 종료
+        room.finish();
+
+        // 7. WebSocket 브로드캐스트
+        // TODO: 리팩토링 - 트랜잭션 커밋 전 메시지 전송 문제
+        //   현재 @Transactional 안에서 convertAndSend 호출 시 커밋 전에 메시지가 전송됨
+        //   → TransactionSynchronizationManager.registerSynchronization의 afterCommit()으로 개선 필요
+        messagingTemplate.convertAndSend("/topic/room/" + roomId, Map.of("type", "BATTLE_FINISHED"));
+    }
+
+    @Transactional(readOnly = true)
+    public BattleResultResponse getResult(Long roomId) {
+
+        BattleRoom room =
+                battleRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+
+        if (room.getStatus() != BattleRoomStatus.FINISHED) {
+            throw new IllegalStateException("아직 정산이 완료되지 않은 방입니다. 현재 상태: " + room.getStatus());
+        }
+
+        List<BattleParticipant> participants = battleParticipantRepository.findByBattleRoom(room);
+
+        List<ParticipantResult> results = participants.stream()
+                .sorted(Comparator.comparingInt(BattleParticipant::getFinalRank))
+                .map(p -> ParticipantResult.from(p, findBestSubmission(room, p)))
+                .toList();
+
+        return BattleResultResponse.from(room, results);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RoomListResponse> getRoomList() {
+
+        List<BattleRoom> playingRooms = battleRoomRepository.findByStatus(BattleRoomStatus.PLAYING);
+
+        return playingRooms.stream()
+                .map(room -> {
+                    int currentPlayers =
+                            battleParticipantRepository.findByBattleRoom(room).size();
+                    return RoomListResponse.from(room, currentPlayers);
+                })
+                .toList();
+    }
+
+    /**
+     * 참여자의 최고 제출 조회
+     * AC 제출 우선, 없으면 passedCount 가장 높은 제출, 제출 없으면 null
+     * Judge0 연동 후 여러 번 제출 가능해지면 이 로직으로 자연스럽게 대응 가능
+     */
+    private Submission findBestSubmission(BattleRoom room, BattleParticipant participant) {
+        // AC 제출이 있으면 첫 번째 AC 반환
+        Optional<Submission> acSubmission =
+                submissionRepository.findFirstByBattleRoomAndMemberAndResultOrderByCreatedAtAsc(
+                        room, participant.getMember(), SubmissionResult.AC);
+
+        if (acSubmission.isPresent()) {
+            return acSubmission.get();
+        }
+
+        // 없으면 passedCount 가장 높은 제출 반환
+        return submissionRepository.findByBattleRoomAndMember(room, participant.getMember()).stream()
+                .filter(s -> s.getPassedCount() != null)
+                .max(Comparator.comparingInt(Submission::getPassedCount))
+                .orElse(null);
+    }
+
+    /**
+     * 순위 산정 기준값 계산
+     * AC 참여자: 소요시간(초) + WA 패널티
+     * 미통과 참여자: Long.MAX_VALUE
+     */
+    private long calcScore(BattleParticipant participant, BattleRoom room) {
+        if (participant.getStatus() != BattleParticipantStatus.EXIT) {
+            return Long.MAX_VALUE;
+        }
+
+        long elapsedSeconds = ChronoUnit.SECONDS.between(room.getStartedAt(), participant.getFinishTime());
+
+        long waPenaltyCount = submissionRepository.countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+                room, participant.getMember(), SubmissionResult.WA, participant.getFinishTime());
+
+        return elapsedSeconds + (waPenaltyCount * WA_PENALTY_SECONDS);
+    }
+}

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -1,10 +1,12 @@
 package com.back.domain.battle.result.service;
 
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -25,7 +27,9 @@ import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BattleResultService {
@@ -58,13 +62,17 @@ public class BattleResultService {
         // 2. 모든 참여자 조회
         List<BattleParticipant> participants = battleParticipantRepository.findByBattleRoom(room);
 
-        // 3. 순위 정렬
+        // 3. 각 참여자 score 미리 계산 (DB 쿼리를 정렬 전에 한 번씩만 실행)
+        //    Comparator 안에서 calcScore() 호출 시 O(N log N) 횟수만큼 DB 조회가 발생하는 문제 방지
+        Map<Long, Long> scoreMap =
+                participants.stream().collect(Collectors.toMap(BattleParticipant::getId, p -> calcScore(p, room)));
+
+        // 4. score 기준 정렬 (in-memory, DB 쿼리 없음)
         //    AC 참여자: score = 소요시간(초) + WA 패널티(회 * 20초) → 낮을수록 좋음
         //    미통과 참여자: score = Long.MAX_VALUE → 항상 뒤로 밀림
         List<BattleParticipant> sorted = participants.stream()
-                .sorted(Comparator.comparingLong((BattleParticipant p) -> calcScore(p, room))
-                        .thenComparing(
-                                p -> p.getFinishTime() != null ? p.getFinishTime() : java.time.LocalDateTime.MAX))
+                .sorted(Comparator.comparingLong((BattleParticipant p) -> scoreMap.get(p.getId()))
+                        .thenComparing(p -> p.getFinishTime() != null ? p.getFinishTime() : LocalDateTime.MAX))
                 .toList();
 
         // 4. 등수 & 점수 부여
@@ -118,8 +126,7 @@ public class BattleResultService {
 
         return playingRooms.stream()
                 .map(room -> {
-                    int currentPlayers =
-                            battleParticipantRepository.findByBattleRoom(room).size();
+                    int currentPlayers = (int) battleParticipantRepository.countByBattleRoom(room);
                     return RoomListResponse.from(room, currentPlayers);
                 })
                 .toList();
@@ -154,6 +161,15 @@ public class BattleResultService {
      */
     private long calcScore(BattleParticipant participant, BattleRoom room) {
         if (participant.getStatus() != BattleParticipantStatus.EXIT) {
+            return Long.MAX_VALUE;
+        }
+
+        // null 방어: 정상 흐름에서는 발생하지 않지만 데이터 이상 시 정산 전체가 실패하는 것을 방지
+        if (room.getStartedAt() == null || participant.getFinishTime() == null) {
+            log.warn(
+                    "startedAt 또는 finishTime이 null - 미통과로 처리. roomId={}, participantId={}",
+                    room.getId(),
+                    participant.getId());
             return Long.MAX_VALUE;
         }
 

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -39,7 +39,7 @@ public class Member extends BaseEntity {
     public void applyScore(long delta) {
         this.score = (this.score == null ? 0L : this.score) + delta;
     }
-  
+
     public Member(String nickname, String email, String encodedPassword) {
         this.nickname = nickname;
         this.email = email;

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -31,4 +31,8 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
+    public void applyScore(long delta) {
+        this.score = (this.score == null ? 0L : this.score) + delta;
+    }
 }

--- a/src/main/java/com/back/domain/problem/submission/dto/SubmissionResponse.java
+++ b/src/main/java/com/back/domain/problem/submission/dto/SubmissionResponse.java
@@ -6,6 +6,9 @@ public record SubmissionResponse(Long submissionId, String result, int passedCou
 
     public static SubmissionResponse from(Submission submission) {
         return new SubmissionResponse(
-                submission.getId(), submission.getResult(), submission.getPassedCount(), submission.getTotalCount());
+                submission.getId(),
+                submission.getResult() != null ? submission.getResult().name() : null,
+                submission.getPassedCount(),
+                submission.getTotalCount());
     }
 }

--- a/src/main/java/com/back/domain/problem/submission/entity/Submission.java
+++ b/src/main/java/com/back/domain/problem/submission/entity/Submission.java
@@ -31,7 +31,10 @@ public class Submission extends BaseEntity {
     private String code;
 
     private String language;
-    private String result; // AC, WA, TLE 등
+
+    @Enumerated(EnumType.STRING)
+    private SubmissionResult result;
+
     private Integer passedCount;
     private Integer totalCount;
 
@@ -44,7 +47,7 @@ public class Submission extends BaseEntity {
         return submission;
     }
 
-    public void applyJudgeResult(String result, int passedCount, int totalCount) {
+    public void applyJudgeResult(SubmissionResult result, int passedCount, int totalCount) {
         this.result = result;
         this.passedCount = passedCount;
         this.totalCount = totalCount;

--- a/src/main/java/com/back/domain/problem/submission/entity/SubmissionResult.java
+++ b/src/main/java/com/back/domain/problem/submission/entity/SubmissionResult.java
@@ -1,0 +1,10 @@
+package com.back.domain.problem.submission.entity;
+
+public enum SubmissionResult {
+    AC, // Accepted
+    WA, // Wrong Answer
+    TLE, // Time Limit Exceeded
+    MLE, // Memory Limit Exceeded
+    RE, // Runtime Error
+    CE // Compile Error
+}

--- a/src/main/java/com/back/domain/problem/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/back/domain/problem/submission/repository/SubmissionRepository.java
@@ -1,16 +1,37 @@
 package com.back.domain.problem.submission.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.submission.entity.Submission;
+import com.back.domain.problem.submission.entity.SubmissionResult;
 
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
 
     List<Submission> findByBattleRoom(BattleRoom battleRoom);
 
     List<Submission> findByBattleRoomAndMember(BattleRoom battleRoom, Member member);
+
+    // AC 제출 중 가장 먼저 제출된 것 조회 (결과 조회용)
+    // Judge0 연동 후 여러 번 제출 가능해지면 이 쿼리로 첫 AC를 찾음
+    Optional<Submission> findFirstByBattleRoomAndMemberAndResultOrderByCreatedAtAsc(
+            BattleRoom room, Member member, SubmissionResult result);
+
+    // AC 제출 시각 이전의 WA 제출 횟수 (패널티 계산용)
+    @Query("SELECT COUNT(s) FROM Submission s " + "WHERE s.battleRoom = :room "
+            + "AND s.member = :member "
+            + "AND s.result = :result "
+            + "AND s.createdAt < :finishTime")
+    long countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+            @Param("room") BattleRoom room,
+            @Param("member") Member member,
+            @Param("result") SubmissionResult result,
+            @Param("finishTime") LocalDateTime finishTime);
 }

--- a/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
+++ b/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
@@ -14,11 +14,13 @@ import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepo
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.submission.dto.SubmissionResponse;
 import com.back.domain.problem.submission.dto.SubmitRequest;
 import com.back.domain.problem.submission.entity.Submission;
+import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,7 @@ public class SubmissionService {
     private final MemberRepository memberRepository;
     private final SubmissionRepository submissionRepository;
     private final SimpMessagingTemplate messagingTemplate;
+    private final BattleResultService battleResultService;
 
     @Transactional
     public SubmissionResponse submit(SubmitRequest request) {
@@ -41,12 +44,10 @@ public class SubmissionService {
                 .findById(request.roomId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
 
-        // 1-1. PLAYING 상태 검증
         if (room.getStatus() != BattleRoomStatus.PLAYING) {
             throw new IllegalStateException("진행 중인 배틀이 아닙니다. 현재 상태: " + room.getStatus());
         }
 
-        // 1-2. 타이머 만료 검증
         if (room.isExpired()) {
             throw new IllegalStateException("배틀 시간이 종료되었습니다.");
         }
@@ -71,7 +72,7 @@ public class SubmissionService {
 
         // 5. 채점 실행 (Mock - 항상 AC 반환)
         // TODO: 실제 Judge API 연동으로 교체
-        String result = "AC";
+        SubmissionResult result = SubmissionResult.AC;
         int totalCount = room.getProblem().getTestCases().size();
         int passedCount = totalCount;
 
@@ -86,14 +87,19 @@ public class SubmissionService {
         messagingTemplate.convertAndSend(
                 "/topic/room/" + room.getId(),
                 Map.of(
-                        "type", "SUBMISSION",
-                        "userId", member.getId(),
-                        "result", result,
-                        "passedCount", passedCount,
-                        "totalCount", totalCount));
+                        "type",
+                        "SUBMISSION",
+                        "userId",
+                        member.getId(),
+                        "result",
+                        result.name(),
+                        "passedCount",
+                        passedCount,
+                        "totalCount",
+                        totalCount));
 
         // 8. AC이면 참여자 완료 처리
-        if ("AC".equals(result)) {
+        if (result == SubmissionResult.AC) {
             participant.complete(LocalDateTime.now());
 
             // TODO: 리팩토링 - 현재 참여자 수가 최대 4명으로 고정이라 성능 문제 없으나,
@@ -113,7 +119,7 @@ public class SubmissionService {
             boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.EXIT);
 
             if (allFinished) {
-                // TODO: Step7 BattleResultService.settle(room.getId()) 호출
+                battleResultService.settle(room.getId());
             }
         }
 

--- a/src/main/java/com/back/global/scheduler/BattleScheduler.java
+++ b/src/main/java/com/back/global/scheduler/BattleScheduler.java
@@ -1,0 +1,39 @@
+package com.back.global.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BattleScheduler {
+
+    private final BattleRoomRepository battleRoomRepository;
+    private final BattleResultService battleResultService;
+
+    /**
+     * 10초마다 타이머가 만료된 PLAYING 방을 조회해 결과 정산
+     * BattleResultService.settle() 내부에서 FINISHED 체크로 중복 정산 방지
+     */
+    @Scheduled(fixedDelay = 10_000)
+    public void checkExpiredRooms() {
+        List<BattleRoom> expiredRooms =
+                battleRoomRepository.findByStatusAndTimerEndBefore(BattleRoomStatus.PLAYING, LocalDateTime.now());
+
+        for (BattleRoom room : expiredRooms) {
+            log.info("타이머 만료 감지 - roomId: {}, timerEnd: {}", room.getId(), room.getTimerEnd());
+            battleResultService.settle(room.getId());
+        }
+    }
+}

--- a/src/main/java/com/back/global/webMvc/WebMvcConfig.java
+++ b/src/main/java/com/back/global/webMvc/WebMvcConfig.java
@@ -1,0 +1,17 @@
+package com.back.global.webMvc;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("https://cdpn.io", "http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/back/global/websocket/BattleWebSocketHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleWebSocketHandler.java
@@ -1,0 +1,38 @@
+package com.back.global.websocket;
+
+import java.util.Map;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import com.back.global.websocket.dto.CodeUpdateMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class BattleWebSocketHandler {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * 참여자가 코드 변경 시 호출
+     * STOMP SEND /app/room/{roomId}/code
+     * Body: { "userId": 1, "code": "..." }
+     *
+     * 관전자 채널로만 브로드캐스트 (참여자끼리는 서로 코드 못 봄)
+     * TODO: Security 연동 후 userId를 Principal에서 추출하도록 변경
+     */
+    @MessageMapping("/room/{roomId}/code")
+    public void handleCodeUpdate(@DestinationVariable Long roomId, CodeUpdateMessage message) {
+
+        messagingTemplate.convertAndSend(
+                "/topic/room/" + roomId + "/spectate",
+                Map.of(
+                        "type", "CODE_UPDATE",
+                        "userId", message.userId(),
+                        "code", message.code()));
+    }
+}

--- a/src/main/java/com/back/global/websocket/dto/CodeUpdateMessage.java
+++ b/src/main/java/com/back/global/websocket/dto/CodeUpdateMessage.java
@@ -1,0 +1,7 @@
+package com.back.global.websocket.dto;
+
+/**
+ * 참여자가 코드 변경 시 서버로 전송하는 메시지
+ * TODO: Security 연동 후 userId 제거하고 Principal에서 추출
+ */
+public record CodeUpdateMessage(Long userId, String code) {}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,3 +13,4 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 100

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h1>실시간 코드 공유</h1>
<h3>개념</h3>
<pre><code class="language-java">참여자가 코드 타이핑
       ↓
STOMP SEND → /app/room/{roomId}/code
       ↓
서버 @MessageMapping 핸들러 수신
       ↓
관전자 채널로만 브로드캐스트
STOMP SEND → /topic/room/{roomId}/spectate
       ↓
관전자가 실시간으로 코드 수신

참여자 → 서버 → 관전자 단방향 릴레이 (참여자끼리는 서로 코드 못봄)

프론트에서 타이핑이 멈춘 후 1초 뒤에 전송하는 방식 같은 디바운스(1~2초) 적용해야함
</code></pre>
<p>새 파일 2개</p>
<ul>
<li>WebSocketConfig.java 이미 있으니 패스</li>
<li>BattleWebSocketHandler.java @MessageMapping 핸들러</li>
</ul>
<p>새 DTO 1개</p>
<ul>
<li>CodeUpdateMessage.java { code } (클라이언트가 보내는 메시지 구조)
<code>{ &quot;userId&quot;: 1, &quot;code&quot;: &quot;print('hello')&quot; }</code></li>
</ul>
<h3>전체 흐름</h3>
<pre><code class="language-java">[참여자 A - 타이핑 중]
STOMP SEND /app/room/1/code 전송
{ &quot;userId&quot;: 1, &quot;code&quot;: &quot;print('hello')&quot; }
          ↓
[서버 BattleWebSocketHandler.handleCodeUpdate()]
  @MessageMapping(&quot;/room/{roomId}/code&quot;) 수신
  roomId = 1, userId = 1, code = &quot;print('hello')&quot;
          ↓
  /topic/room/1/spectate 으로 브로드캐스트 (관전자 전체에게 전달)
  { &quot;type&quot;: &quot;CODE_UPDATE&quot;, &quot;userId&quot;: 1, &quot;code&quot;: &quot;print('hello')&quot; }
          ↓
[관전자 - /topic/room/1/spectate 구독 중]
  메시지 수신 → 화면에 A의 코드 실시간 표시
</code></pre>
<h3>현재 채널 구분</h3>

채널 | 용도 | 구독자
-- | -- | --
/topic/room/{id} | 배틀 이벤트 (BATTLE_STARTED, SUBMISSION 등) | 참여자 + 관전자
/topic/room/{id}/spectate | 실시간 코드 스트림 | 관전자 전용
/app/room/{id}/code | 코드 변경 전송 | 참여자 → 서버


<p>테스트 방법
4명 모두 POST /api/v1/submissions 완료 시:</p>
<ol>
<li>PARTICIPANT_DONE 4개 브로드캐스트</li>
<li>settle() 자동 호출</li>
<li>BATTLE_FINISHED 브로드캐스트</li>
<li>DB에서 finalRank, scoreDelta, member.score 갱신 확인</li>
</ol>
<h3>룸 내 순위 산정 규칙</h3>
<ul>
<li>정답을 맞춘 참가자가 정답을 못 맞춘 참가자보다 우선한다.</li>
<li>정답을 맞춘 참가자끼리는<strong>첫 정답 제출까지 걸린 시간 + 정답 전 오답 제출 패널티</strong>가 작은 순으로 정렬한다.</li>
<li>오답 제출 패널티는 <strong>1회당 20초</strong>로 한다.</li>
<li>동점이면 <strong>먼저 정답을 받은 참가자</strong>가 앞선다.</li>
<li>끝까지 정답을 못 맞춘 참가자는 모두 정답자 아래로 배치한다.</li>
</ul>
<p>1순위: AC 여부 (AC &gt; 미통과)
2순위: 걸린 시간 + 오답 패널티 오름차순
→ 실제 소요시간 = finishTime - 배틀 시작시간
→ 패널티 = 오답 제출 횟수 * 20초
3순위: 동점이면 finishTime 오름차순 (먼저 맞춘 사람)</p>
<h3>점수 정책</h3>
<p>AC 1등:  +100점
AC 2등:   +70점
AC 3등:   +40점
AC 4등:   +20점
미통과:      +0점</p>
<h3>중복 정산 방지가 중요한 이유</h3>
<p>상황: 마지막 참여자 AC + 타이머가 거의 동시에 만료
SubmissionService.settle() 호출
BattleScheduler.settle()   호출  ← 거의 동시</p>
<pre><code class="language-java">타이머 만료 → 스케줄러 settle() 호출
      ↑
마지막 참여자 AC → SubmissionService settle() 호출
</code></pre>
<p>두 곳에서 동시에 호출될 수 있어서, status == FINISHED 체크로 두 번 정산을 막아야함 (두 번째 호출은 즉시 리턴)</p>
<hr>
<h1>타이머 만료 스케줄러</h1>
<p>타이머 만료 시 자동 정산을 위해서 만들었다.</p>
<p>SubmissionService에서 settle()을 호출하는 건 모든 참여자가 AC를 맞춘 경우에만 동작한다.</p>
<p>케이스 1: 4명 모두 AC 완료
→ SubmissionService에서 allFinished 감지 → settle() 즉시 호출 ✓</p>
<p>케이스 2: 시간이 다 됐는데 아무도 못 풀거나 일부만 품
→ 아무도 settle()을 호출하지 않음 → 방이 PLAYING 상태로 영원히 남음 ✗</p>
<p>이 케이스 2를 처리하려면 서버가 주기적으로 &quot;혹시 만료된 방 있어?&quot;를 체크해야 하는데 그게 BattleScheduler의 역할이다.</p>
<p>10초마다 체크
→ PLAYING 상태 + timerEnd &lt; now 인 방 발견
→ settle() 호출 → 정산 + BATTLE_FINISHED 브로드캐스트</p>
<p>새로 생성</p>
<ul>
<li>BattleScheduler.java - 10초마다 만료된 방 감지 후 settle() 호출</li>
<li>@EnableScheduling - BackApplication.java에 추가해둠</li>
<li>findByStatusAndTimerEndBefore - BattleRoomRepository에 있음</li>
</ul>
<p>동작 방식</p>
<pre><code class="language-java">10초마다 실행
  → PLAYING 상태이면서 timerEnd &lt; now 인 방 조회
  → 각 방에 settle(roomId) 호출
    → 내부에서 FINISHED 체크로 중복 정산 방지
</code></pre>
<p>테스트 방법
배틀방 timerEnd를 과거 시간으로 직접 DB에서 수정하면 10초 이내에 자동 정산되고 <code>BATTLE_FINISHED</code> 브로드캐스트가 온다.</p>
<hr>
<h1>결과 조회</h1>
<p>지금 구현한 코드 상에서 보면 ac받으면 바로 퇴장이기 때문에 마지막 ac 제출 1개만 조회하는 식으로 구현</p>
<pre><code class="language-java">제출 → AC받음 → participant.complete() → status: EXIT → 재제출 불가

SubmissionService에서 이미 막혀있음
if (participant.getStatus() != BattleParticipantStatus.PLAYING) {
    throw new IllegalStateException(&quot;제출할 수 없는 상태입니다.&quot;);
}

현재 로직상 참여자당 제출 횟수는:
WA 0회 이상 + AC 1회 = 총 n회
                ↑
           이게 마지막 제출
결과 조회 시 findByBattleRoomAndMember()로 가져온 뒤 마지막 제출(AC)만 쓰면 됨
</code></pre>
<p>그러니까 지금 MVP에서는</p>
<ul>
<li>항상 AC 1개만 있으니까 AC 반환 경로만 탐</li>
</ul>
<p>Judge0 연동 후에는</p>
<ul>
<li>WA 여러 개 + 마지막 AC → AC 반환</li>
<li>WA만 여러 개 → passedCount 가장 높은 것 반환</li>
<li>제출 없음 → null 반환</li>
</ul>
<p>SubmissionRepository에 정렬 쿼리 추가</p>
<pre><code class="language-java">// AC 제출 중 첫 번째 (finishTime 기준)
Optional&lt;Submission&gt; findFirstByBattleRoomAndMemberAndResultOrderByCreatedAtAsc(
    BattleRoom room, Member member, SubmissionResult result);
</code></pre>
<h3>무엇을 하는가</h3>
<p>배틀이 끝난 후 결과를 HTTP로 조회하는 API
WebSocket으로 BATTLE_FINISHED를 받은 클라이언트가 **그래서 순위/점수가 어떻게 됐어?**를 물어보는 단계</p>
<p>API 2개</p>
<ol>
<li>결과 조회 <code>GET /api/v1/battle/rooms/{roomId}/result</code>
배틀 종료 후 최종 순위, 점수, 제출 결과 반환
<code>status != FINISHED</code> 이면 예외</li>
<li>진행 중 방 목록 <code>GET /api/v1/battle/rooms</code>
현재 PLAYING 상태인 방 목록 반환
관전자가 어떤 방을 볼지 선택하기 위한 용도</li>
</ol>
<h3>동작 흐름</h3>
<pre><code class="language-java">GET /api/v1/battle/rooms/1/result
      ↓
1. BattleRoom 조회
   status != FINISHED → 예외 (&quot;아직 정산 완료되지 않은 방&quot;)
      ↓
2. BattleParticipant 목록 조회
   → finalRank 오름차순 정렬
      ↓
3. 각 참여자별 findBestSubmission() 호출
   ┌─ AC 제출 있으면 → 첫 번째 AC 반환
   └─ AC 없으면     → passedCount 가장 높은 제출 반환
                       제출 자체 없으면 → null
      ↓
4. BattleResultResponse 조립 후 반환
   {
     roomId, problemTitle,
     participants: [
       { userId, nickname, finalRank, scoreDelta,
         result, passedCount, totalCount, finishTime }
     ]
   }

GET /api/v1/battle/rooms
      ↓
1. PLAYING 상태인 방 목록 조회
      ↓
2. 각 방의 현재 참여자 수 조회
      ↓
3. RoomListResponse 목록 반환
   [{ roomId, status, problemTitle, currentPlayers, maxPlayers }]
</code></pre>
<h3>findBestSubmission이 중요한 이유</h3>
<p><strong>현재 MVP</strong>
Mock 채점 → 항상 AC 1개 → AC 반환 경로만 탐</p>
<p><strong>Judge0 연동 후</strong>
WA 여러 개 + AC 1개     → AC 반환
WA만 여러 개                  → passedCount 가장 높은 것 반환
제출 없음                          → null 반환</p>
<p>지금 로직을 바꾸지 않아도 Judge0 연동 후 자연스럽게 대응할 수 있다.</p>
<!-- notionvc: fc68ade0-bc9c-42f3-82ed-4b98581f45b1 --><!--EndFragment-->
</body>
</html>