### PR TITLE
[refactor] 매칭 큐 waitingCount 정합성 개선 및 queue 조회 부수효과 제거

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -112,48 +112,56 @@ public class MatchingQueueService {
     }
 
     public QueueStatusResponse cancelQueue(Long userId) {
-        // 1. 유저가 어느 큐에 들어가 있는지 찾는다.
+        // 1) 유저가 어떤 큐에 들어가 있는지 조회
         QueueKey queueKey = userQueueMap.get(userId);
 
-        // 2. 대기열에 없는 유저면 예외 발생
+        // 2) 애초에 참가 중이 아니면 취소 불가
         if (queueKey == null) {
             throw new IllegalStateException("현재 매칭 대기열에 참가 중이 아닙니다.");
         }
 
-        // 3. 해당 큐를 가져온다.
+        // 3) 해당 큐 조회
         Deque<WaitingUser> queue = waitingQueues.get(queueKey);
-        AtomicInteger waitingCount = waitingCounts.get(queueKey);
 
-        // 4. 큐 자체가 없으면 비정상 상태
+        // 4) 큐가 없으면 비정상 상태
         if (queue == null) {
-            userQueueMap.remove(userId);
             throw new IllegalStateException("대기열 정보를 찾을 수 없습니다.");
         }
 
-        int currentSize;
         boolean removed;
+        int currentSize;
 
+        // 5) 큐 변경(remove)도 동시성 보호 필요
         synchronized (queue) {
-            // 5. 큐에서 해당 userId를 가진 WaitingUser 제거
+            AtomicInteger waitingCount = waitingCounts.get(queueKey); // [변경] waitingCount 조회를 락 안으로 이동
+
+            // [변경] queue는 있는데 waitingCount가 없으면 비정상 상태로 처리
+            if (waitingCount == null) {
+                throw new IllegalStateException("대기열 카운트 정보를 찾을 수 없습니다.");
+            }
+
+            // 6) 해당 유저를 큐에서 제거
             removed = queue.removeIf(waitingUser -> waitingUser.getUserId().equals(userId));
 
-            // 7. 큐에서 제거 실패 시 예외
+            // 7) 제거 실패 시 비정상 상태
             if (!removed) {
                 throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
             }
 
-            // 6. userQueueMap에서도 제거
+            // 8) 유저-큐 매핑 제거
             userQueueMap.remove(userId);
+
+            // 9) 대기 인원 수 감소
             currentSize = waitingCount.decrementAndGet();
+
+            // [변경] 마지막 인원이 빠져 0명이 되면 map 정리도 같은 락 안에서 수행
+            if (currentSize == 0) {
+                waitingQueues.remove(queueKey, queue);
+                waitingCounts.remove(queueKey, waitingCount);
+            }
         }
 
-        // 8. 해당 큐가 비어 있으면 삭제하고
-        if (currentSize == 0) {
-            waitingQueues.remove(queueKey);
-            waitingCounts.remove(queueKey);
-        }
-
-        // 9. 응답 반환
+        // 10) 취소 결과 반환
         return new QueueStatusResponse(
                 "매칭 대기열에서 취소되었습니다.", queueKey.category(), queueKey.difficulty().name(), currentSize);
     }
@@ -162,10 +170,12 @@ public class MatchingQueueService {
     private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey, Deque<WaitingUser> queue) {
 
         List<WaitingUser> matchedUsers;
-        AtomicInteger waitingCount = waitingCounts.get(queueKey);
+        AtomicInteger waitingCount; // [변경] 락 밖 조회 제거, 락 안에서 조회하도록 변경
 
         // 락 안에서는 4명 확인 + 4명 추출까지만 수행
         synchronized (queue) {
+            waitingCount = waitingCounts.get(queueKey); // [변경] waitingCount 조회를 락 안으로 이동
+
             // 2차 체크: 바깥에서 4명 이상이었더라도
             // 이 시점에는 다른 스레드가 먼저 가져갔을 수 있으므로 다시 확인 필요
             // 4명 미만이면 매칭 X
@@ -190,7 +200,7 @@ public class MatchingQueueService {
                 return null;
             }
 
-            waitingCount.addAndGet(-4);
+            waitingCount.addAndGet(-4); // [변경] 성공 전 map remove 하지 않고 count만 감소
         }
 
         // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
@@ -210,9 +220,14 @@ public class MatchingQueueService {
             matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
 
             // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
-            if (waitingCount.get() == 0) {
-                waitingQueues.remove(queueKey);
-                waitingCounts.remove(queueKey);
+            synchronized (queue) { // [변경] 성공 후에만 다시 락 잡고 최종 정리
+                AtomicInteger latestWaitingCount = waitingCounts.get(queueKey); // [변경]
+
+                // [변경] 내가 처리하던 같은 카운터 객체가 아직 살아 있고, 실제 0명일 때만 제거
+                if (latestWaitingCount == waitingCount && latestWaitingCount.get() == 0) {
+                    waitingQueues.remove(queueKey, queue);
+                    waitingCounts.remove(queueKey, latestWaitingCount);
+                }
             }
 
             return response;
@@ -223,7 +238,7 @@ public class MatchingQueueService {
                 for (int i = matchedUsers.size() - 1; i >= 0; i--) {
                     queue.addFirst(matchedUsers.get(i));
                 }
-                waitingCount.addAndGet(matchedUsers.size());
+                waitingCount.addAndGet(matchedUsers.size()); // [변경] 같은 queue / 같은 count에 그대로 롤백
             }
             throw e;
         }

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.stereotype.Service;
 
@@ -53,6 +54,7 @@ public class MatchingQueueService {
      * 4. 유저를 대기열에 추가
      * 5. userQueueMap에도 기록
      */
+    private final Map<QueueKey, AtomicInteger> waitingCounts = new ConcurrentHashMap<>();
 
     // 매칭 성사 시 방 생성 호출용 서비스
     private final BattleRoomService battleRoomService;
@@ -70,6 +72,7 @@ public class MatchingQueueService {
 
         // 해당 큐가 없으면 새로 만들고, 있으면 기존 큐를 가져온다.
         Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
+        AtomicInteger waitingCount = waitingCounts.computeIfAbsent(queueKey, key -> new AtomicInteger(0));
 
         WaitingUser waitingUser = new WaitingUser(userId, queueKey);
 
@@ -77,7 +80,7 @@ public class MatchingQueueService {
         int currentSize;
         synchronized (queue) {
             queue.addLast(waitingUser);
-            currentSize = queue.size();
+            currentSize = waitingCount.incrementAndGet();
         }
         // 1차 빠른 체크: 4명 미만이면 굳이 매칭 함수까지 안 들어감
         if (currentSize < 4) {
@@ -85,23 +88,27 @@ public class MatchingQueueService {
                     "매칭 대기열에 참가했습니다.",
                     queueKey.category(),
                     queueKey.difficulty().name(),
-                    queue.size());
+                    currentSize);
         }
 
         // 4명 이상일 때만 실제 매칭 시도
         CreateRoomResponse room = tryMatchAndCreateRoom(queueKey, queue);
 
         if (room != null) {
+            int updatedCount =
+                    waitingCounts.getOrDefault(queueKey, new AtomicInteger(0)).get();
             return new QueueStatusResponse(
                     "매칭 성사 및 방 생성 완료 (roomId=" + room.roomId() + ")",
                     queueKey.category(),
                     queueKey.difficulty().name(),
-                    queue.size());
+                    updatedCount);
         }
 
         // 아직 인원 부족이면 대기 상태 응답
+        int updatedCount =
+                waitingCounts.getOrDefault(queueKey, new AtomicInteger(0)).get();
         return new QueueStatusResponse(
-                "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
+                "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), updatedCount);
     }
 
     public QueueStatusResponse cancelQueue(Long userId) {
@@ -115,6 +122,7 @@ public class MatchingQueueService {
 
         // 3. 해당 큐를 가져온다.
         Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+        AtomicInteger waitingCount = waitingCounts.get(queueKey);
 
         // 4. 큐 자체가 없으면 비정상 상태
         if (queue == null) {
@@ -136,11 +144,14 @@ public class MatchingQueueService {
 
             // 6. userQueueMap에서도 제거
             userQueueMap.remove(userId);
-            currentSize = queue.size();
+            currentSize = waitingCount.decrementAndGet();
         }
 
-        // 8. 해당 큐가 비어 있으면 삭제하고, 안 비어 있으면 그대로 둬라
-        waitingQueues.computeIfPresent(queueKey, (key, q) -> q.isEmpty() ? null : q);
+        // 8. 해당 큐가 비어 있으면 삭제하고
+        if (currentSize == 0) {
+            waitingQueues.remove(queueKey);
+            waitingCounts.remove(queueKey);
+        }
 
         // 9. 응답 반환
         return new QueueStatusResponse(
@@ -151,13 +162,14 @@ public class MatchingQueueService {
     private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey, Deque<WaitingUser> queue) {
 
         List<WaitingUser> matchedUsers;
+        AtomicInteger waitingCount = waitingCounts.get(queueKey);
 
         // 락 안에서는 4명 확인 + 4명 추출까지만 수행
         synchronized (queue) {
             // 2차 체크: 바깥에서 4명 이상이었더라도
             // 이 시점에는 다른 스레드가 먼저 가져갔을 수 있으므로 다시 확인 필요
             // 4명 미만이면 매칭 X
-            if (queue.size() < 4) {
+            if (waitingCount == null || waitingCount.get() < 4) {
                 return null;
             }
 
@@ -177,6 +189,8 @@ public class MatchingQueueService {
                 }
                 return null;
             }
+
+            waitingCount.addAndGet(-4);
         }
 
         // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
@@ -196,7 +210,10 @@ public class MatchingQueueService {
             matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
 
             // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
-            waitingQueues.computeIfPresent(queueKey, (k, q) -> q.isEmpty() ? null : q);
+            if (waitingCount.get() == 0) {
+                waitingQueues.remove(queueKey);
+                waitingCounts.remove(queueKey);
+            }
 
             return response;
         } catch (RuntimeException e) {
@@ -206,6 +223,7 @@ public class MatchingQueueService {
                 for (int i = matchedUsers.size() - 1; i >= 0; i--) {
                     queue.addFirst(matchedUsers.get(i));
                 }
+                waitingCount.addAndGet(matchedUsers.size());
             }
             throw e;
         }
@@ -222,20 +240,17 @@ public class MatchingQueueService {
         Deque<WaitingUser> queue = waitingQueues.get(queueKey);
 
         // 맵에는 있는데 실제 큐가 없으면 비정상 상태지만, 조회는 안전하게 false 처리
-        // 불일치 발견: userQueueMap에는 있으나 실제 대기열(waitingQueues)에는 없음
         if (queue == null) {
-            // 원자적으로 제거 (내가 확인했던 그 queueKey일 때만 제거하여 동시성 이슈 방지)
-            userQueueMap.remove(userId, queueKey);
-
-            // 로그를 남겨 추적 가능하게 함
-            // log.warn("Inconsistency detected: User {} was in userQueueMap but queue {} was missing. Cleaned up.",
-            // userId, queueKey);
-
+            // log.warn("Queue state inconsistency: userId={}, queueKey={}", userId, queueKey);
             return new QueueStateResponse(false, null, null, 0);
         }
 
+        AtomicInteger waitingCount = waitingCounts.get(queueKey);
+        // [변경] queue.size() -> waitingCounts 기준으로 통일
+        int currentCount = waitingCount == null ? 0 : waitingCount.get();
+
         return new QueueStateResponse(
-                true, queueKey.category(), queueKey.difficulty().name(), queue.size());
+                true, queueKey.category(), queueKey.difficulty().name(), currentCount);
     }
 
     // 찬의님 연동 지점 (여기만 나중에 연결하면 됨)


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #52 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #52 

---

<html>
<body>
<hr>

<h1>매칭 큐 waitingCount 정합성 개선 및 queue 조회 부수효과 제거</h1>

<p>이번 PR은 매칭 큐 서비스에서 <strong>대기 인원 수(waitingCount)를 더 일관되고 가볍게 관리하도록 리팩터링</strong>한 작업입니다.</p>
<p>기존에는 응답 생성 시 <code>queue.size()</code>를 직접 사용하고 있었는데, 이는 <code>ConcurrentLinkedDeque</code> 환경에서 비용이 커질 수 있고 락 밖 재조회로 인해 순간적으로 흔들린 값을 반환할 수 있었습니다.</p>
<p>이번 변경에서는 <code>QueueKey -&gt; AtomicInteger</code> 형태의 <code>waitingCounts</code>를 도입해 큐 변경과 카운터 변경을 함께 처리하도록 정리했고, 추가로 <code>GET /queue/me</code> 조회 시 발생하던 내부 상태 변경(side effect)도 제거했습니다.</p>

<hr>

<h3>1. waitingCounts 맵 추가</h3>
<p>기존에는 대기 인원 수를 매번 <code>queue.size()</code>로 계산했지만, 이번 PR에서는 공식 대기 인원 수를 별도로 관리하기 위해 <code>waitingCounts</code>를 추가했습니다.</p>

<pre><code class="language-java">private final Map&lt;QueueKey, AtomicInteger&gt; waitingCounts = new ConcurrentHashMap&lt;&gt;();
</code></pre>

<p>역할은 아래와 같습니다.</p>
<ul>
<li><code>waitingQueues</code>: 실제 대기 순서(FIFO) 보관</li>
<li><code>waitingCounts</code>: 해당 큐의 현재 대기 인원 수 보관</li>
</ul>

<p>즉, 이제는 큐 자체에서 매번 사람 수를 다시 세지 않고, 카운터 값을 공식 waitingCount로 사용합니다.</p>

<hr>

<h3>2. joinQueue에서 큐 추가와 waitingCount 증가를 함께 처리</h3>
<p>기존에는 사용자 추가 후 응답 시점에 <code>queue.size()</code>를 다시 읽는 방식이었지만, 이번 변경에서는 큐에 사용자를 넣는 작업과 카운터 증가를 같은 락 구간에서 수행하도록 바꿨습니다.</p>

<pre><code class="language-java">Deque&lt;WaitingUser&gt; queue = waitingQueues.computeIfAbsent(queueKey, key -&gt; new ConcurrentLinkedDeque&lt;&gt;());
AtomicInteger waitingCount = waitingCounts.computeIfAbsent(queueKey, key -&gt; new AtomicInteger(0));

int currentSize;
synchronized (queue) {
    queue.addLast(waitingUser);
    currentSize = waitingCount.incrementAndGet();
}
</code></pre>

<p>이렇게 바뀌면서 <code>joinQueue()</code>는 현재 요청이 반영된 직후의 waitingCount를 바로 응답에 사용할 수 있게 됐습니다.</p>

<hr>

<h3>3. cancelQueue에서 큐 제거와 waitingCount 감소를 함께 처리</h3>
<p>취소 로직도 동일하게 큐 제거와 카운터 감소를 같은 락 안에서 처리하도록 정리했습니다.</p>

<pre><code class="language-java">int currentSize;
boolean removed;

synchronized (queue) {
    removed = queue.removeIf(waitingUser -&gt; waitingUser.getUserId().equals(userId));

    if (!removed) {
        throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
    }

    userQueueMap.remove(userId);
    currentSize = waitingCount.decrementAndGet();
}
</code></pre>

<p>그리고 카운터가 0이 되면, 큐와 카운터를 함께 제거하도록 변경했습니다.</p>

<pre><code class="language-java">if (currentSize == 0) {
    waitingQueues.remove(queueKey);
    waitingCounts.remove(queueKey);
}
</code></pre>

<p>기존에는 <code>waitingQueues</code>만 정리하는 구조였지만, 이제는 <code>waitingQueues</code>와 <code>waitingCounts</code>를 한 세트처럼 관리합니다.</p>

<hr>

<h3>4. 4인 매칭 시 poll과 카운터 감소를 함께 처리</h3>
<p>방 생성 직전 4명을 추출하는 로직에서도 waitingCount를 같이 갱신하도록 변경했습니다.</p>
<p>기존에는 큐에서 4명을 꺼낸 뒤 응답에서 다시 큐 크기를 읽는 구조였다면, 이번 변경에서는 매칭 시점에 공식 카운터를 바로 줄입니다.</p>

<pre><code class="language-java">synchronized (queue) {
    if (waitingCount == null || waitingCount.get() &lt; 4) {
        return null;
    }

    matchedUsers = new ArrayList&lt;&gt;(4);
    for (int i = 0; i &lt; 4; i++) {
        WaitingUser user = queue.pollFirst();
        if (user != null) {
            matchedUsers.add(user);
        }
    }

    if (matchedUsers.size() &lt; 4) {
        for (int i = matchedUsers.size() - 1; i &gt;= 0; i--) {
            queue.addFirst(matchedUsers.get(i));
        }
        return null;
    }

    waitingCount.addAndGet(-4);
}
</code></pre>

<p>이렇게 하면 매칭 후 남은 대기 인원 수 역시 <code>queue.size()</code>가 아니라 공식 카운터 값으로 관리됩니다.</p>

<hr>

<h3>5. 방 생성 실패 시 큐와 waitingCount를 함께 롤백</h3>
<p>방 생성 중 예외가 발생했을 때는 기존처럼 큐에 사용자들을 되돌려 놓는 것뿐 아니라, 감소했던 카운터도 함께 복구하도록 변경했습니다.</p>

<pre><code class="language-java">catch (RuntimeException e) {
    synchronized (queue) {
        for (int i = matchedUsers.size() - 1; i &gt;= 0; i--) {
            queue.addFirst(matchedUsers.get(i));
        }
        waitingCount.addAndGet(matchedUsers.size());
    }
    throw e;
}
</code></pre>

<p>즉, 이제 롤백 시에는</p>
<ul>
<li>큐 상태 복구</li>
<li>waitingCount 복구</li>
</ul>
<p>를 같이 처리하므로, 인원 수 정합성이 깨지지 않도록 맞췄습니다.</p>

<hr>

<h3>6. getMyQueueState에서 queue.size() 제거</h3>
<p><code>GET /api/v1/queue/me</code> 조회 시에도 더 이상 <code>queue.size()</code>를 사용하지 않고, <code>waitingCounts</code>에서 현재 인원 수를 읽도록 변경했습니다.</p>

<pre><code class="language-java">AtomicInteger waitingCount = waitingCounts.get(queueKey);
int currentCount = waitingCount == null ? 0 : waitingCount.get();

return new QueueStateResponse(
        true,
        queueKey.category(),
        queueKey.difficulty().name(),
        currentCount);
</code></pre>

<p>이로써 조회 API 역시 공식 카운터 기준으로 waitingCount를 반환하게 되었습니다.</p>

<hr>

<h3>7. GET /queue/me의 cleanup side effect 제거</h3>
<p>기존 조회 로직에서는 <code>userQueueMap</code>에는 있는데 실제 큐는 없는 비정상 상태를 감지하면, 조회 API 내부에서 <code>userQueueMap.remove(...)</code>로 정리하고 있었습니다.</p>
<p>하지만 GET API는 read-only 성격을 유지하는 것이 자연스럽기 때문에, 이번 변경에서는 조회 시 내부 상태를 수정하지 않고 단순히 <code>inQueue=false</code>를 반환하도록 정리했습니다.</p>

<pre><code class="language-java">if (queue == null) {
    return new QueueStateResponse(false, null, null, 0);
}
</code></pre>

<p>즉, 이번 PR로 <strong>조회 API는 더 이상 서버 상태를 변경하지 않게 되었습니다.</strong></p>

<hr>

<h3>이번 리팩터링으로 정리된 부분</h3>
<ul>
<li><code>queue.size()</code> 의존도를 줄이고 공식 waitingCount를 별도 관리</li>
<li>큐 변경과 카운터 변경을 같은 락 구간에서 처리해 정합성 개선</li>
<li>4인 매칭/롤백 시 waitingCount도 함께 반영</li>
<li>큐가 비었을 때 <code>waitingQueues</code>와 <code>waitingCounts</code>를 함께 정리</li>
<li><code>GET /queue/me</code>에서 발생하던 cleanup side effect 제거</li>
</ul>

<hr>

<h3>정리</h3>
<p>이번 PR은 기능 추가라기보다는, 기존 매칭 큐 서비스에서 <strong>waitingCount를 더 신뢰할 수 있는 값으로 관리하도록 정리한 리팩터링</strong>입니다.</p>
<p>특히 리뷰에서 지적된</p>
<ul>
<li><code>queue.size()</code> 기반 응답값의 비용 및 일관성 문제</li>
<li>조회 API의 내부 상태 변경 문제</li>
</ul>
<p>를 함께 정리하는 방향으로 반영했습니다.</p>

</body>
</html>
