### PR TITLE
[feat] 내 정보 조회 API 추가

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package com.back.domain.member.member.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.member.member.dto.JoinRequest;
+import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.rsData.RsData;
 
@@ -22,6 +25,14 @@ public class MemberController {
     @PostMapping("/join")
     public RsData<Void> join(@Valid @RequestBody JoinRequest req) {
         RsData<Void> res = memberService.join(req);
+        return res;
+    }
+
+    // 내정보 조회
+    @GetMapping("/me")
+    public RsData<MyInfoResponse> getMyInfo(@RequestHeader("X-Member-Id") Long memberId) {
+        // TODO: 인증 인프라 도입 후 X-Member-Id 헤더 제거하고 SecurityContext 기반으로 전환
+        RsData<MyInfoResponse> res = memberService.getMyInfo(memberId);
         return res;
     }
 }

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -3,14 +3,15 @@ package com.back.domain.member.member.controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.member.member.dto.JoinRequest;
-import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.dto.LoginRequest;
+import com.back.domain.member.member.dto.MyInfoResponse;
+import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
+import com.back.global.exception.ServiceException;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 
@@ -47,9 +48,12 @@ public class MemberController {
 
     // 내정보 조회
     @GetMapping("/me")
-    public RsData<MyInfoResponse> getMyInfo(@RequestHeader("X-Member-Id") Long memberId) {
-        // TODO: 인증 인프라 도입 후 X-Member-Id 헤더 제거하고 SecurityContext 기반으로 전환
-        RsData<MyInfoResponse> res = memberService.getMyInfo(memberId);
-        return res;
+    public RsData<MyInfoResponse> getMyInfo() {
+        Member actor = rq.getActor();
+        if (actor == null || actor.getId() == null) {
+            throw new ServiceException("MEMBER_401", "로그인이 필요합니다");
+        }
+
+        return memberService.getMyInfo(actor.getId());
     }
 }

--- a/src/main/java/com/back/domain/member/member/dto/MyInfoResponse.java
+++ b/src/main/java/com/back/domain/member/member/dto/MyInfoResponse.java
@@ -1,0 +1,16 @@
+package com.back.domain.member.member.dto;
+
+import com.back.domain.member.member.entity.Member;
+
+public record MyInfoResponse(Long memberId, String nickname, String email, Long score, String tier, String role) {
+
+    public static MyInfoResponse from(Member member) {
+        return new MyInfoResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getEmail(),
+                member.getScore(),
+                member.getTier(),
+                member.getRole().name());
+    }
+}

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 import com.back.domain.member.member.dto.JoinRequest;
+import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.global.exception.ServiceException;
@@ -51,5 +52,17 @@ public class MemberService {
         memberRepository.save(member);
 
         return RsData.of("200", "회원가입성공");
+    }
+
+    public RsData<MyInfoResponse> getMyInfo(Long memberId) {
+        if (memberId == null || memberId <= 0) {
+            throw new ServiceException("MEMBER_400", "유효한 회원 ID가 필요합니다");
+        }
+
+        Member member = memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new ServiceException("MEMBER_404", "존재하지 않는 회원입니다"));
+
+        return RsData.of("200", "내 정보 조회 성공", MyInfoResponse.from(member));
     }
 }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 import com.back.domain.member.member.dto.JoinRequest;
-import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.dto.LoginRequest;
+import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.global.exception.ServiceException;
@@ -68,7 +68,7 @@ public class MemberService {
 
         return RsData.of("200", "내 정보 조회 성공", MyInfoResponse.from(member));
     }
-  
+
     // 로그인 — 인증 성공 시 accessToken 문자열 반환 (쿠키 설정은 컨트롤러가 담당)
     public String login(@Valid LoginRequest req) {
 

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -1,7 +1,7 @@
 package com.back.domain.member.member.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -21,9 +21,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.repository.MemberRepository;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
@@ -87,17 +84,32 @@ class MemberControllerTest {
     @Test
     @DisplayName("내정보 조회 요청 시 회원 정보를 반환한다")
     void getMyInfo_success() throws Exception {
-        // given
-        Member member = memberRepository.save(Member.createUser("내정보유저", "me-test@example.com", "encoded-password"));
+        // given - 로그인해서 accessToken 쿠키 확보
+        Member member = memberRepository.findByEmail(LOGIN_TEST_EMAIL).orElseThrow();
+
+        String loginBody = """
+                {
+                    "email": "%s",
+                    "password": "%s"
+                }
+                """.formatted(LOGIN_TEST_EMAIL, LOGIN_TEST_PASSWORD);
+
+        MvcResult loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody))
+                .andReturn();
+
+        String cookieHeader = loginResult.getResponse().getHeader("Set-Cookie");
+        String token = cookieHeader.split("accessToken=")[1].split(";")[0];
 
         // when & then
-        mockMvc.perform(get("/api/v1/members/me").header("X-Member-Id", member.getId()))
+        mockMvc.perform(get("/api/v1/members/me").cookie(new MockCookie("accessToken", token)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200"))
                 .andExpect(jsonPath("$.msg").value("내 정보 조회 성공"))
                 .andExpect(jsonPath("$.data.memberId").value(member.getId()))
-                .andExpect(jsonPath("$.data.nickname").value("내정보유저"))
-                .andExpect(jsonPath("$.data.email").value("me-test@example.com"))
+                .andExpect(jsonPath("$.data.nickname").value("로그인테스터"))
+                .andExpect(jsonPath("$.data.email").value(LOGIN_TEST_EMAIL))
                 .andExpect(jsonPath("$.data.score").value(0))
                 .andExpect(jsonPath("$.data.tier").isEmpty())
                 .andExpect(jsonPath("$.data.role").value("USER"));

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.back.domain.member.member.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,6 +14,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
@@ -20,6 +24,9 @@ class MemberControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Test
     @DisplayName("정상적인 회원가입 요청 시 200 응답을 반환한다")
@@ -41,5 +48,24 @@ class MemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200"))
                 .andExpect(jsonPath("$.msg").value("회원가입성공"));
+    }
+
+    @Test
+    @DisplayName("내정보 조회 요청 시 회원 정보를 반환한다")
+    void getMyInfo_success() throws Exception {
+        // given
+        Member member = memberRepository.save(Member.createUser("내정보유저", "me-test@example.com", "encoded-password"));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/members/me").header("X-Member-Id", member.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("내 정보 조회 성공"))
+                .andExpect(jsonPath("$.data.memberId").value(member.getId()))
+                .andExpect(jsonPath("$.data.nickname").value("내정보유저"))
+                .andExpect(jsonPath("$.data.email").value("me-test@example.com"))
+                .andExpect(jsonPath("$.data.score").value(0))
+                .andExpect(jsonPath("$.data.tier").isEmpty())
+                .andExpect(jsonPath("$.data.role").value("USER"));
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #56

---

## 📝 작업 내용
내 정보 조회 API(`GET /api/v1/members/me`)를 추가했습니다. 로그인 쿠키 기반 인증 흐름과 맞추기 위해 컨트롤러에서 `rq.getActor()`로 현재 사용자 ID를 가져와 조회하도록 구현했습니다.

```java
// MemberController
@GetMapping("/me")
public RsData<MyInfoResponse> getMyInfo() {
    Member actor = rq.getActor();
    if (actor == null || actor.getId() == null) {
        throw new ServiceException("MEMBER_401", "로그인이 필요합니다");
    }
    return memberService.getMyInfo(actor.getId());
}
```

```java
// MemberService
public RsData<MyInfoResponse> getMyInfo(Long memberId) {
    if (memberId == null || memberId <= 0) {
        throw new ServiceException("MEMBER_400", "유효한 회원 ID가 필요합니다");
    }

    Member member = memberRepository.findById(memberId)
            .orElseThrow(() -> new ServiceException("MEMBER_404", "존재하지 않는 회원입니다"));

    return RsData.of("200", "내 정보 조회 성공", MyInfoResponse.from(member));
}
```

```java
// DTO 매핑
public static MyInfoResponse from(Member member) {
    return new MyInfoResponse(
            member.getId(),
            member.getNickname(),
            member.getEmail(),
            member.getScore(),
            member.getTier(),
            member.getRole().name());
}
```

---

## ✅ 주요 변경 사항
1) `GET /api/v1/members/me` 엔드포인트 추가
2) `MyInfoResponse` DTO 추가 (`score`, `tier` 포함)
3) 회원 ID 유효성/존재 검증 추가 (`MEMBER_400`, `MEMBER_404`)
4) 인증 사용자가 없을 때 `MEMBER_401` 반환
5) 컨트롤러 테스트에 내정보 조회 시나리오 추가 (`score`, `tier` 검증 포함)

---

## 🧪 테스트 결과
```bash
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew spotlessCheck
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test --tests "com.back.domain.member.member.controller.MemberControllerTest"
```

- [x] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
- `/me`는 인증 필요 경로이므로 헤더 기반 식별 대신 `rq.getActor()`를 사용하도록 정합성 맞춤.
- `from()` 매핑 사용 이유
  - 엔티티→응답 변환 로직을 DTO로 모아 중복 제거
  - 응답 필드 변경 시 서비스/컨트롤러 수정 범위 최소화
  - 응답 스키마 의도(`노출 필드`)를 코드에서 명확히 분리

---

## 📎 참고 사항 (선택)
- 변경 파일
  - `src/main/java/com/back/domain/member/member/controller/MemberController.java`
  - `src/main/java/com/back/domain/member/member/service/MemberService.java`
  - `src/main/java/com/back/domain/member/member/dto/MyInfoResponse.java`
  - `src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java`
