### PR TITLE
[refactor] 매칭 큐 waitingcount 제거 및 queuesize 기반 상태 관리 단순화

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -86,7 +86,7 @@ public class MatchingQueueService {
                     "매칭 대기열에 참가했습니다.",
                     queueKey.category(),
                     queueKey.difficulty().name(),
-                    currentSize // [변경] queue.size() 대신 락 안에서 구한 currentSize 사용
+                    currentSize // \ queue.size() 대신 락 안에서 구한 currentSize 사용
                     );
         }
 
@@ -98,21 +98,21 @@ public class MatchingQueueService {
                     "매칭 성사 및 방 생성 완료 (roomId=" + room.roomId() + ")",
                     queueKey.category(),
                     queueKey.difficulty().name(),
-                    0 // [변경] 매칭 성공이면 이 유저는 더 이상 대기열에 없으므로 0으로 명확화
+                    0 //  매칭 성공이면 이 유저는 더 이상 대기열에 없으므로 0으로 명확화
                     );
         }
 
         // 아직 인원 부족이면 대기 상태 응답
-        int remainingSize; // [변경] 응답 직전 다시 읽을 값은 락으로 보호해서 조회
-        synchronized (queue) { // [변경]
-            remainingSize = queue.size(); // [변경]
+        int remainingSize; //  응답 직전 다시 읽을 값은 락으로 보호해서 조회
+        synchronized (queue) {
+            remainingSize = queue.size();
         }
 
         return new QueueStatusResponse(
                 "매칭 대기열에 참가했습니다.",
                 queueKey.category(),
                 queueKey.difficulty().name(),
-                remainingSize // [변경] 락 밖 queue.size() 직접 호출 제거
+                remainingSize // 락 밖 queue.size() 직접 호출 제거
                 );
     }
 
@@ -151,8 +151,8 @@ public class MatchingQueueService {
             currentSize = queue.size();
 
             // 8. 해당 큐가 비어 있으면 삭제하고, 안 비어 있으면 그대로 둬라
-            if (currentSize == 0) { // [변경] 빈 큐 정리를 락 안으로 이동
-                waitingQueues.remove(queueKey, queue); // [변경] 내가 잡고 있는 바로 그 queue일 때만 제거
+            if (currentSize == 0) { //  빈 큐 정리를 락 안으로 이동
+                waitingQueues.remove(queueKey, queue); //  내가 잡고 있는 바로 그 queue일 때만 제거
             }
         }
 
@@ -165,6 +165,7 @@ public class MatchingQueueService {
     private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey, Deque<WaitingUser> queue) {
 
         List<WaitingUser> matchedUsers;
+        boolean shouldRemoveQueue = false; //  성공 후 정리 여부를 락 안에서 판단하기 위한 플래그 추가
 
         // 락 안에서는 4명 확인 + 4명 추출까지만 수행
         synchronized (queue) {
@@ -191,6 +192,10 @@ public class MatchingQueueService {
                 }
                 return null;
             }
+
+            // 현재 4명을 꺼낸 직후 큐가 비었는지 미리 기록
+            // 성공 후 같은 queue에 대해 map 정리할 때 사용
+            shouldRemoveQueue = queue.isEmpty();
         }
 
         // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
@@ -210,7 +215,13 @@ public class MatchingQueueService {
             matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
 
             // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
-            waitingQueues.computeIfPresent(queueKey, (k, q) -> q.isEmpty() ? null : q);
+            if (shouldRemoveQueue) { // 락 밖 computeIfPresent 제거
+                synchronized (queue) { // 빈 큐 정리를 같은 queue 락 안에서 수행
+                    if (queue.isEmpty()) { // 그 사이 다시 들어온 유저가 없을 때만 제거
+                        waitingQueues.remove(queueKey, queue); // 내가 처리한 바로 그 queue일 때만 제거
+                    }
+                }
+            }
 
             return response;
         } catch (RuntimeException e) {

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -165,7 +165,6 @@ public class MatchingQueueService {
     private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey, Deque<WaitingUser> queue) {
 
         List<WaitingUser> matchedUsers;
-        boolean shouldRemoveQueue = false; //  성공 후 정리 여부를 락 안에서 판단하기 위한 플래그 추가
 
         // 락 안에서는 4명 확인 + 4명 추출까지만 수행
         synchronized (queue) {
@@ -192,10 +191,6 @@ public class MatchingQueueService {
                 }
                 return null;
             }
-
-            // 현재 4명을 꺼낸 직후 큐가 비었는지 미리 기록
-            // 성공 후 같은 queue에 대해 map 정리할 때 사용
-            shouldRemoveQueue = queue.isEmpty();
         }
 
         // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
@@ -215,11 +210,9 @@ public class MatchingQueueService {
             matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
 
             // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
-            if (shouldRemoveQueue) { // 락 밖 computeIfPresent 제거
-                synchronized (queue) { // 빈 큐 정리를 같은 queue 락 안에서 수행
-                    if (queue.isEmpty()) { // 그 사이 다시 들어온 유저가 없을 때만 제거
-                        waitingQueues.remove(queueKey, queue); // 내가 처리한 바로 그 queue일 때만 제거
-                    }
+            synchronized (queue) { //  성공 후 같은 queue 락 안에서 직접 확인 후 제거
+                if (queue.isEmpty()) { //  플래그 대신 현재 시점의 실제 상태 확인
+                    waitingQueues.remove(queueKey, queue); // 내가 처리한 바로 그 queue일 때만 제거
                 }
             }
 

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.stereotype.Service;
 
@@ -54,7 +53,6 @@ public class MatchingQueueService {
      * 4. 유저를 대기열에 추가
      * 5. userQueueMap에도 기록
      */
-    private final Map<QueueKey, AtomicInteger> waitingCounts = new ConcurrentHashMap<>();
 
     // 매칭 성사 시 방 생성 호출용 서비스
     private final BattleRoomService battleRoomService;
@@ -72,7 +70,6 @@ public class MatchingQueueService {
 
         // 해당 큐가 없으면 새로 만들고, 있으면 기존 큐를 가져온다.
         Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
-        AtomicInteger waitingCount = waitingCounts.computeIfAbsent(queueKey, key -> new AtomicInteger(0));
 
         WaitingUser waitingUser = new WaitingUser(userId, queueKey);
 
@@ -80,7 +77,7 @@ public class MatchingQueueService {
         int currentSize;
         synchronized (queue) {
             queue.addLast(waitingUser);
-            currentSize = waitingCount.incrementAndGet();
+            currentSize = queue.size();
         }
         // 1차 빠른 체크: 4명 미만이면 굳이 매칭 함수까지 안 들어감
         if (currentSize < 4) {
@@ -88,80 +85,64 @@ public class MatchingQueueService {
                     "매칭 대기열에 참가했습니다.",
                     queueKey.category(),
                     queueKey.difficulty().name(),
-                    currentSize);
+                    queue.size());
         }
 
         // 4명 이상일 때만 실제 매칭 시도
         CreateRoomResponse room = tryMatchAndCreateRoom(queueKey, queue);
 
         if (room != null) {
-            int updatedCount =
-                    waitingCounts.getOrDefault(queueKey, new AtomicInteger(0)).get();
             return new QueueStatusResponse(
                     "매칭 성사 및 방 생성 완료 (roomId=" + room.roomId() + ")",
                     queueKey.category(),
                     queueKey.difficulty().name(),
-                    updatedCount);
+                    queue.size());
         }
 
         // 아직 인원 부족이면 대기 상태 응답
-        int updatedCount =
-                waitingCounts.getOrDefault(queueKey, new AtomicInteger(0)).get();
         return new QueueStatusResponse(
-                "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), updatedCount);
+                "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
     }
 
     public QueueStatusResponse cancelQueue(Long userId) {
-        // 1) 유저가 어떤 큐에 들어가 있는지 조회
+        // 1. 유저가 어느 큐에 들어가 있는지 찾는다.
         QueueKey queueKey = userQueueMap.get(userId);
 
-        // 2) 애초에 참가 중이 아니면 취소 불가
+        // 2. 대기열에 없는 유저면 예외 발생
         if (queueKey == null) {
             throw new IllegalStateException("현재 매칭 대기열에 참가 중이 아닙니다.");
         }
 
-        // 3) 해당 큐 조회
+        // 3. 해당 큐를 가져온다.
         Deque<WaitingUser> queue = waitingQueues.get(queueKey);
 
-        // 4) 큐가 없으면 비정상 상태
+        // 4. 큐 자체가 없으면 비정상 상태
         if (queue == null) {
+            userQueueMap.remove(userId);
             throw new IllegalStateException("대기열 정보를 찾을 수 없습니다.");
         }
 
-        boolean removed;
         int currentSize;
+        boolean removed;
 
-        // 5) 큐 변경(remove)도 동시성 보호 필요
         synchronized (queue) {
-            AtomicInteger waitingCount = waitingCounts.get(queueKey); // [변경] waitingCount 조회를 락 안으로 이동
-
-            // [변경] queue는 있는데 waitingCount가 없으면 비정상 상태로 처리
-            if (waitingCount == null) {
-                throw new IllegalStateException("대기열 카운트 정보를 찾을 수 없습니다.");
-            }
-
-            // 6) 해당 유저를 큐에서 제거
+            // 5. 큐에서 해당 userId를 가진 WaitingUser 제거
             removed = queue.removeIf(waitingUser -> waitingUser.getUserId().equals(userId));
 
-            // 7) 제거 실패 시 비정상 상태
+            // 7. 큐에서 제거 실패 시 예외
             if (!removed) {
                 throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
             }
 
-            // 8) 유저-큐 매핑 제거
+            // 6. userQueueMap에서도 제거
             userQueueMap.remove(userId);
-
-            // 9) 대기 인원 수 감소
-            currentSize = waitingCount.decrementAndGet();
-
-            // [변경] 마지막 인원이 빠져 0명이 되면 map 정리도 같은 락 안에서 수행
-            if (currentSize == 0) {
-                waitingQueues.remove(queueKey, queue);
-                waitingCounts.remove(queueKey, waitingCount);
-            }
+            currentSize = queue.size();
         }
 
-        // 10) 취소 결과 반환
+        // 8. 해당 큐가 비어 있으면 삭제하고, 안 비어 있으면 그대로 둬라
+        waitingQueues.computeIfPresent(queueKey, (key, q) -> q.isEmpty() ? null : q);
+
+        // 9. 응답 반환
         return new QueueStatusResponse(
                 "매칭 대기열에서 취소되었습니다.", queueKey.category(), queueKey.difficulty().name(), currentSize);
     }
@@ -170,16 +151,13 @@ public class MatchingQueueService {
     private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey, Deque<WaitingUser> queue) {
 
         List<WaitingUser> matchedUsers;
-        AtomicInteger waitingCount; // [변경] 락 밖 조회 제거, 락 안에서 조회하도록 변경
 
         // 락 안에서는 4명 확인 + 4명 추출까지만 수행
         synchronized (queue) {
-            waitingCount = waitingCounts.get(queueKey); // [변경] waitingCount 조회를 락 안으로 이동
-
             // 2차 체크: 바깥에서 4명 이상이었더라도
             // 이 시점에는 다른 스레드가 먼저 가져갔을 수 있으므로 다시 확인 필요
             // 4명 미만이면 매칭 X
-            if (waitingCount == null || waitingCount.get() < 4) {
+            if (queue.size() < 4) {
                 return null;
             }
 
@@ -199,8 +177,6 @@ public class MatchingQueueService {
                 }
                 return null;
             }
-
-            waitingCount.addAndGet(-4); // [변경] 성공 전 map remove 하지 않고 count만 감소
         }
 
         // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
@@ -220,15 +196,7 @@ public class MatchingQueueService {
             matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
 
             // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
-            synchronized (queue) { // [변경] 성공 후에만 다시 락 잡고 최종 정리
-                AtomicInteger latestWaitingCount = waitingCounts.get(queueKey); // [변경]
-
-                // [변경] 내가 처리하던 같은 카운터 객체가 아직 살아 있고, 실제 0명일 때만 제거
-                if (latestWaitingCount == waitingCount && latestWaitingCount.get() == 0) {
-                    waitingQueues.remove(queueKey, queue);
-                    waitingCounts.remove(queueKey, latestWaitingCount);
-                }
-            }
+            waitingQueues.computeIfPresent(queueKey, (k, q) -> q.isEmpty() ? null : q);
 
             return response;
         } catch (RuntimeException e) {
@@ -238,7 +206,6 @@ public class MatchingQueueService {
                 for (int i = matchedUsers.size() - 1; i >= 0; i--) {
                     queue.addFirst(matchedUsers.get(i));
                 }
-                waitingCount.addAndGet(matchedUsers.size()); // [변경] 같은 queue / 같은 count에 그대로 롤백
             }
             throw e;
         }
@@ -255,17 +222,20 @@ public class MatchingQueueService {
         Deque<WaitingUser> queue = waitingQueues.get(queueKey);
 
         // 맵에는 있는데 실제 큐가 없으면 비정상 상태지만, 조회는 안전하게 false 처리
+        // 불일치 발견: userQueueMap에는 있으나 실제 대기열(waitingQueues)에는 없음
         if (queue == null) {
-            // log.warn("Queue state inconsistency: userId={}, queueKey={}", userId, queueKey);
+            // 원자적으로 제거 (내가 확인했던 그 queueKey일 때만 제거하여 동시성 이슈 방지)
+            userQueueMap.remove(userId, queueKey);
+
+            // 로그를 남겨 추적 가능하게 함
+            // log.warn("Inconsistency detected: User {} was in userQueueMap but queue {} was missing. Cleaned up.",
+            // userId, queueKey);
+
             return new QueueStateResponse(false, null, null, 0);
         }
 
-        AtomicInteger waitingCount = waitingCounts.get(queueKey);
-        // [변경] queue.size() -> waitingCounts 기준으로 통일
-        int currentCount = waitingCount == null ? 0 : waitingCount.get();
-
         return new QueueStateResponse(
-                true, queueKey.category(), queueKey.difficulty().name(), currentCount);
+                true, queueKey.category(), queueKey.difficulty().name(), queue.size());
     }
 
     // 찬의님 연동 지점 (여기만 나중에 연결하면 됨)

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -79,13 +79,15 @@ public class MatchingQueueService {
             queue.addLast(waitingUser);
             currentSize = queue.size();
         }
+
         // 1차 빠른 체크: 4명 미만이면 굳이 매칭 함수까지 안 들어감
         if (currentSize < 4) {
             return new QueueStatusResponse(
                     "매칭 대기열에 참가했습니다.",
                     queueKey.category(),
                     queueKey.difficulty().name(),
-                    queue.size());
+                    currentSize // [변경] queue.size() 대신 락 안에서 구한 currentSize 사용
+                    );
         }
 
         // 4명 이상일 때만 실제 매칭 시도
@@ -96,12 +98,22 @@ public class MatchingQueueService {
                     "매칭 성사 및 방 생성 완료 (roomId=" + room.roomId() + ")",
                     queueKey.category(),
                     queueKey.difficulty().name(),
-                    queue.size());
+                    0 // [변경] 매칭 성공이면 이 유저는 더 이상 대기열에 없으므로 0으로 명확화
+                    );
         }
 
         // 아직 인원 부족이면 대기 상태 응답
+        int remainingSize; // [변경] 응답 직전 다시 읽을 값은 락으로 보호해서 조회
+        synchronized (queue) { // [변경]
+            remainingSize = queue.size(); // [변경]
+        }
+
         return new QueueStatusResponse(
-                "매칭 대기열에 참가했습니다.", queueKey.category(), queueKey.difficulty().name(), queue.size());
+                "매칭 대기열에 참가했습니다.",
+                queueKey.category(),
+                queueKey.difficulty().name(),
+                remainingSize // [변경] 락 밖 queue.size() 직접 호출 제거
+                );
     }
 
     public QueueStatusResponse cancelQueue(Long userId) {
@@ -137,10 +149,12 @@ public class MatchingQueueService {
             // 6. userQueueMap에서도 제거
             userQueueMap.remove(userId);
             currentSize = queue.size();
-        }
 
-        // 8. 해당 큐가 비어 있으면 삭제하고, 안 비어 있으면 그대로 둬라
-        waitingQueues.computeIfPresent(queueKey, (key, q) -> q.isEmpty() ? null : q);
+            // 8. 해당 큐가 비어 있으면 삭제하고, 안 비어 있으면 그대로 둬라
+            if (currentSize == 0) { // [변경] 빈 큐 정리를 락 안으로 이동
+                waitingQueues.remove(queueKey, queue); // [변경] 내가 잡고 있는 바로 그 queue일 때만 제거
+            }
+        }
 
         // 9. 응답 반환
         return new QueueStatusResponse(


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #54 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #54 

---
<html>
<body>
<h1>[refactor] 매칭 큐 waitingCount 제거 및 queue.size() 기반 상태 관리 단순화</h1>

<h3>이슈 유형</h3>
<p>refactor</p>

<h3>개요</h3>
<p>이번 PR은 매칭 큐에서 별도로 관리하던 <code>waitingCount</code> 맵을 제거하고, <code>queue.size()</code>를 단일 기준으로 사용하는 방향으로 내부 상태 관리 로직을 정리했습니다.</p>
<p>기존에는 <code>waitingQueues</code>와 <code>waitingCounts</code>를 함께 유지하면서 큐와 카운트가 서로 어긋날 가능성이 있었고, 일부 응답/조회 로직은 <code>queue.size()</code>와 <code>waitingCount.get()</code>를 혼용하고 있었습니다. 이번 정리로 큐 자체를 source of truth로 삼고, 빈 큐 정리와 조회 시점도 더 명확하게 맞췄습니다.</p>

<p>수정 파일: <code>MatchingQueueService.java</code> 1개</p>
<p>신규 API/DTO 추가 없음. 외부 응답 스펙은 유지하고, <code>waitingCount</code> 계산 기준만 내부적으로 변경했습니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) <code>waitingCount</code> 별도 맵 제거</h3>
<p>기존에는 큐 본체와 별도로 <code>Map&lt;QueueKey, AtomicInteger&gt; waitingCounts</code>를 유지하면서 enqueue/dequeue/match/rollback 때마다 큐와 카운트를 동시에 맞춰줘야 했습니다.</p>
<p>이번 PR에서는 별도 카운트 맵을 제거하고, 실제 대기열 크기인 <code>queue.size()</code>를 기준값으로 사용하도록 단순화했습니다.</p>

<pre><code class="language-java">private final Map&lt;QueueKey, Deque&lt;WaitingUser&gt;&gt; waitingQueues = new ConcurrentHashMap&lt;&gt;();
private final Map&lt;Long, QueueKey&gt; userQueueMap = new ConcurrentHashMap&lt;&gt;();
</code></pre>

<p>이 변경으로 <code>queue는 있는데 waitingCount가 없음</code>, <code>count는 0인데 queue가 남아 있음</code> 같은 이중 상태 관리 리스크를 줄였습니다.</p>

<h3>2) <code>joinQueue()</code> 응답 waitingCount 계산 방식 정리</h3>
<p>유저를 큐에 넣을 때는 <code>synchronized(queue)</code> 안에서 enqueue 직후의 실제 크기를 읽어 <code>currentSize</code>로 보관합니다.</p>
<p>즉, 락 밖에서 <code>queue.size()</code>를 바로 읽지 않고, 큐를 수정한 시점의 값을 같은 동기화 구간 안에서 확보하도록 바꿨습니다.</p>

<pre><code class="language-java">int currentSize;
synchronized (queue) {
    queue.addLast(waitingUser);
    currentSize = queue.size();
}

if (currentSize &lt; 4) {
    return new QueueStatusResponse(
            "매칭 대기열에 참가했습니다.",
            queueKey.category(),
            queueKey.difficulty().name(),
            currentSize);
}
</code></pre>

<p>또한 4번째 유저 진입으로 매칭이 성사된 경우, 해당 유저는 더 이상 대기열에 속하지 않으므로 응답의 <code>waitingCount</code>를 <code>0</code>으로 명확히 반환하도록 했습니다.</p>

<pre><code class="language-java">if (room != null) {
    return new QueueStatusResponse(
            "매칭 성사 및 방 생성 완료 (roomId=" + room.roomId() + ")",
            queueKey.category(),
            queueKey.difficulty().name(),
            0);
}
</code></pre>

<p>매칭 시도 후에도 아직 대기 상태라면, 응답 직전에 다시 락을 잡고 현재 큐 크기를 읽어 <code>remainingSize</code>로 반환합니다. 이를 통해 락 밖 <code>queue.size()</code> 직접 조회를 제거했습니다.</p>

<h3>3) <code>cancelQueue()</code>에서 제거/정리 로직 단순화</h3>
<p>취소 시에도 더 이상 별도 카운트를 감소시키지 않고, 큐에서 사용자를 제거한 뒤 <code>queue.size()</code>를 그대로 현재 인원 수로 사용합니다.</p>
<p>마지막 인원이 나가 큐가 비는 경우에는 같은 동기화 구간 안에서 바로 <code>waitingQueues.remove(queueKey, queue)</code>를 호출해, 내가 잡고 있던 바로 그 큐일 때만 안전하게 맵에서 제거합니다.</p>

<pre><code class="language-java">synchronized (queue) {
    removed = queue.removeIf(waitingUser -&gt; waitingUser.getUserId().equals(userId));

    if (!removed) {
        throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
    }

    userQueueMap.remove(userId);
    currentSize = queue.size();

    if (currentSize == 0) {
        waitingQueues.remove(queueKey, queue);
    }
}
</code></pre>

<p>추가로 <code>userQueueMap</code>에는 있는데 실제 <code>waitingQueues</code>에는 큐가 없는 비정상 상황이면, stale 매핑을 먼저 정리한 뒤 예외를 던지도록 보완했습니다.</p>

<h3>4) <code>tryMatchAndCreateRoom()</code>의 4인 추출/빈 큐 정리 흐름 정리</h3>
<p>매칭 시도 시 2차 검증도 별도 카운터가 아니라 실제 큐 크기를 기준으로 수행합니다.</p>

<pre><code class="language-java">synchronized (queue) {
    if (queue.size() &lt; 4) {
        return null;
    }

    matchedUsers = new ArrayList&lt;&gt;(4);
    for (int i = 0; i &lt; 4; i++) {
        WaitingUser user = queue.pollFirst();
        if (user != null) {
            matchedUsers.add(user);
        }
    }

    if (matchedUsers.size() &lt; 4) {
        for (int i = matchedUsers.size() - 1; i &gt;= 0; i--) {
            queue.addFirst(matchedUsers.get(i));
        }
        return null;
    }
}
</code></pre>

<p>핵심은 락 안에서는 <strong>4명 이상인지 확인하고 4명을 꺼내는 작업까지만</strong> 수행하고, 실제 문제 선택 및 방 생성 호출은 락 밖에서 처리한다는 점입니다. 따라서 긴 외부 연동 구간 때문에 큐 전체가 오래 잠기지 않습니다.</p>
<p>방 생성 성공 후에는 매칭된 유저를 <code>userQueueMap</code>에서 제거하고, 같은 큐 락을 다시 잡아 현재 시점에도 정말 비어 있으면 <code>waitingQueues</code>에서 제거합니다.</p>

<pre><code class="language-java">matchedUsers.forEach(user -&gt; userQueueMap.remove(user.getUserId()));

synchronized (queue) {
    if (queue.isEmpty()) {
        waitingQueues.remove(queueKey, queue);
    }
}
</code></pre>

<p>반대로 방 생성 또는 문제 선택 단계에서 예외가 발생하면, 뽑아뒀던 4명을 원래 순서대로 큐 앞에 다시 넣어 FIFO 순서를 유지합니다. 기존처럼 카운트 복구를 따로 신경 쓸 필요가 없어져 롤백 로직도 단순해졌습니다.</p>

<h3>5) <code>getMyQueueState()</code> 조회 기준 통일 및 유령 매핑 정리</h3>
<p>내 큐 상태 조회도 더 이상 별도 count를 보지 않고 실제 <code>queue.size()</code>를 그대로 반환합니다.</p>
<p>또한 <code>userQueueMap</code>에는 기록돼 있는데 실제 <code>waitingQueues</code>에는 해당 큐가 없는 경우, stale 상태로 판단해 <code>userQueueMap.remove(userId, queueKey)</code>로 원자적으로 정리한 뒤 <code>inQueue=false</code>를 반환하도록 했습니다.</p>

<pre><code class="language-java">if (queue == null) {
    userQueueMap.remove(userId, queueKey);
    return new QueueStateResponse(false, null, null, 0);
}

return new QueueStateResponse(
        true, queueKey.category(), queueKey.difficulty().name(), queue.size());
</code></pre>

<h3>6) 정리된 효과</h3>
<ul>
<li><code>waitingQueues</code>와 <code>waitingCounts</code>를 동시에 맞춰야 했던 이중 상태 관리 부담이 사라집니다.</li>
<li>응답/조회/취소/매칭/롤백 모두가 같은 기준값(<code>queue.size()</code>)을 사용해 정합성이 좋아집니다.</li>
<li>빈 큐 정리 위치를 큐 락과 맞춰서 두어, 정리 타이밍이 더 명확해집니다.</li>
<li>API 응답 필드는 그대로 유지하면서 내부 구현 복잡도만 낮췄습니다.</li>
</ul>

<hr>

<h2>확인 포인트</h2>
<ol>
<li><code>/api/v1/queue/join</code> 호출 시 1, 2, 3번째 유저는 각각 현재 대기 인원 수(<code>1, 2, 3</code>)를 받는지 확인</li>
<li>4번째 유저 진입 시 방 생성이 1회만 호출되고, 해당 유저 응답의 <code>waitingCount</code>가 <code>0</code>인지 확인</li>
<li>마지막 1명이 <code>/api/v1/queue/cancel</code>을 호출하면 해당 <code>QueueKey</code>가 <code>waitingQueues</code>에서 제거되는지 확인</li>
<li>방 생성 실패 시 뽑아둔 4명이 다시 큐에 복구되어 다음 취소/조회에서 인원 수가 유지되는지 확인</li>
<li><code>/api/v1/queue/me</code> 조회 시 stale 매핑이 있으면 <code>inQueue=false</code>와 <code>waitingCount=0</code>으로 안전하게 정리되는지 확인</li>
</ol>
</body>
</html>
