### PR TITLE
[Feat] 내 전적 조회 api 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ scripts/__pycache__/
 **/__pycache__/
 *.pyc
 .claude
+.gradle-user-home/

--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -3,10 +3,15 @@ package com.back.domain.battle.battleparticipant.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.member.member.entity.Member;
 
 public interface BattleParticipantRepository extends JpaRepository<BattleParticipant, Long> {
@@ -17,4 +22,32 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
 
     // 방별 참여자 수 조회 (N+1 방지용 - 전체 로드 없이 COUNT만 조회)
     long countByBattleRoom(BattleRoom battleRoom);
+
+    /**
+     * 특정 회원의 종료된 배틀 전적을 페이지 단위로 조회한다.
+     *
+     * join fetch 를 사용한 이유:
+     * - battleRoom, problem 제목을 응답에 바로 써야 하므로
+     * - 서비스/DTO 변환 시 N+1 문제를 줄이기 위해 같이 읽는다.
+     *
+     * 정렬 기준:
+     * - 최신 배틀이 먼저 오도록 battleRoom.createdAt 내림차순
+     */
+    @Query(value = """
+                    select bp
+                    from BattleParticipant bp
+                    join fetch bp.battleRoom br
+                    join fetch br.problem p
+                    where bp.member.id = :memberId
+                      and br.status = :status
+                    order by br.createdAt desc
+                    """, countQuery = """
+                    select count(bp)
+                    from BattleParticipant bp
+                    join bp.battleRoom br
+                    where bp.member.id = :memberId
+                      and br.status = :status
+                    """)
+    Page<BattleParticipant> findFinishedBattleResultsByMemberId(
+            @Param("memberId") Long memberId, @Param("status") BattleRoomStatus status, Pageable pageable);
 }

--- a/src/main/java/com/back/domain/battle/result/dto/MyBattleResultsResponse.java
+++ b/src/main/java/com/back/domain/battle/result/dto/MyBattleResultsResponse.java
@@ -1,0 +1,73 @@
+package com.back.domain.battle.result.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+
+/**
+ * 내 전적 조회 응답 DTO
+ *
+ * battleResults: 전적 목록
+ * pageInfo: 페이징 정보
+ */
+public record MyBattleResultsResponse(List<MyBattleResultItem> battleResults, PageInfo pageInfo) {
+
+    /**
+     * 전적 목록의 한 줄(row)에 해당하는 데이터
+     */
+    public record MyBattleResultItem(
+            Long roomId,
+            Long problemId,
+            String problemTitle,
+            Integer finalRank,
+            Long scoreDelta,
+            boolean solved,
+            LocalDateTime finishTime,
+            LocalDateTime playedAt) {
+
+        /**
+         * BattleParticipant 엔티티를 전적 응답 아이템으로 변환
+         *
+         * solved:
+         * - 배틀에서 정답 처리 후 complete() 되면 EXIT 상태가 되므로
+         * - EXIT 이면 solved = true 로 본다.
+         */
+        public static MyBattleResultItem from(BattleParticipant participant) {
+            return new MyBattleResultItem(
+                    participant.getBattleRoom().getId(),
+                    participant.getBattleRoom().getProblem().getId(),
+                    participant.getBattleRoom().getProblem().getTitle(),
+                    participant.getFinalRank(),
+                    participant.getScoreDelta(),
+                    participant.getStatus() == BattleParticipantStatus.EXIT,
+                    participant.getFinishTime(),
+                    // 배틀이 생성된 시각을 "플레이한 시각" 기준값으로 사용
+                    participant.getBattleRoom().getCreatedAt());
+        }
+    }
+
+    /**
+     * 페이지 정보 DTO
+     */
+    public record PageInfo(int page, int size, long totalElements, int totalPages, boolean hasNext) {
+        public static PageInfo from(Page<?> page) {
+            return new PageInfo(
+                    page.getNumber(), page.getSize(), page.getTotalElements(), page.getTotalPages(), page.hasNext());
+        }
+    }
+
+    /**
+     * Page<BattleParticipant> -> MyBattleResultsResponse 변환
+     */
+    public static MyBattleResultsResponse from(Page<BattleParticipant> participantPage) {
+        List<MyBattleResultItem> items = participantPage.getContent().stream()
+                .map(MyBattleResultItem::from)
+                .toList();
+
+        return new MyBattleResultsResponse(items, PageInfo.from(participantPage));
+    }
+}

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,11 +22,13 @@ import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
 import com.back.domain.battle.result.dto.BattleResultResponse;
 import com.back.domain.battle.result.dto.BattleResultResponse.ParticipantResult;
+import com.back.domain.battle.result.dto.MyBattleResultsResponse;
 import com.back.domain.battle.result.dto.RoomListResponse;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.submission.entity.Submission;
 import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
+import com.back.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -179,5 +183,34 @@ public class BattleResultService {
                 room, participant.getMember(), SubmissionResult.WA, participant.getFinishTime());
 
         return elapsedSeconds + (waPenaltyCount * WA_PENALTY_SECONDS);
+    }
+
+    /**
+     * 현재 로그인 사용자의 전적 목록 조회용 서비스 메서드
+     *
+     * memberId:
+     * - 컨트롤러에서 rq.getActor() 로 꺼낸 현재 사용자 id
+     *
+     * page, size:
+     * - 0-based 페이지 기준
+     */
+    @Transactional(readOnly = true)
+    public MyBattleResultsResponse getMyBattleResults(Long memberId, int page, int size) {
+        // 로그인 사용자 없이 호출되면 예외
+        if (memberId == null) {
+            throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
+        }
+
+        // 잘못된 페이지 파라미터 방어
+        if (page < 0 || size < 1) {
+            throw new ServiceException("MEMBER_400", "page는 0 이상이고 size는 1 이상이어야 합니다.");
+        }
+
+        // 종료된(FINISHED) 배틀만 전적으로 조회
+        Page<BattleParticipant> participantPage = battleParticipantRepository.findFinishedBattleResultsByMemberId(
+                memberId, BattleRoomStatus.FINISHED, PageRequest.of(page, size));
+
+        // 엔티티 페이지를 응답 DTO로 변환
+        return MyBattleResultsResponse.from(participantPage);
     }
 }

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -1,13 +1,14 @@
 package com.back.domain.member.member.controller;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import com.back.domain.battle.result.dto.MyBattleResultsResponse;
+import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.dto.JoinRequest;
 import com.back.domain.member.member.dto.LoginRequest;
+import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
+import com.back.global.exception.ServiceException;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("api/v1/members")
 public class MemberController {
     private final MemberService memberService;
+    private final BattleResultService battleResultService;
     private final Rq rq;
 
     // 회원가입
@@ -40,5 +42,33 @@ public class MemberController {
     public RsData<Void> logout() {
         rq.deleteCookie("accessToken");
         return RsData.of("200", "로그아웃 성공");
+    }
+
+    /**
+     * 내 전적 조회 API
+     *
+     * /api/v1/members/me/battle-results?page=0&size=20
+     *
+     * - memberId를 직접 받지 않고
+     * - rq.getActor() 로 현재 로그인 사용자를 가져온다.
+     * - 응답은 MemberController 스타일에 맞게 RsData 로 감싼다.
+     */
+    @GetMapping("/me/battle-results")
+    public RsData<MyBattleResultsResponse> getMyBattleResults(
+            @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "20") int size) {
+
+        // 현재 로그인 사용자 조회
+        Member actor = rq.getActor();
+
+        // 인증 정보가 없으면 로그인 필요 예외
+        if (actor == null) {
+            throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
+        }
+
+        // 배틀 도메인 서비스에서 실제 전적 조회 수행
+        MyBattleResultsResponse response = battleResultService.getMyBattleResults(actor.getId(), page, size);
+
+        // MemberController 쪽 응답 규약에 맞춰 RsData 로 감싸서 반환
+        return RsData.of("200", "내 전적 조회 성공", response);
     }
 }

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -72,7 +72,7 @@ public class MemberController {
         // MemberController 쪽 응답 규약에 맞춰 RsData 로 감싸서 반환
         return RsData.of("200", "내 전적 조회 성공", response);
     }
-  
+
     // 내정보 조회
     @GetMapping("/me")
     public RsData<MyInfoResponse> getMyInfo() {

--- a/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
@@ -1,0 +1,124 @@
+package com.back.domain.battle.result.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.dto.MyBattleResultsResponse;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.submission.repository.SubmissionRepository;
+import com.back.global.exception.ServiceException;
+
+class BattleResultServiceTest {
+
+    private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final SubmissionRepository submissionRepository = mock(SubmissionRepository.class);
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+
+    private final BattleResultService battleResultService = new BattleResultService(
+            battleRoomRepository,
+            battleParticipantRepository,
+            submissionRepository,
+            memberRepository,
+            messagingTemplate);
+
+    @Test
+    @DisplayName("내 전적 조회 성공 시 battleResults와 pageInfo를 반환한다")
+    void getMyBattleResults_success() {
+        // given
+        Long memberId = 1L;
+        int page = 0;
+        int size = 20;
+
+        BattleParticipant participant = mock(BattleParticipant.class);
+        BattleRoom room = mock(BattleRoom.class);
+        Problem problem = mock(Problem.class);
+
+        LocalDateTime finishTime = LocalDateTime.of(2026, 3, 24, 20, 15, 20);
+        LocalDateTime playedAt = LocalDateTime.of(2026, 3, 24, 20, 0, 0);
+
+        when(participant.getBattleRoom()).thenReturn(room);
+        when(participant.getFinalRank()).thenReturn(2);
+        when(participant.getScoreDelta()).thenReturn(70L);
+        when(participant.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(participant.getFinishTime()).thenReturn(finishTime);
+
+        when(room.getId()).thenReturn(101L);
+        when(room.getProblem()).thenReturn(problem);
+        when(room.getCreatedAt()).thenReturn(playedAt);
+
+        when(problem.getId()).thenReturn(5L);
+        when(problem.getTitle()).thenReturn("Two Sum");
+
+        Page<BattleParticipant> participantPage = new PageImpl<>(List.of(participant), PageRequest.of(0, 20), 1);
+
+        when(battleParticipantRepository.findFinishedBattleResultsByMemberId(
+                        eq(memberId), eq(BattleRoomStatus.FINISHED), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(participantPage);
+
+        // when
+        MyBattleResultsResponse response = battleResultService.getMyBattleResults(memberId, page, size);
+
+        // then
+        assertThat(response.battleResults()).hasSize(1);
+        assertThat(response.pageInfo().page()).isEqualTo(0);
+        assertThat(response.pageInfo().size()).isEqualTo(20);
+        assertThat(response.pageInfo().totalElements()).isEqualTo(1);
+
+        MyBattleResultsResponse.MyBattleResultItem item =
+                response.battleResults().get(0);
+        assertThat(item.roomId()).isEqualTo(101L);
+        assertThat(item.problemId()).isEqualTo(5L);
+        assertThat(item.problemTitle()).isEqualTo("Two Sum");
+        assertThat(item.finalRank()).isEqualTo(2);
+        assertThat(item.scoreDelta()).isEqualTo(70L);
+        assertThat(item.solved()).isTrue();
+        assertThat(item.finishTime()).isEqualTo(finishTime);
+        assertThat(item.playedAt()).isEqualTo(playedAt);
+    }
+
+    @Test
+    @DisplayName("memberId가 없으면 로그인 필요 예외를 던진다")
+    void getMyBattleResults_fail_whenMemberIdIsNull() {
+        assertThatThrownBy(() -> battleResultService.getMyBattleResults(null, 0, 20))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("로그인이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("page가 0 미만이면 예외를 던진다")
+    void getMyBattleResults_fail_whenPageIsNegative() {
+        assertThatThrownBy(() -> battleResultService.getMyBattleResults(1L, -1, 20))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("page는 0 이상");
+    }
+
+    @Test
+    @DisplayName("size가 1 미만이면 예외를 던진다")
+    void getMyBattleResults_fail_whenSizeIsInvalid() {
+        assertThatThrownBy(() -> battleResultService.getMyBattleResults(1L, 0, 0))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("size는 1 이상");
+    }
+}

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerBattleResultsTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerBattleResultsTest.java
@@ -1,0 +1,96 @@
+package com.back.domain.member.member.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.back.domain.battle.result.dto.MyBattleResultsResponse;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.global.globalExceptionHandler.GlobalExceptionHandler;
+import com.back.global.rq.Rq;
+
+class MemberControllerBattleResultsTest {
+
+    private final MemberService memberService = mock(MemberService.class);
+    private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final Rq rq = mock(Rq.class);
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        MemberController controller = new MemberController(memberService, battleResultService, rq);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("로그인 사용자는 RsData 래핑된 내 전적 조회 응답을 받는다")
+    void getMyBattleResults_success() throws Exception {
+        // given
+        Member actor = Member.of(1L, "test@example.com", "tester");
+
+        MyBattleResultsResponse.MyBattleResultItem item = new MyBattleResultsResponse.MyBattleResultItem(
+                101L,
+                5L,
+                "Two Sum",
+                2,
+                70L,
+                true,
+                LocalDateTime.of(2026, 3, 24, 20, 15, 20),
+                LocalDateTime.of(2026, 3, 24, 20, 0, 0));
+
+        MyBattleResultsResponse response =
+                new MyBattleResultsResponse(List.of(item), new MyBattleResultsResponse.PageInfo(0, 20, 1, 1, false));
+
+        when(rq.getActor()).thenReturn(actor);
+        when(battleResultService.getMyBattleResults(1L, 0, 20)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/members/me/battle-results")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("내 전적 조회 성공"))
+                .andExpect(jsonPath("$.data.battleResults[0].roomId").value(101))
+                .andExpect(jsonPath("$.data.battleResults[0].problemId").value(5))
+                .andExpect(jsonPath("$.data.battleResults[0].problemTitle").value("Two Sum"))
+                .andExpect(jsonPath("$.data.battleResults[0].finalRank").value(2))
+                .andExpect(jsonPath("$.data.battleResults[0].scoreDelta").value(70))
+                .andExpect(jsonPath("$.data.battleResults[0].solved").value(true))
+                .andExpect(jsonPath("$.data.pageInfo.page").value(0))
+                .andExpect(jsonPath("$.data.pageInfo.size").value(20))
+                .andExpect(jsonPath("$.data.pageInfo.totalElements").value(1))
+                .andExpect(jsonPath("$.data.pageInfo.totalPages").value(1))
+                .andExpect(jsonPath("$.data.pageInfo.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자는 401 응답을 받는다")
+    void getMyBattleResults_fail_whenNotLoggedIn() throws Exception {
+        // given
+        when(rq.getActor()).thenReturn(null);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/members/me/battle-results"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("MEMBER_401"))
+                .andExpect(jsonPath("$.msg").value("로그인이 필요합니다."));
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #59 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #59 

---

<html>
<body>
<hr>

<h1>내 전적 조회 API</h1>

<p>이번 PR은 로그인한 사용자가 자신의 종료된 배틀 전적만 조회할 수 있도록 <code>GET /api/v1/members/me/battle-results</code> API를 추가한 작업입니다.</p>
<p>전적 전용 테이블을 새로 만들지 않고, 기존 <code>battle_participants</code>를 전적의 기준 테이블로 사용해 <code>battle_rooms</code>, <code>problems</code>를 조인해 응답을 구성했습니다.</p>
<p>또한 멤버 도메인 응답 규약에 맞춰 <code>RsData</code>로 래핑하고, <code>Rq.getActor()</code>를 사용해 현재 로그인 사용자를 식별하도록 구현했습니다.</p>

<hr>

<h3>관련 커밋</h3>
<ul>
<li><code>170d1cc</code> <code>feat: 내 전적 조회 API 추가</code></li>
<li><code>526ebb5</code> <code>test: 내 전적 조회 API 테스트 추가</code></li>
</ul>

<hr>

<h3>1. MemberController에 내 전적 조회 API 추가</h3>
<p>기존 <code>MemberController</code>는 회원가입/로그인/로그아웃만 담당하고 있었는데, 이번 PR에서 <code>/me/battle-results</code> 엔드포인트를 추가했습니다.</p>
<p>이 API는 사용자가 직접 <code>memberId</code>를 넘기지 않고, <code>rq.getActor()</code>로 현재 로그인 사용자를 가져와 전적 조회를 수행합니다.</p>

<pre><code class="language-java">@GetMapping("/me/battle-results")
public RsData&lt;MyBattleResultsResponse&gt; getMyBattleResults(
        @RequestParam(defaultValue = "0") int page,
        @RequestParam(defaultValue = "20") int size) {

    Member actor = rq.getActor();

    if (actor == null) {
        throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
    }

    MyBattleResultsResponse response = battleResultService.getMyBattleResults(actor.getId(), page, size);
    return RsData.of("200", "내 전적 조회 성공", response);
}
</code></pre>

<p>즉, 최종 API 형태는 아래와 같습니다.</p>
<pre><code>GET /api/v1/members/me/battle-results?page=0&amp;size=20</code></pre>

<hr>

<h3>2. BattleResultService에 내 전적 조회 로직 추가</h3>
<p>조회 로직은 배틀 결과 도메인에 두었습니다. 전적의 원본 데이터가 <code>battle_participants</code>, <code>battle_rooms</code>, <code>submissions</code> 등 배틀 도메인에 이미 모여 있기 때문입니다.</p>

<p>서비스 메서드는 다음 역할을 합니다.</p>
<ul>
<li>로그인 사용자 여부 검증</li>
<li>페이지 파라미터 검증</li>
<li>종료된 배틀(FINISHED)만 조회</li>
<li>조회 결과를 DTO로 변환</li>
</ul>

<pre><code class="language-java">@Transactional(readOnly = true)
public MyBattleResultsResponse getMyBattleResults(Long memberId, int page, int size) {
    if (memberId == null) {
        throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
    }

    if (page < 0 || size < 1) {
        throw new ServiceException("MEMBER_400", "page는 0 이상이고 size는 1 이상이어야 합니다.");
    }

    Page&lt;BattleParticipant&gt; participantPage = battleParticipantRepository.findFinishedBattleResultsByMemberId(
            memberId, BattleRoomStatus.FINISHED, PageRequest.of(page, size));

    return MyBattleResultsResponse.from(participantPage);
}
</code></pre>

<hr>

<h3>3. 전적 조회용 DTO 추가</h3>
<p>응답 전용 DTO <code>MyBattleResultsResponse</code>를 새로 추가했습니다.</p>
<p>이 DTO는 전적 목록과 페이지 정보를 함께 반환합니다.</p>

<pre><code class="language-java">public record MyBattleResultsResponse(
        List&lt;MyBattleResultItem&gt; battleResults,
        PageInfo pageInfo) {
</code></pre>

<p>전적 한 건은 아래 정보를 포함합니다.</p>
<ul>
<li><code>roomId</code></li>
<li><code>problemId</code></li>
<li><code>problemTitle</code></li>
<li><code>finalRank</code></li>
<li><code>scoreDelta</code></li>
<li><code>solved</code></li>
<li><code>finishTime</code></li>
<li><code>playedAt</code></li>
</ul>

<pre><code class="language-java">public record MyBattleResultItem(
        Long roomId,
        Long problemId,
        String problemTitle,
        Integer finalRank,
        Long scoreDelta,
        boolean solved,
        LocalDateTime finishTime,
        LocalDateTime playedAt) {
</code></pre>

<p><code>solved</code>는 <code>BattleParticipantStatus.EXIT</code> 여부로 판단합니다.</p>

<pre><code class="language-java">participant.getStatus() == BattleParticipantStatus.EXIT
</code></pre>

<p>페이지 정보는 <code>PageInfo</code>로 분리해 반환합니다.</p>

<pre><code class="language-java">public record PageInfo(
        int page,
        int size,
        long totalElements,
        int totalPages,
        boolean hasNext) {
</code></pre>

<hr>

<h3>4. BattleParticipantRepository에 전적 조회용 페이지 쿼리 추가</h3>
<p>내 전적 조회는 <code>battle_participants</code>를 기준으로 가져오되, 응답 구성에 필요한 <code>battleRoom</code>과 <code>problem</code>도 함께 읽어야 합니다.</p>
<p>그래서 리포지토리에 페이징 조회 메서드를 추가했고, <code>join fetch</code>를 사용해 방과 문제를 같이 가져오도록 했습니다.</p>

<pre><code class="language-java">@Query(
        value = """
                select bp
                from BattleParticipant bp
                join fetch bp.battleRoom br
                join fetch br.problem p
                where bp.member.id = :memberId
                  and br.status = :status
                order by br.createdAt desc
                """,
        countQuery = """
                select count(bp)
                from BattleParticipant bp
                join bp.battleRoom br
                where bp.member.id = :memberId
                  and br.status = :status
                """)
Page&lt;BattleParticipant&gt; findFinishedBattleResultsByMemberId(
        @Param("memberId") Long memberId,
        @Param("status") BattleRoomStatus status,
        Pageable pageable);
</code></pre>

<p>조회 조건은 아래와 같습니다.</p>
<ol>
<li>현재 로그인한 사용자(<code>bp.member.id = :memberId</code>)</li>
<li>종료된 방만(<code>br.status = FINISHED</code>)</li>
<li>최신 배틀이 먼저 오도록 <code>br.createdAt desc</code> 정렬</li>
</ol>

<p>즉, 이번 전적 조회는 “내가 참여했던 종료된 배틀 목록”만 반환하고, 다른 회원 전적은 포함하지 않습니다.</p>

<hr>

<h3>5. 응답 래핑 방식은 MemberController 규약에 맞춰 RsData로 통일</h3>
<p>이전에는 조회 API를 DTO 바로 반환으로 둘 수도 있었지만, 현재 <code>MemberController</code>가 <code>join/login/logout</code>에서 모두 <code>RsData</code>를 사용하고 있어 멤버 도메인 규약에 맞춰 통일했습니다.</p>

<p>최종 응답 형태는 아래와 같습니다.</p>

<pre><code class="language-json">{
  "resultCode": "200",
  "msg": "내 전적 조회 성공",
  "data": {
    "battleResults": [
      {
        "roomId": 101,
        "problemId": 5,
        "problemTitle": "Two Sum",
        "finalRank": 2,
        "scoreDelta": 70,
        "solved": true,
        "finishTime": "2026-03-24T20:15:20",
        "playedAt": "2026-03-24T20:00:00"
      }
    ],
    "pageInfo": {
      "page": 0,
      "size": 20,
      "totalElements": 1,
      "totalPages": 1,
      "hasNext": false
    }
  }
}
</code></pre>

<hr>

<h3>6. 테스트 추가</h3>
<p>이번 PR에서는 기능 추가와 함께 테스트 2종을 추가했습니다.</p>

<ul>
<li><code>BattleResultServiceTest</code> - 서비스 단위 테스트</li>
<li><code>MemberControllerBattleResultsTest</code> - 컨트롤러 응답/예외 테스트</li>
</ul>

<h4>6-1. BattleResultServiceTest</h4>
<p>서비스 테스트에서는 전적 조회 성공 시 DTO 매핑과 페이지 정보가 올바른지 검증하고, 예외 시나리오도 함께 확인합니다.</p>

<pre><code class="language-java">@Test
@DisplayName("내 전적 조회 성공 시 battleResults와 pageInfo를 반환한다")
void getMyBattleResults_success() {
    Long memberId = 1L;
    int page = 0;
    int size = 20;

    Page&lt;BattleParticipant&gt; participantPage =
            new PageImpl&lt;&gt;(List.of(participant), PageRequest.of(0, 20), 1);

    when(battleParticipantRepository.findFinishedBattleResultsByMemberId(
                    eq(memberId), eq(BattleRoomStatus.FINISHED), any()))
            .thenReturn(participantPage);

    MyBattleResultsResponse response = battleResultService.getMyBattleResults(memberId, page, size);

    assertThat(response.battleResults()).hasSize(1);
    assertThat(response.pageInfo().page()).isEqualTo(0);
    assertThat(response.pageInfo().size()).isEqualTo(20);
    assertThat(response.pageInfo().totalElements()).isEqualTo(1);
}
</code></pre>

<p>추가로 아래 예외 케이스도 테스트했습니다.</p>
<ul>
<li><code>memberId == null</code> → 로그인 필요 예외</li>
<li><code>page &lt; 0</code> → 잘못된 page 예외</li>
<li><code>size &lt; 1</code> → 잘못된 size 예외</li>
</ul>

<h4>6-2. MemberControllerBattleResultsTest</h4>
<p>컨트롤러 테스트에서는 <code>Rq.getActor()</code> 결과에 따라 정상 응답과 인증 실패 응답이 모두 올바르게 나오는지 확인합니다.</p>

<pre><code class="language-java">@Test
@DisplayName("로그인 사용자는 RsData 래핑된 내 전적 조회 응답을 받는다")
void getMyBattleResults_success() throws Exception {
    when(rq.getActor()).thenReturn(actor);
    when(battleResultService.getMyBattleResults(1L, 0, 20)).thenReturn(response);

    mockMvc.perform(get("/api/v1/members/me/battle-results")
                    .param("page", "0")
                    .param("size", "20"))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.resultCode").value("200"))
            .andExpect(jsonPath("$.msg").value("내 전적 조회 성공"));
}
</code></pre>

<pre><code class="language-java">@Test
@DisplayName("비로그인 사용자는 401 응답을 받는다")
void getMyBattleResults_fail_whenNotLoggedIn() throws Exception {
    when(rq.getActor()).thenReturn(null);

    mockMvc.perform(get("/api/v1/members/me/battle-results"))
            .andExpect(status().isUnauthorized())
            .andExpect(jsonPath("$.resultCode").value("MEMBER_401"))
            .andExpect(jsonPath("$.msg").value("로그인이 필요합니다."));
}
</code></pre>

<hr>

<h3>정리</h3>
<ul>
<li><code>/api/v1/members/me/battle-results</code> API 추가</li>
<li><code>Rq.getActor()</code> 기반으로 현재 로그인 사용자 식별</li>
<li><code>RsData</code> 래핑으로 멤버 도메인 응답 규약 통일</li>
<li>전적 전용 테이블 없이 <code>battle_participants</code> 기반 조회</li>
<li><code>battle_rooms</code>, <code>problems</code> 조인으로 요약형 전적 목록 반환</li>
<li>서비스/컨트롤러 테스트 추가</li>
</ul>

<p>즉 이번 PR은 <strong>로그인한 사용자가 자신의 종료된 배틀 전적을 페이지 단위로 조회할 수 있도록 API, 조회 쿼리, 응답 DTO, 테스트를 한 번에 추가한 작업</strong>입니다.</p>
</body>
</html>
