### PR TITLE
[Feat] 로그인, 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.member.member.dto.JoinRequest;
+import com.back.domain.member.member.dto.LoginRequest;
+import com.back.domain.member.member.dto.LoginResponse;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.rsData.RsData;
 
@@ -21,7 +23,12 @@ public class MemberController {
     // 회원가입
     @PostMapping("/join")
     public RsData<Void> join(@Valid @RequestBody JoinRequest req) {
-        RsData<Void> res = memberService.join(req);
-        return res;
+        return memberService.join(req);
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public RsData<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
+        return memberService.login(req);
     }
 }

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.member.member.dto.JoinRequest;
 import com.back.domain.member.member.dto.LoginRequest;
-import com.back.domain.member.member.dto.LoginResponse;
 import com.back.domain.member.member.service.MemberService;
+import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 
 import jakarta.validation.Valid;
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("api/v1/members")
 public class MemberController {
     private final MemberService memberService;
+    private final Rq rq;
 
     // 회원가입
     @PostMapping("/join")
@@ -26,9 +27,18 @@ public class MemberController {
         return memberService.join(req);
     }
 
-    // 로그인
+    // 로그인 — 발급된 토큰을 HttpOnly 쿠키에 저장
     @PostMapping("/login")
-    public RsData<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
-        return memberService.login(req);
+    public RsData<Void> login(@Valid @RequestBody LoginRequest req) {
+        String accessToken = memberService.login(req);
+        rq.setCookie("accessToken", accessToken);
+        return RsData.of("200", "로그인 성공");
+    }
+
+    // 로그아웃 — accessToken 쿠키 만료
+    @PostMapping("/logout")
+    public RsData<Void> logout() {
+        rq.deleteCookie("accessToken");
+        return RsData.of("200", "로그아웃 성공");
     }
 }

--- a/src/main/java/com/back/domain/member/member/dto/LoginRequest.java
+++ b/src/main/java/com/back/domain/member/member/dto/LoginRequest.java
@@ -1,0 +1,8 @@
+package com.back.domain.member.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수 입력값입니다") @Email(message = "올바른 이메일 형식이 아닙니다") String email,
+        @NotBlank(message = "비밀번호는 필수 입력값입니다") String password) {}

--- a/src/main/java/com/back/domain/member/member/dto/LoginRequest.java
+++ b/src/main/java/com/back/domain/member/member/dto/LoginRequest.java
@@ -5,4 +5,5 @@ import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
         @NotBlank(message = "이메일은 필수 입력값입니다") @Email(message = "올바른 이메일 형식이 아닙니다") String email,
+
         @NotBlank(message = "비밀번호는 필수 입력값입니다") String password) {}

--- a/src/main/java/com/back/domain/member/member/dto/LoginResponse.java
+++ b/src/main/java/com/back/domain/member/member/dto/LoginResponse.java
@@ -1,0 +1,3 @@
+package com.back.domain.member.member.dto;
+
+public record LoginResponse(String accessToken) {}

--- a/src/main/java/com/back/domain/member/member/dto/LoginResponse.java
+++ b/src/main/java/com/back/domain/member/member/dto/LoginResponse.java
@@ -1,3 +1,0 @@
-package com.back.domain.member.member.dto;
-
-public record LoginResponse(String accessToken) {}

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -59,6 +59,17 @@ public class Member extends BaseEntity {
         this.score = (this.score == null ? 0L : this.score) + delta;
     }
 
+    // Rq.getActor() 전용 — DB 조회 없이 토큰 데이터로 경량 Member 생성
+    // password, role 등 민감 정보 없이 id/email/nickname만 담은 객체 반환
+    public static Member of(Long id, String email, String nickname) {
+        // 같은 클래스이므로 protected 기본 생성자 접근 가능
+        Member member = new Member();
+        member.id = id;
+        member.email = email;
+        member.nickname = nickname;
+        return member;
+    }
+
     public static Member createUser(String nickname, String email, String encodedPassword) {
         // 이메일 정규화 (앞뒤 공백 제거 및 소문자 변환)
         String normalizedEmail = (email != null) ? email.trim().toLowerCase(Locale.ROOT) : null;

--- a/src/main/java/com/back/domain/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/back/domain/member/member/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.back.domain.member.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +10,6 @@ import com.back.domain.member.member.entity.Member;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -7,9 +7,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 import com.back.domain.member.member.dto.JoinRequest;
+import com.back.domain.member.member.dto.LoginRequest;
+import com.back.domain.member.member.dto.LoginResponse;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.global.exception.ServiceException;
+import com.back.global.jwt.JwtProvider;
 import com.back.global.rsData.RsData;
 
 import jakarta.validation.Valid;
@@ -21,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     public RsData<Void> join(@Valid JoinRequest req) {
 
@@ -51,5 +55,32 @@ public class MemberService {
         memberRepository.save(member);
 
         return RsData.of("200", "회원가입성공");
+    }
+
+    // 로그인
+    public RsData<LoginResponse> login(@Valid LoginRequest req) {
+
+        // req null 방어
+        if (req == null) {
+            throw new ServiceException("MEMBER_400", "요청 바디가 비어 있습니다");
+        }
+
+        // 이메일 정규화
+        String normalizedEmail = req.email().trim().toLowerCase(Locale.ROOT);
+
+        // 이메일로 회원 조회 (없으면 보안상 동일 메시지)
+        Member member = memberRepository
+                .findByEmail(normalizedEmail)
+                .orElseThrow(() -> new ServiceException("MEMBER_401", "이메일 또는 비밀번호가 올바르지 않습니다"));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(req.password(), member.getPassword())) {
+            throw new ServiceException("MEMBER_401", "이메일 또는 비밀번호가 올바르지 않습니다");
+        }
+
+        // JWT 토큰 발급
+        String accessToken = jwtProvider.createToken(member.getId(), member.getEmail(), member.getRole().getKey());
+
+        return RsData.of("200", "로그인 성공", new LoginResponse(accessToken));
     }
 }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -79,7 +79,11 @@ public class MemberService {
         }
 
         // JWT 토큰 발급
-        String accessToken = jwtProvider.createToken(member.getId(), member.getEmail(), member.getRole().getKey());
+        String accessToken = jwtProvider.createToken(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getRole().getKey());
 
         return RsData.of("200", "로그인 성공", new LoginResponse(accessToken));
     }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -8,7 +8,6 @@ import org.springframework.validation.annotation.Validated;
 
 import com.back.domain.member.member.dto.JoinRequest;
 import com.back.domain.member.member.dto.LoginRequest;
-import com.back.domain.member.member.dto.LoginResponse;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.global.exception.ServiceException;
@@ -57,8 +56,8 @@ public class MemberService {
         return RsData.of("200", "회원가입성공");
     }
 
-    // 로그인
-    public RsData<LoginResponse> login(@Valid LoginRequest req) {
+    // 로그인 — 인증 성공 시 accessToken 문자열 반환 (쿠키 설정은 컨트롤러가 담당)
+    public String login(@Valid LoginRequest req) {
 
         // req null 방어
         if (req == null) {
@@ -78,13 +77,11 @@ public class MemberService {
             throw new ServiceException("MEMBER_401", "이메일 또는 비밀번호가 올바르지 않습니다");
         }
 
-        // JWT 토큰 발급
-        String accessToken = jwtProvider.createToken(
+        // JWT 토큰 생성 후 반환
+        return jwtProvider.createToken(
                 member.getId(),
                 member.getEmail(),
                 member.getNickname(),
                 member.getRole().getKey());
-
-        return RsData.of("200", "로그인 성공", new LoginResponse(accessToken));
     }
 }

--- a/src/main/java/com/back/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/back/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.back.global.jwt;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Claims claims = jwtProvider.parseToken(token);
+
+            String role = claims.get("role", String.class);
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    claims.getSubject(), null, List.of(new SimpleGrantedAuthority(role)));
+            auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    // Authorization 헤더에서 Bearer 토큰 추출
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/back/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/back/global/jwt/JwtAuthenticationFilter.java
@@ -1,15 +1,15 @@
 package com.back.global.jwt;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.back.global.security.SecurityUser;
 
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -24,27 +24,41 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
 
+    // 모든 요청마다 한 번씩 실행되어 JWT 유효성을 검사하고 인증 정보를 등록
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        // Authorization 헤더에서 토큰 추출
         String token = resolveToken(request);
 
+        // 토큰이 존재하고 유효한 경우에만 인증 처리
         if (token != null && jwtProvider.validateToken(token)) {
+            // 토큰에서 claims(페이로드) 파싱
             Claims claims = jwtProvider.parseToken(token);
 
-            String role = claims.get("role", String.class);
-            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                    claims.getSubject(), null, List.of(new SimpleGrantedAuthority(role)));
+            // claims 데이터로 SecurityUser 생성 — DB 조회 없음
+            SecurityUser securityUser = new SecurityUser(
+                    Long.parseLong(claims.getSubject()), // subject = memberId
+                    claims.get("email", String.class),
+                    claims.get("nickname", String.class),
+                    claims.get("role", String.class));
+
+            // SecurityUser를 principal로 담은 인증 객체 생성
+            UsernamePasswordAuthenticationToken auth =
+                    new UsernamePasswordAuthenticationToken(securityUser, null, securityUser.getAuthorities());
+            // 요청 IP 등 추가 정보 설정
             auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
+            // SecurityContext에 인증 정보 저장 — 이후 rq.getActor()로 조회 가능
             SecurityContextHolder.getContext().setAuthentication(auth);
         }
 
+        // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
 
-    // Authorization 헤더에서 Bearer 토큰 추출
+    // Authorization 헤더에서 "Bearer " 접두사를 제거하고 순수 토큰 문자열 반환
     private String resolveToken(HttpServletRequest request) {
         String bearer = request.getHeader("Authorization");
         if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {

--- a/src/main/java/com/back/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/back/global/jwt/JwtAuthenticationFilter.java
@@ -1,12 +1,12 @@
 package com.back.global.jwt;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.back.global.security.SecurityUser;
@@ -14,6 +14,7 @@ import com.back.global.security.SecurityUser;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -58,12 +59,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    // Authorization 헤더에서 "Bearer " 접두사를 제거하고 순수 토큰 문자열 반환
+    // 쿠키에서 "accessToken" 값을 추출해 반환 — 없으면 null
     private String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
-        }
-        return null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies)
+                .filter(c -> "accessToken".equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/back/global/jwt/JwtProvider.java
+++ b/src/main/java/com/back/global/jwt/JwtProvider.java
@@ -1,0 +1,63 @@
+package com.back.global.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+
+import com.nimbusds.jose.crypto.impl.HMAC;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration; // ms 단위
+
+    private SecretKey key;
+
+    //의존성 주입 완료 후, JWT 서명에 사용할 HMAC-SHA 키를 생성
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 토큰 생성
+    public String createToken(Long memberId, String email, String role) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .claim("email", email)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    // 토큰 파싱
+    public Claims parseToken(String token) {
+        return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            parseToken(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/back/global/jwt/JwtProvider.java
+++ b/src/main/java/com/back/global/jwt/JwtProvider.java
@@ -14,8 +14,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 
-import com.nimbusds.jose.crypto.impl.HMAC;
-
 @Component
 public class JwtProvider {
 
@@ -27,18 +25,19 @@ public class JwtProvider {
 
     private SecretKey key;
 
-    //의존성 주입 완료 후, JWT 서명에 사용할 HMAC-SHA 키를 생성
+    // 의존성 주입 완료 후, JWT 서명에 사용할 HMAC-SHA 키를 생성
     @PostConstruct
     public void init() {
         this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     // 토큰 생성
-    public String createToken(Long memberId, String email, String role) {
+    public String createToken(Long memberId, String email, String nickname, String role) {
         Date now = new Date();
         return Jwts.builder()
                 .subject(String.valueOf(memberId))
                 .claim("email", email)
+                .claim("nickname", nickname)
                 .claim("role", role)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expiration))

--- a/src/main/java/com/back/global/rq/Rq.java
+++ b/src/main/java/com/back/global/rq/Rq.java
@@ -1,0 +1,97 @@
+package com.back.global.rq;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.global.security.SecurityUser;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+// HTTP 요청/응답 컨텍스트를 다루는 유틸리티 빈
+// 현재 로그인 유저 조회, 헤더/쿠키 조작, 리다이렉트 등을 한 곳에서 처리
+@Component
+@RequiredArgsConstructor
+public class Rq {
+
+    private final HttpServletRequest req;
+    private final HttpServletResponse resp;
+
+    // SecurityContext에서 현재 로그인 유저를 꺼내 경량 Member 객체로 반환
+    // DB 조회 없이 JWT 토큰에 담긴 데이터만 사용 — 비용이 낮음
+    // 로그인하지 않은 상태라면 null 반환
+    public Member getActor() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .map(Authentication::getPrincipal)
+                // principal이 SecurityUser 타입인 경우에만 처리
+                .filter(principal -> principal instanceof SecurityUser)
+                .map(principal -> (SecurityUser) principal)
+                // SecurityUser의 id, email, nickname으로 경량 Member 생성
+                .map(securityUser ->
+                        Member.of(securityUser.getId(), securityUser.getUsername(), securityUser.getName()))
+                .orElse(null);
+    }
+
+    // 요청 헤더 값 조회 — 없거나 빈 값이면 defaultValue 반환
+    public String getHeader(String name, String defaultValue) {
+        return Optional.ofNullable(req.getHeader(name))
+                .filter(headerValue -> !headerValue.isBlank())
+                .orElse(defaultValue);
+    }
+
+    // 응답 헤더 설정 — 빈 값이면 속성 제거, 값이 있으면 헤더에 추가
+    public void setHeader(String name, String value) {
+        if (value == null) value = "";
+        if (value.isBlank()) {
+            // 빈 값이면 요청 속성에서 제거
+            req.removeAttribute(name);
+        } else {
+            resp.setHeader(name, value);
+        }
+    }
+
+    // 쿠키 값 조회 — 해당 이름의 쿠키가 없거나 빈 값이면 defaultValue 반환
+    public String getCookieValue(String name, String defaultValue) {
+        return Optional.ofNullable(req.getCookies())
+                .flatMap(cookies -> Arrays.stream(cookies)
+                        .filter(cookie -> cookie.getName().equals(name))
+                        .map(Cookie::getValue)
+                        .filter(value -> !value.isBlank())
+                        .findFirst())
+                .orElse(defaultValue);
+    }
+
+    // 쿠키 설정 — 보안 속성(HttpOnly, Secure, SameSite) 적용
+    // 빈 값이면 쿠키 삭제(MaxAge=0), 값이 있으면 1년 유지
+    public void setCookie(String name, String value) {
+        if (value == null) value = "";
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/"); // 모든 경로에서 접근 가능
+        cookie.setHttpOnly(true); // JS에서 접근 불가 (XSS 방지)
+        cookie.setDomain("localhost");
+        cookie.setSecure(true); // HTTPS에서만 전송
+        cookie.setAttribute("SameSite", "Strict"); // CSRF 방지
+        if (value.isBlank()) cookie.setMaxAge(0); // 쿠키 즉시 삭제
+        else cookie.setMaxAge(60 * 60 * 24 * 365); // 1년 유지
+        resp.addCookie(cookie);
+    }
+
+    // 쿠키 삭제 — setCookie에 빈 값을 전달해 MaxAge=0으로 만료시킴
+    public void deleteCookie(String name) {
+        setCookie(name, null);
+    }
+
+    // 지정한 URL로 리다이렉트 — @SneakyThrows로 IOException 처리
+    @SneakyThrows
+    public void sendRedirect(String url) {
+        resp.sendRedirect(url);
+    }
+}

--- a/src/main/java/com/back/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/back/global/security/CustomUserDetailsService.java
@@ -1,0 +1,37 @@
+package com.back.global.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+// Spring Security가 인증 시 유저 정보를 로드하는 서비스
+// 현재는 JWT 필터가 직접 인증을 처리하므로 실제로는 OAuth2 도입 시 자동 호출됨
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    // 이메일로 회원을 조회해 SecurityUser로 변환 후 반환
+    // OAuth2 / 폼 로그인 도입 시 Spring Security가 이 메서드를 자동 호출
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // 이메일로 회원 조회 — 없으면 Spring Security 표준 예외 발생
+        Member member = memberRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다: " + email));
+
+        // 조회한 Member 데이터를 SecurityUser로 변환해 반환
+        return new SecurityUser(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getRole().getKey());
+    }
+}

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -31,7 +31,11 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 회원가입, 로그인은 인증 없이 접근 허용
-                        .requestMatchers("/api/v1/members/join", "/api/v1/members/login")
+                        .requestMatchers(
+                                "/api/v1/members/join",
+                                "/api/v1/members/login",
+                                // 로그아웃은 인증 없이도 호출 가능해야 함
+                                "/api/v1/members/logout")
                         .permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest()

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.back.global.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -21,21 +22,37 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
+        http.csrf(AbstractHttpConfigurer::disable) // REST API이므로 CSRF 비활성화
+                // 세션을 사용하지 않는 Stateless 방식 설정
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        // 회원가입, 로그인은 인증 없이 접근 허용
                         .requestMatchers("/api/v1/members/join", "/api/v1/members/login")
                         .permitAll()
+                        // 그 외 모든 요청은 인증 필요
                         .anyRequest()
                         .authenticated())
+                // UsernamePasswordAuthenticationFilter 앞에 JWT 필터 삽입
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
+    // OAuth2 도입 시 Spring Security가 사용할 인증 프로바이더
+    // UserDetailsService와 PasswordEncoder를 연결해 인증 처리를 위임
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(customUserDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    // 비밀번호 암호화에 BCrypt 알고리즘 사용
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -9,19 +9,29 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-/**
- * 임시 security config입니다.
- */
+import com.back.global.jwt.JwtAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/members/join", "/api/v1/members/login")
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/back/global/security/SecurityUser.java
+++ b/src/main/java/com/back/global/security/SecurityUser.java
@@ -1,0 +1,76 @@
+package com.back.global.security;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import lombok.Getter;
+
+// Spring Security가 인증 객체(principal)로 사용하는 유저 정보 클래스
+// Member 엔티티를 직접 쓰지 않고 래퍼로 분리해 도메인 오염을 방지
+public class SecurityUser implements UserDetails {
+
+    // Rq.getActor()에서 Member.of() 호출 시 사용
+    @Getter
+    private final Long id; // 회원 PK
+
+    private final String username; // 이메일 (Spring Security 식별자로 사용)
+    // Rq.getActor()에서 Member.of() 호출 시 사용
+    @Getter
+    private final String name; // 닉네임
+
+    private final String role; // 권한 (ex. ROLE_USER)
+
+    // JWT claims 데이터로 생성 — DB 조회 없이 토큰에서 바로 만들 수 있음
+    public SecurityUser(Long id, String username, String name, String role) {
+        this.id = id;
+        this.username = username;
+        this.name = name;
+        this.role = role;
+    }
+
+    // UserDetails 구현 — Spring Security가 유저 식별자로 사용 (이메일 반환)
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    // JWT 방식에서는 비밀번호를 SecurityContext에 저장할 필요 없음
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    // role 값을 GrantedAuthority로 변환해 Spring Security에 권한 정보를 제공
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    // 계정 만료 여부 — 현재는 만료 정책 없으므로 항상 유효
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    // 계정 잠금 여부 — 현재는 잠금 정책 없으므로 항상 잠금 해제
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    // 자격증명(비밀번호) 만료 여부 — JWT 방식이므로 항상 유효
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    // 계정 활성화 여부 — 현재는 비활성화 정책 없으므로 항상 활성
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,10 @@ spring:
         default_batch_fetch_size: 100
   security:
     debug: true
+
+jwt:
+  secret: ${JWT_SECRET:back-application-jwt-secret-key-must-be-at-least-32-bytes}
+  expiration: 3600000 # 1시간 (ms)
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
 logging:

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -4,14 +4,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -20,6 +26,32 @@ class MemberControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private static final String LOGIN_TEST_EMAIL = "logintest@example.com";
+    private static final String LOGIN_TEST_PASSWORD = "Test1234!";
+
+    @BeforeEach
+    void setUp() {
+        // 로그인 테스트용 회원 사전 등록
+        memberRepository
+                .findByEmail(LOGIN_TEST_EMAIL)
+                .ifPresent(memberRepository::delete);
+        Member member = Member.createUser("로그인테스터", LOGIN_TEST_EMAIL, passwordEncoder.encode(LOGIN_TEST_PASSWORD));
+        memberRepository.save(member);
+    }
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.findByEmail(LOGIN_TEST_EMAIL).ifPresent(memberRepository::delete);
+    }
+
+    // ============ 회원가입 ============
 
     @Test
     @DisplayName("정상적인 회원가입 요청 시 200 응답을 반환한다")
@@ -41,5 +73,102 @@ class MemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200"))
                 .andExpect(jsonPath("$.msg").value("회원가입성공"));
+    }
+
+    // ============ 로그인 ============
+
+    @Test
+    @DisplayName("정상적인 로그인 요청 시 200 응답과 accessToken을 반환한다")
+    void login_success() throws Exception {
+        // given
+        String requestBody = """
+                {
+                    "email": "%s",
+                    "password": "%s"
+                }
+                """.formatted(LOGIN_TEST_EMAIL, LOGIN_TEST_PASSWORD);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("로그인 성공"))
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 로그인 시 401 응답을 반환한다")
+    void login_fail_email_not_found() throws Exception {
+        // given
+        String requestBody = """
+                {
+                    "email": "notexist@example.com",
+                    "password": "Test1234!"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("MEMBER_401"))
+                .andExpect(jsonPath("$.msg").value("이메일 또는 비밀번호가 올바르지 않습니다"));
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호로 로그인 시 401 응답을 반환한다")
+    void login_fail_wrong_password() throws Exception {
+        // given
+        String requestBody = """
+                {
+                    "email": "%s",
+                    "password": "Wrong1234!"
+                }
+                """.formatted(LOGIN_TEST_EMAIL);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("MEMBER_401"))
+                .andExpect(jsonPath("$.msg").value("이메일 또는 비밀번호가 올바르지 않습니다"));
+    }
+
+    @Test
+    @DisplayName("이메일 없이 로그인 요청 시 400 응답을 반환한다")
+    void login_fail_missing_email() throws Exception {
+        // given
+        String requestBody = """
+                {
+                    "password": "Test1234!"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("비밀번호 없이 로그인 요청 시 400 응답을 반환한다")
+    void login_fail_missing_password() throws Exception {
+        // given
+        String requestBody = """
+                {
+                    "email": "%s"
+                }
+                """.formatted(LOGIN_TEST_EMAIL);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -39,9 +39,7 @@ class MemberControllerTest {
     @BeforeEach
     void setUp() {
         // 로그인 테스트용 회원 사전 등록
-        memberRepository
-                .findByEmail(LOGIN_TEST_EMAIL)
-                .ifPresent(memberRepository::delete);
+        memberRepository.findByEmail(LOGIN_TEST_EMAIL).ifPresent(memberRepository::delete);
         Member member = Member.createUser("로그인테스터", LOGIN_TEST_EMAIL, passwordEncoder.encode(LOGIN_TEST_PASSWORD));
         memberRepository.save(member);
     }
@@ -49,6 +47,8 @@ class MemberControllerTest {
     @AfterEach
     void tearDown() {
         memberRepository.findByEmail(LOGIN_TEST_EMAIL).ifPresent(memberRepository::delete);
+        // join_success 테스트가 생성한 회원 정리 — 미삭제 시 재실행 때 중복 이메일로 실패
+        memberRepository.findByEmail("test@example.com").ifPresent(memberRepository::delete);
     }
 
     // ============ 회원가입 ============

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -1,6 +1,9 @@
 package com.back.domain.member.member.controller;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,9 +15,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
@@ -78,7 +83,7 @@ class MemberControllerTest {
     // ============ 로그인 ============
 
     @Test
-    @DisplayName("정상적인 로그인 요청 시 200 응답과 accessToken을 반환한다")
+    @DisplayName("정상적인 로그인 요청 시 200 응답과 accessToken 쿠키를 반환한다")
     void login_success() throws Exception {
         // given
         String requestBody = """
@@ -95,7 +100,39 @@ class MemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200"))
                 .andExpect(jsonPath("$.msg").value("로그인 성공"))
-                .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
+                // 응답 바디에 토큰이 없어야 함
+                .andExpect(jsonPath("$.data").doesNotExist())
+                // Set-Cookie 헤더에 accessToken 쿠키가 존재해야 함
+                .andExpect(header().string("Set-Cookie", containsString("accessToken=")));
+    }
+
+    @Test
+    @DisplayName("로그아웃 요청 시 200 응답과 accessToken 쿠키가 만료된다")
+    void logout_success() throws Exception {
+        // given — 먼저 로그인해서 쿠키 획득
+        String loginBody = """
+                {
+                    "email": "%s",
+                    "password": "%s"
+                }
+                """.formatted(LOGIN_TEST_EMAIL, LOGIN_TEST_PASSWORD);
+
+        MvcResult loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody))
+                .andReturn();
+
+        // 로그인 응답에서 accessToken 쿠키 추출
+        String cookieHeader = loginResult.getResponse().getHeader("Set-Cookie");
+        String token = cookieHeader.split("accessToken=")[1].split(";")[0];
+
+        // when & then — 쿠키를 담아 로그아웃 요청
+        mockMvc.perform(post("/api/v1/members/logout").cookie(new MockCookie("accessToken", token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("로그아웃 성공"))
+                // Set-Cookie 헤더에서 accessToken이 만료(Max-Age=0)되어야 함
+                .andExpect(cookie().maxAge("accessToken", 0));
     }
 
     @Test


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #42 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #42 

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
로그인, 로그아웃 기능 구현
jwt토큰을 발급하고 쿠키에 저장

---

## ✅ 주요 변경 사항
<JWT 기반 회원 인증 기능 구현>

- 회원가입 API (POST /api/v1/members/join) 구현
- 로그인 API (POST /api/v1/members/login) 구현 — BCrypt 비밀번호 검증 후 JWT 발급
- 로그아웃 API (POST /api/v1/members/logout) 구현
- JWT 토큰 저장 방식을 응답 바디 → HttpOnly 쿠키로 전환 (XSS 방어)
- JwtProvider 구현 — HMAC-SHA256 서명 기반 토큰 생성/검증/파싱
- JwtAuthenticationFilter 구현 — 매 요청마다 쿠키에서 토큰 추출 후 인증 처리
- SecurityUser / CustomUserDetailsService 구현 — OAuth2 도입 대비
- Rq 클래스 도입 — 현재 로그인 유저 조회, 쿠키/헤더 조작 유틸리티
- SecurityConfig 설정 — Stateless, JWT 필터 등록, 인증 경로 설정
회- 원가입/로그인/로그아웃 통합 테스트 작성 (Testcontainers + MockMvc)

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->


---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
