### PR TITLE
[feat] 인메모리 매칭 상태 조회 API 추가

### DIFF
--- a/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
+++ b/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
@@ -15,6 +15,7 @@ import com.back.domain.battle.battleroom.dto.JoinRoomRequest;
 import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
 import com.back.domain.battle.battleroom.dto.RoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
+import com.back.domain.matching.queue.service.MatchingQueueService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class BattleRoomController {
 
     private final BattleRoomService battleRoomService;
+    private final MatchingQueueService matchingQueueService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -33,7 +35,11 @@ public class BattleRoomController {
 
     @PostMapping("/{roomId}/join")
     public JoinRoomResponse joinRoom(@PathVariable Long roomId, @RequestBody JoinRoomRequest request) {
-        return battleRoomService.joinRoom(roomId, request.memberId());
+        JoinRoomResponse response = battleRoomService.joinRoom(roomId, request.memberId());
+
+        // 이 유저는 이제 실제로 방 입장까지 끝났으므로 매칭 결과 정리
+        matchingQueueService.clearMatchedRoom(request.memberId(), roomId);
+        return response;
     }
 
     @GetMapping("/{roomId}")

--- a/src/main/java/com/back/domain/matching/queue/controller/MatchingStatusController.java
+++ b/src/main/java/com/back/domain/matching/queue/controller/MatchingStatusController.java
@@ -1,0 +1,35 @@
+package com.back.domain.matching.queue.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.matching.queue.dto.MatchStateResponse;
+import com.back.domain.matching.queue.service.MatchingQueueService;
+import com.back.domain.member.member.entity.Member;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+
+import lombok.RequiredArgsConstructor;
+
+// 매칭 상태 전용 조회 컨트롤러
+@RestController
+@RequestMapping("/api/v1/matches")
+@RequiredArgsConstructor
+public class MatchingStatusController {
+
+    private final MatchingQueueService matchingQueueService;
+    private final Rq rq;
+
+    // 현재 사용자의 매칭 상태 조회
+    @GetMapping("/me")
+    public MatchStateResponse getMyMatchState() {
+        Member actor = rq.getActor();
+
+        if (actor == null) {
+            throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
+        }
+
+        return matchingQueueService.getMyMatchState(actor.getId());
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/dto/MatchStateResponse.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/MatchStateResponse.java
@@ -1,0 +1,7 @@
+package com.back.domain.matching.queue.dto;
+
+// 매칭 상태 조회 응답 DTO
+public record MatchStateResponse(
+        String status, // SEARCHING, MATCHED, IDLE
+        Long roomId // 매칭 완료 전이면 null
+        ) {}

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -13,6 +13,7 @@ import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.adapter.QueueProblemPicker;
+import com.back.domain.matching.queue.dto.MatchStateResponse;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStateResponse;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
@@ -58,6 +59,10 @@ public class MatchingQueueService {
     private final BattleRoomService battleRoomService;
 
     private final QueueProblemPicker queueProblemPicker;
+
+    // 매칭 완료 후 유저가 어느 방으로 가야 하는지 저장
+    // 예: 1L -> 10L (user1 은 room10 으로 이동해야 함)
+    private final Map<Long, Long> matchedRoomMap = new ConcurrentHashMap<>();
 
     public QueueStatusResponse joinQueue(Long userId, QueueJoinRequest request) {
         // 이미 대기열에 들어가 있는 유저는 다시 참가할 수 없다.
@@ -207,7 +212,13 @@ public class MatchingQueueService {
 
             // 7) 방 생성 성공 시에만 "유저-큐 맵"에서 매칭된 유저 제거
             //    (실패했는데 먼저 제거하면 상태 꼬임 발생)
-            matchedUsers.forEach(user -> userQueueMap.remove(user.getUserId()));
+            // 매칭 성공 시 4명 모두 큐에서는 제거하고, roomId를 저장
+            Long roomId = response.roomId();
+
+            matchedUsers.forEach(user -> {
+                userQueueMap.remove(user.getUserId());
+                matchedRoomMap.put(user.getUserId(), roomId);
+            });
 
             // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
             synchronized (queue) { //  성공 후 같은 queue 락 안에서 직접 확인 후 제거
@@ -254,6 +265,30 @@ public class MatchingQueueService {
 
         return new QueueStateResponse(
                 true, queueKey.category(), queueKey.difficulty().name(), queue.size());
+    }
+
+    // 현재 사용자의 매칭 상태 조회
+    public MatchStateResponse getMyMatchState(Long userId) {
+        Long roomId = matchedRoomMap.get(userId);
+
+        // 이미 방이 배정된 상태
+        if (roomId != null) {
+            return new MatchStateResponse("MATCHED", roomId);
+        }
+
+        // 아직 큐에서 기다리는 중
+        if (userQueueMap.containsKey(userId)) {
+            return new MatchStateResponse("SEARCHING", null);
+        }
+
+        // 큐에도 없고, 배정된 방도 없는 상태
+        return new MatchStateResponse("IDLE", null);
+    }
+
+    // 방 입장 성공 후 해당 유저의 매칭 결과 정리
+    public void clearMatchedRoom(Long userId, Long roomId) {
+        // userId 에 저장된 roomId 가 지금 입장한 roomId 일 때만 제거
+        matchedRoomMap.remove(userId, roomId);
     }
 
     // 찬의님 연동 지점 (여기만 나중에 연결하면 됨)


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #63 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #63 

---

<html>
<body>
<h1>인메모리 매칭 결과 저장 및 내 매칭 상태 조회 API 추가</h1>

<h3>개요</h3>
<p>이번 PR은 <strong>4인 매칭이 성사된 뒤, 사용자가 현재 어떤 매칭 상태인지 조회할 수 있는 API</strong>를 추가하고, <strong>매칭 완료 후 방 입장 전까지 userId -&gt; roomId 매핑을 인메모리로 잠시 저장</strong>하는 흐름을 구현했습니다.</p>
<p>기존에는 매칭이 성사되어 방이 생성돼도, 사용자가 지금 단순 대기 중인지, 이미 방이 배정됐는지, 아니면 아무 매칭도 없는 상태인지 구분해서 조회할 수 있는 전용 API가 없었습니다. 이번 PR에서는 <code>SEARCHING</code>, <code>MATCHED</code>, <code>IDLE</code> 3가지 상태로 현재 매칭 상태를 내려주고, 방 입장까지 완료되면 해당 매칭 결과를 정리하도록 연결했습니다.</p>

<p>새 파일 2개 / 수정 파일 2개</p>
<ul>
<li><code>MatchingStatusController.java</code> - 내 매칭 상태 조회 API</li>
<li><code>MatchStateResponse.java</code> - 매칭 상태 응답 DTO</li>
<li><code>MatchingQueueService.java</code> - 매칭 결과 저장/조회/정리 로직 추가</li>
<li><code>BattleRoomController.java</code> - 방 입장 성공 시 매칭 결과 정리 연동</li>
</ul>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) 매칭 완료 결과를 인메모리로 저장하는 <code>matchedRoomMap</code> 추가</h3>
<p>매칭이 성사되어 방이 생성되면, 각 사용자에게 어떤 <code>roomId</code>가 배정됐는지 잠깐 보관할 수 있어야 합니다. 이를 위해 <code>MatchingQueueService</code> 내부에 <code>matchedRoomMap</code>을 추가했습니다.</p>

<pre><code class="language-java">private final Map&lt;Long, Long&gt; matchedRoomMap = new ConcurrentHashMap&lt;&gt;();
</code></pre>

<p>의미는 아래와 같습니다.</p>
<ul>
<li><code>1L -&gt; 10L</code> : userId 1번 사용자는 roomId 10번 방으로 입장해야 함</li>
</ul>

<p>즉, 큐에서 빠진 뒤 아직 실제 방 입장 API를 호출하기 전까지의 “매칭 완료 상태”를 별도로 기억하는 역할입니다.</p>

<h3>2) 방 생성 성공 시 4명 모두의 <code>roomId</code> 저장</h3>
<p>기존 <code>tryMatchAndCreateRoom()</code>에서는 방 생성 성공 후 매칭된 유저들을 <code>userQueueMap</code>에서 제거하는 것까지만 처리하고 있었습니다.</p>
<p>이번 PR에서는 여기에 더해, 생성된 <code>roomId</code>를 4명 모두의 <code>matchedRoomMap</code>에 저장하도록 변경했습니다.</p>

<pre><code class="language-java">CreateRoomResponse response =
        battleRoomService.createRoom(new CreateRoomRequest(problemId, participantIds, 4));

Long roomId = response.roomId();

matchedUsers.forEach(user -&gt; {
    userQueueMap.remove(user.getUserId());
    matchedRoomMap.put(user.getUserId(), roomId);
});
</code></pre>

<p>이렇게 하면 사용자는 더 이상 “검색 중(SEARCHING)”은 아니고, 아직 방 입장은 안 했지만 “이미 방이 배정된 상태(MATCHED)”로 조회할 수 있습니다.</p>

<h3>3) 내 매칭 상태 조회 서비스 메서드 추가</h3>
<p><code>MatchingQueueService</code>에 현재 사용자의 매칭 상태를 단순하게 판별하는 <code>getMyMatchState()</code> 메서드를 추가했습니다.</p>

<pre><code class="language-java">public MatchStateResponse getMyMatchState(Long userId) {
    Long roomId = matchedRoomMap.get(userId);

    if (roomId != null) {
        return new MatchStateResponse("MATCHED", roomId);
    }

    if (userQueueMap.containsKey(userId)) {
        return new MatchStateResponse("SEARCHING", null);
    }

    return new MatchStateResponse("IDLE", null);
}
</code></pre>

<p>상태 판정 규칙은 아래와 같습니다.</p>
<ul>
<li><code>MATCHED</code> : 이미 방이 배정됐고, 응답에 <code>roomId</code> 포함</li>
<li><code>SEARCHING</code> : 아직 큐에서 대기 중, <code>roomId</code>는 없음</li>
<li><code>IDLE</code> : 큐에도 없고 배정된 방도 없는 상태</li>
</ul>

<p>즉, 프론트는 이 API 하나로 “아직 찾는 중인지”, “이제 방으로 들어가야 하는지”, “아무 상태도 아닌지”를 구분할 수 있습니다.</p>

<h3>4) 내 매칭 상태 조회 API 신규 추가</h3>
<p>위 서비스 메서드를 실제로 호출할 수 있도록 <code>MatchingStatusController</code>를 새로 만들고, <code>GET /api/v1/matches/me</code> 엔드포인트를 추가했습니다.</p>

<pre><code class="language-java">@RestController
@RequestMapping("/api/v1/matches")
@RequiredArgsConstructor
public class MatchingStatusController {

    private final MatchingQueueService matchingQueueService;
    private final Rq rq;

    @GetMapping("/me")
    public MatchStateResponse getMyMatchState() {
        Member actor = rq.getActor();

        if (actor == null) {
            throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
        }

        return matchingQueueService.getMyMatchState(actor.getId());
    }
}
</code></pre>

<p>특징은 아래와 같습니다.</p>
<ul>
<li>기존 <code>/api/v1/queue/me</code>처럼 <code>userId</code>를 query param으로 받지 않고, 로그인 사용자 기준으로 조회</li>
<li>로그인하지 않은 경우 <code>MEMBER_401</code> 예외 반환</li>
<li>응답은 큐 상세 정보가 아니라 매칭 상태만 단순하게 반환</li>
</ul>

<h3>5) 매칭 상태 응답 DTO 추가</h3>
<p>응답은 아주 단순하게 <code>status</code>와 <code>roomId</code>만 내려주는 record DTO로 만들었습니다.</p>

<pre><code class="language-java">public record MatchStateResponse(
        String status, // SEARCHING, MATCHED, IDLE
        Long roomId // 매칭 완료 전이면 null
) {}
</code></pre>

<p>즉, 프론트는 아래처럼 해석하면 됩니다.</p>
<ul>
<li><code>{ "status": "SEARCHING", "roomId": null }</code></li>
<li><code>{ "status": "MATCHED", "roomId": 12 }</code></li>
<li><code>{ "status": "IDLE", "roomId": null }</code></li>
</ul>

<h3>6) 방 입장 성공 시 매칭 결과 정리 연동</h3>
<p>사용자가 실제로 방 입장 API를 성공적으로 호출하면, 이제 더 이상 <code>matchedRoomMap</code>에 남아 있을 필요가 없습니다. 그래서 <code>BattleRoomController.joinRoom()</code>에서 방 입장 성공 직후 <code>clearMatchedRoom()</code>를 호출하도록 연결했습니다.</p>

<pre><code class="language-java">@PostMapping("/{roomId}/join")
public JoinRoomResponse joinRoom(@PathVariable Long roomId, @RequestBody JoinRoomRequest request) {
    JoinRoomResponse response = battleRoomService.joinRoom(roomId, request.memberId());

    matchingQueueService.clearMatchedRoom(request.memberId(), roomId);
    return response;
}
</code></pre>

<p>즉, 흐름은 아래와 같습니다.</p>
<ul>
<li>매칭 성공 -&gt; <code>matchedRoomMap</code>에 <code>userId -&gt; roomId</code> 저장</li>
<li>클라이언트가 <code>/api/v1/matches/me</code> 조회 -&gt; <code>MATCHED</code>와 <code>roomId</code> 확인</li>
<li>클라이언트가 <code>/api/v1/battle/rooms/{roomId}/join</code> 호출</li>
<li>입장 성공 -&gt; 해당 사용자 매칭 결과 정리</li>
</ul>

<h3>7) 잘못된 방 입장 정리를 막기 위해 <code>remove(userId, roomId)</code> 사용</h3>
<p><code>clearMatchedRoom()</code>에서는 단순히 <code>userId</code>만 보고 제거하지 않고, 저장된 <code>roomId</code>가 지금 입장한 <code>roomId</code>와 정확히 일치할 때만 제거하도록 했습니다.</p>

<pre><code class="language-java">public void clearMatchedRoom(Long userId, Long roomId) {
    matchedRoomMap.remove(userId, roomId);
}
</code></pre>

<p>이렇게 하면 잘못된 방 번호로 호출되거나 stale 요청이 들어온 경우, 다른 매칭 결과를 실수로 지우는 일을 막을 수 있습니다.</p>

<h3>8) 기존 큐 상태 조회 API와 역할 분리</h3>
<p>이번 PR로 상태 조회 API가 2개가 됩니다.</p>

<ul>
<li><code>GET /api/v1/queue/me?userId=...</code> : 현재 어떤 큐(category/difficulty)에 들어가 있고, 대기 인원이 몇 명인지 조회</li>
<li><code>GET /api/v1/matches/me</code> : 현재 내 매칭 상태가 SEARCHING / MATCHED / IDLE 중 무엇인지, MATCHED라면 어느 roomId인지 조회</li>
</ul>

<p>즉, 기존 큐 조회 API가 “대기열 정보”를 주는 역할이라면, 이번에 추가한 API는 “매칭 결과 상태”를 주는 역할입니다.</p>

<h3>9) 전체 흐름</h3>
<pre><code class="language-java">1. 사용자가 /api/v1/queue/join 으로 매칭 시작
      ↓
2. MatchingQueueService 가 userQueueMap / waitingQueues 에 사용자 추가
      ↓
3. 4명이 모이면 tryMatchAndCreateRoom() 에서 방 생성
      ↓
4. 방 생성 성공 시 matchedRoomMap 에 4명 모두의 userId -> roomId 저장
      ↓
5. 사용자가 /api/v1/matches/me 조회
   ┌─ matchedRoomMap 에 roomId 있으면 → MATCHED + roomId 반환
   ├─ userQueueMap 에 있으면         → SEARCHING 반환
   └─ 둘 다 없으면                  → IDLE 반환
      ↓
6. 클라이언트가 /api/v1/battle/rooms/{roomId}/join 호출
      ↓
7. 방 입장 성공 후 clearMatchedRoom(userId, roomId) 호출
      ↓
8. 이후 같은 사용자가 /api/v1/matches/me 조회 시 MATCHED 상태는 제거됨
</code></pre>

<h3>10) 현재 구현의 성격</h3>
<p>이번 PR은 제목 그대로 <strong>인메모리 방식</strong>으로 매칭 결과를 저장합니다.</p>
<p>즉, 현재는 <code>ConcurrentHashMap</code> 기반이므로 단일 서버 기준 MVP 흐름에는 충분하지만, 서버 재시작 시 상태가 초기화되고 다중 서버 환경에서는 공유되지 않습니다. 이후 Redis 같은 외부 저장소로 확장할 수 있는 전 단계 구현이라고 볼 수 있습니다.</p>

<hr>

<h2>확인 포인트</h2>
<ol>
<li>사용자가 매칭 큐에만 들어가 있는 상태에서 <code>GET /api/v1/matches/me</code> 호출 시 <code>SEARCHING</code>이 반환되는지 확인</li>
<li>4인 매칭 성사 후 방 생성이 완료되면, 해당 4명 모두에게 <code>MATCHED</code>와 같은 <code>roomId</code>가 반환되는지 확인</li>
<li>사용자가 실제로 <code>POST /api/v1/battle/rooms/{roomId}/join</code> 호출 후 성공하면, 이후 <code>/api/v1/matches/me</code>에서 더 이상 <code>MATCHED</code>로 남아있지 않은지 확인</li>
<li>로그인하지 않은 상태에서 <code>GET /api/v1/matches/me</code> 호출 시 <code>MEMBER_401</code> 예외가 발생하는지 확인</li>
<li>잘못된 <code>roomId</code>로 방 입장 처리되더라도 다른 매칭 결과가 지워지지 않는지 <code>remove(userId, roomId)</code> 동작 기준으로 확인</li>
</ol>
</body>
</html>