### PR TITLE
[feat] 채점

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ DB_PORT=5432
 DB_NAME=back
 DB_USERNAME=back
 DB_PASSWORD=change-this-local-password
+
+# judge0 ec2 ip
+JUDGE0_EC2_IP=NEED_TO_SET

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,5 @@ downloads/
 scripts/__pycache__/
 **/__pycache__/
 *.pyc
-*.md
 .claude
+myContext

--- a/src/main/java/com/back/BackApplication.java
+++ b/src/main/java/com/back/BackApplication.java
@@ -3,11 +3,13 @@ package com.back;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableAsync
 public class BackApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/back/domain/problem/submission/dto/SubmissionResponse.java
+++ b/src/main/java/com/back/domain/problem/submission/dto/SubmissionResponse.java
@@ -7,8 +7,8 @@ public record SubmissionResponse(Long submissionId, String result, int passedCou
     public static SubmissionResponse from(Submission submission) {
         return new SubmissionResponse(
                 submission.getId(),
-                submission.getResult() != null ? submission.getResult().name() : null,
-                submission.getPassedCount(),
-                submission.getTotalCount());
+                submission.getResult() != null ? submission.getResult().name() : "JUDGING",
+                submission.getPassedCount() != null ? submission.getPassedCount() : 0,
+                submission.getTotalCount() != null ? submission.getTotalCount() : 0);
     }
 }

--- a/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
+++ b/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
@@ -1,10 +1,8 @@
 package com.back.domain.problem.submission.service;
 
-import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,14 +12,14 @@ import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepo
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.submission.dto.SubmissionResponse;
 import com.back.domain.problem.submission.dto.SubmitRequest;
 import com.back.domain.problem.submission.entity.Submission;
-import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.JudgeService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,8 +31,7 @@ public class SubmissionService {
     private final BattleParticipantRepository battleParticipantRepository;
     private final MemberRepository memberRepository;
     private final SubmissionRepository submissionRepository;
-    private final SimpMessagingTemplate messagingTemplate;
-    private final BattleResultService battleResultService;
+    private final JudgeService judgeService;
 
     @Transactional
     public SubmissionResponse submit(SubmitRequest request) {
@@ -66,63 +63,17 @@ public class SubmissionService {
             throw new IllegalStateException("제출할 수 없는 상태입니다. 현재 상태: " + participant.getStatus());
         }
 
-        // 4. Submission 생성 후 저장
+        // 4. Submission 생성 후 저장 (result = null, 채점 중 상태)
         Submission submission = Submission.create(room, member, request.code(), request.language());
         submissionRepository.save(submission);
 
-        // 5. 채점 실행 (Mock - 항상 AC 반환)
-        // TODO: 실제 Judge API 연동으로 교체
-        SubmissionResult result = SubmissionResult.AC;
-        int totalCount = room.getProblem().getTestCases().size();
-        int passedCount = totalCount;
+        // 5. 테스트케이스 로드 후 비동기 채점 시작 → 즉시 JUDGING 응답
+        // new ArrayList<>()로 강제 초기화: PersistentBag을 트랜잭션 안에서 일반 List로 변환,
+        // 트랜잭션 종료 후 세션이 닫혀도 JudgeService에서 안전하게 접근 가능
+        List<TestCase> testCases = new ArrayList<>(room.getProblem().getTestCases());
+        judgeService.judge(
+                submission.getId(), room.getId(), member.getId(), request.code(), request.language(), testCases);
 
-        // 6. 채점 결과 저장
-        submission.applyJudgeResult(result, passedCount, totalCount);
-
-        // 7. WebSocket 브로드캐스트 - 제출 결과 전파
-        // TODO: 리팩토링 - 트랜잭션 커밋 전 메시지 전송 문제
-        //   현재 @Transactional 안에서 convertAndSend 호출 시 커밋 전에 메시지가 전송됨
-        //   수신자가 DB 조회 시 아직 반영되지 않은 상태를 볼 수 있음
-        //   → TransactionSynchronizationManager.registerSynchronization의 afterCommit()으로 개선 필요
-        messagingTemplate.convertAndSend(
-                "/topic/room/" + room.getId(),
-                Map.of(
-                        "type",
-                        "SUBMISSION",
-                        "userId",
-                        member.getId(),
-                        "result",
-                        result.name(),
-                        "passedCount",
-                        passedCount,
-                        "totalCount",
-                        totalCount));
-
-        // 8. AC이면 참여자 완료 처리
-        if (result == SubmissionResult.AC) {
-            participant.complete(LocalDateTime.now());
-
-            // TODO: 리팩토링 - 현재 참여자 수가 최대 4명으로 고정이라 성능 문제 없으나,
-            //   추후 참여자 수 확장 시 DB 집계 쿼리로 교체 필요
-            //   → BattleParticipantRepository에 countByBattleRoomAndStatus 추가 후
-            //      completedCount = repo.countByBattleRoomAndStatus(room, EXIT) 으로 변경
-            List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
-            long completedCount = allParticipants.stream()
-                    .filter(p -> p.getStatus() == BattleParticipantStatus.EXIT)
-                    .count();
-
-            messagingTemplate.convertAndSend(
-                    "/topic/room/" + room.getId(),
-                    Map.of("type", "PARTICIPANT_DONE", "userId", member.getId(), "rank", completedCount));
-
-            // 9. 모든 참여자 완료 시 결과 정산 트리거
-            boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.EXIT);
-
-            if (allFinished) {
-                battleResultService.settle(room.getId());
-            }
-        }
-
-        return SubmissionResponse.from(submission);
+        return new SubmissionResponse(submission.getId(), "JUDGING", 0, 0);
     }
 }

--- a/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
+++ b/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
@@ -3,6 +3,7 @@ package com.back.domain.problem.submission.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +20,7 @@ import com.back.domain.problem.submission.dto.SubmitRequest;
 import com.back.domain.problem.submission.entity.Submission;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
 import com.back.domain.problem.testcase.entity.TestCase;
-import com.back.global.judge.JudgeService;
+import com.back.global.judge.event.JudgeRequestedEvent;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +32,7 @@ public class SubmissionService {
     private final BattleParticipantRepository battleParticipantRepository;
     private final MemberRepository memberRepository;
     private final SubmissionRepository submissionRepository;
-    private final JudgeService judgeService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public SubmissionResponse submit(SubmitRequest request) {
@@ -54,7 +55,7 @@ public class SubmissionService {
                 .findById(request.memberId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        // 3. BattleParticipant 조회 + 제출 가능 상태 검증
+        // 3. BattleParticipant 조회 + 제출 가능 상태(PLAYING) 검증
         BattleParticipant participant = battleParticipantRepository
                 .findByBattleRoomAndMember(room, member)
                 .orElseThrow(() -> new IllegalArgumentException("해당 방의 참여자가 아닙니다."));
@@ -67,12 +68,13 @@ public class SubmissionService {
         Submission submission = Submission.create(room, member, request.code(), request.language());
         submissionRepository.save(submission);
 
-        // 5. 테스트케이스 로드 후 비동기 채점 시작 → 즉시 JUDGING 응답
+        // 5. 테스트케이스 로드 후 이벤트 발행 → 트랜잭션 커밋 후 비동기 채점 시작 → 즉시 JUDGING 응답
         // new ArrayList<>()로 강제 초기화: PersistentBag을 트랜잭션 안에서 일반 List로 변환,
         // 트랜잭션 종료 후 세션이 닫혀도 JudgeService에서 안전하게 접근 가능
         List<TestCase> testCases = new ArrayList<>(room.getProblem().getTestCases());
-        judgeService.judge(
-                submission.getId(), room.getId(), member.getId(), request.code(), request.language(), testCases);
+        // 이벤트 기반으로 변경: 이벤트를 발행하고 끝, JudgeService에서 수신해서 judge실행
+        eventPublisher.publishEvent(new JudgeRequestedEvent(
+                submission.getId(), room.getId(), member.getId(), request.code(), request.language(), testCases));
 
         return new SubmissionResponse(submission.getId(), "JUDGING", 0, 0);
     }

--- a/src/main/java/com/back/global/async/AsyncConfig.java
+++ b/src/main/java/com/back/global/async/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.back.global.async;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("judge-async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/back/global/judge/Judge0Client.java
+++ b/src/main/java/com/back/global/judge/Judge0Client.java
@@ -1,0 +1,118 @@
+package com.back.global.judge;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.back.global.judge.dto.Judge0SubmitRequest;
+import com.back.global.judge.dto.Judge0SubmitResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class Judge0Client {
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+
+    public Judge0Client(@Value("${judge0.url}") String baseUrl, ObjectMapper objectMapper) {
+        this.baseUrl = baseUrl;
+        this.objectMapper = objectMapper;
+        this.httpClient = HttpClient.newBuilder().build();
+    }
+
+    /**
+     * 테스트케이스 목록을 Judge0 Batch API로 일괄 제출하고 토큰 목록을 반환한다.
+     * Judge0는 snake_case 필드명(source_code, language_id 등)을 요구한다.
+     */
+    public List<String> submitBatch(List<Judge0SubmitRequest> submissions) {
+        log.debug("submitBatch called with {} submissions", submissions.size());
+
+        List<Map<String, Object>> submissionMaps = submissions.stream()
+                .map(s -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    map.put("source_code", s.sourceCode());
+                    map.put("language_id", s.languageId());
+                    map.put("stdin", s.stdin() != null ? s.stdin() : "");
+                    if (s.expectedOutput() != null) {
+                        map.put("expected_output", s.expectedOutput());
+                    }
+                    return map;
+                })
+                .toList();
+
+        try {
+            String requestBodyJson = objectMapper.writeValueAsString(Map.of("submissions", submissionMaps));
+            log.debug("Judge0 batch request body: {}", requestBodyJson);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/submissions/batch"))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBodyJson, StandardCharsets.UTF_8))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            log.debug("Judge0 batch response status: {}, body: {}", response.statusCode(), response.body());
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new RuntimeException(
+                        "Judge0 batch submit failed: " + response.statusCode() + " " + response.body());
+            }
+
+            List<TokenResponse> tokenResponses =
+                    objectMapper.readValue(response.body(), new TypeReference<List<TokenResponse>>() {});
+            return tokenResponses.stream().map(TokenResponse::token).toList();
+
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Judge0 submitBatch error", e);
+        }
+    }
+
+    /**
+     * 토큰 목록으로 채점 결과를 조회한다.
+     */
+    public List<Judge0SubmitResponse> getBatchResults(List<String> tokens) {
+        String tokenParam = String.join(",", tokens);
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/submissions/batch?tokens=" + tokenParam))
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new RuntimeException(
+                        "Judge0 getBatchResults failed: " + response.statusCode() + " " + response.body());
+            }
+
+            BatchResultResponse result = objectMapper.readValue(response.body(), BatchResultResponse.class);
+            return result.submissions();
+
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Judge0 getBatchResults error", e);
+        }
+    }
+
+    private record TokenResponse(String token) {}
+
+    private record BatchResultResponse(List<Judge0SubmitResponse> submissions) {}
+}

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -86,7 +86,7 @@ public class JudgeService {
         submission.applyJudgeResult(judgeResult, passedCount, totalCount);
         submissionRepository.save(submission);
 
-        // WebSocket: 제출 결과 브로드캐스트
+        // WebSocket: 제출 결과 브로드캐스트 (알림)
         messagingTemplate.convertAndSend(
                 "/topic/room/" + roomId,
                 Map.of(
@@ -96,9 +96,14 @@ public class JudgeService {
                         "passedCount", passedCount,
                         "totalCount", totalCount));
 
+        /*
+         * result != AC일 때
+         * SUBMISSION 브로드캐스트만 하고 끝. handleAc()가 호출되지 않으므로 participant 상태 변경 없음, 정산도 없음.
+         */
         if (judgeResult == SubmissionResult.AC) {
             handleAc(roomId, memberId);
         }
+        // SUBMISSION 브로드캐스트는 알림이고, AC일 때만 참여자 완료 처리 → 전원 완료 시 정산까지 연결
     }
 
     private void handleAc(Long roomId, Long memberId) {
@@ -113,6 +118,10 @@ public class JudgeService {
                 .findByBattleRoomAndMember(room, member)
                 .orElseThrow(() -> new IllegalStateException("Participant not found"));
 
+        /*
+         * status: PLAYING에서 EXIT
+         * finishTime 기록
+         */
         participant.complete(LocalDateTime.now());
         battleParticipantRepository.save(participant);
 
@@ -120,11 +129,20 @@ public class JudgeService {
         long completedCount = allParticipants.stream()
                 .filter(p -> p.getStatus() == BattleParticipantStatus.EXIT)
                 .count();
-
+        // PARTICIPANT_DONE 브로드캐스트
         messagingTemplate.convertAndSend(
                 "/topic/room/" + roomId,
                 Map.of("type", "PARTICIPANT_DONE", "userId", memberId, "rank", completedCount));
 
+        /*
+         * 전원 EXIT 체크
+         *     → 아직 남은 사람 있으면 종료
+         *     → 전원 완료면 battleResultService.settle() 호출
+         *         → 순위/점수 계산
+         *         → member.score 갱신
+         *         → room.finish() → status: FINISHED
+         *         → BATTLE_FINISHED 브로드캐스트
+         */
         boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.EXIT);
         if (allFinished) {
             battleResultService.settle(roomId);

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -1,0 +1,199 @@
+package com.back.global.judge;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.submission.entity.Submission;
+import com.back.domain.problem.submission.entity.SubmissionResult;
+import com.back.domain.problem.submission.repository.SubmissionRepository;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.dto.Judge0SubmitRequest;
+import com.back.global.judge.dto.Judge0SubmitResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JudgeService {
+
+    private static final int MAX_POLL_ATTEMPTS = 10;
+    private static final int POLL_INTERVAL_MS = 1000;
+
+    private final Judge0Client judge0Client;
+    private final SubmissionRepository submissionRepository;
+    private final BattleParticipantRepository battleParticipantRepository;
+    private final BattleRoomRepository battleRoomRepository;
+    private final MemberRepository memberRepository;
+    private final BattleResultService battleResultService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * 비동기 채점 실행. SubmissionService에서 저장 직후 호출된다.
+     * testCases는 SubmissionService 트랜잭션 안에서 미리 로드된 데이터이며,
+     * 직접 컬럼 필드(input, expectedOutput)만 사용하므로 detach 후에도 안전하다.
+     */
+    @Async
+    public void judge(
+            Long submissionId, Long roomId, Long memberId, String code, String language, List<TestCase> testCases) {
+
+        int totalCount = testCases.size();
+        SubmissionResult judgeResult;
+        int passedCount = 0;
+
+        if (totalCount == 0) {
+            log.warn("Submission {} has no test cases, marking as WA", submissionId);
+            judgeResult = SubmissionResult.WA;
+        } else {
+            int languageId = getLanguageId(language);
+            List<Judge0SubmitRequest> batchRequests = testCases.stream()
+                    .map(tc -> new Judge0SubmitRequest(
+                            code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
+                    .toList();
+
+            List<Judge0SubmitResponse> results = runJudge(batchRequests);
+            results.forEach(r -> log.info(
+                    "Judge0 result: token={}, statusId={}, stderr={}, compileOutput={}, message={}",
+                    r.token(),
+                    r.status() != null ? r.status().id() : null,
+                    r.stderr(),
+                    r.compileOutput(),
+                    r.message()));
+            judgeResult = aggregateResult(results, totalCount);
+            passedCount = (int) results.stream()
+                    .filter(r -> r.status() != null && r.status().id() == 3)
+                    .count();
+        }
+
+        // 결과 저장 — 폴링 완료 시점에는 SubmissionService 트랜잭션이 반드시 커밋된 상태
+        Submission submission = submissionRepository
+                .findById(submissionId)
+                .orElseThrow(() -> new IllegalStateException("Submission not found: " + submissionId));
+        submission.applyJudgeResult(judgeResult, passedCount, totalCount);
+        submissionRepository.save(submission);
+
+        // WebSocket: 제출 결과 브로드캐스트
+        messagingTemplate.convertAndSend(
+                "/topic/room/" + roomId,
+                Map.of(
+                        "type", "SUBMISSION",
+                        "userId", memberId,
+                        "result", judgeResult.name(),
+                        "passedCount", passedCount,
+                        "totalCount", totalCount));
+
+        if (judgeResult == SubmissionResult.AC) {
+            handleAc(roomId, memberId);
+        }
+    }
+
+    private void handleAc(Long roomId, Long memberId) {
+        BattleRoom room = battleRoomRepository
+                .findById(roomId)
+                .orElseThrow(() -> new IllegalStateException("BattleRoom not found: " + roomId));
+        Member member = memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new IllegalStateException("Member not found: " + memberId));
+
+        BattleParticipant participant = battleParticipantRepository
+                .findByBattleRoomAndMember(room, member)
+                .orElseThrow(() -> new IllegalStateException("Participant not found"));
+
+        participant.complete(LocalDateTime.now());
+        battleParticipantRepository.save(participant);
+
+        List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
+        long completedCount = allParticipants.stream()
+                .filter(p -> p.getStatus() == BattleParticipantStatus.EXIT)
+                .count();
+
+        messagingTemplate.convertAndSend(
+                "/topic/room/" + roomId,
+                Map.of("type", "PARTICIPANT_DONE", "userId", memberId, "rank", completedCount));
+
+        boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.EXIT);
+        if (allFinished) {
+            battleResultService.settle(roomId);
+        }
+    }
+
+    /**
+     * 폴링 부분 (Judge0 worker가 코드를 실행 완료할 때까지 1초 간격으로 계속 물어보는 것)
+     *   submitBatch() → 토큰 발급 ["abc", "def"]
+     *        │
+     *        ▼
+     *   1초 후 getBatchResults() → status_id 1 (처리 중) → 다시 대기
+     *   1초 후 getBatchResults() → status_id 1 (처리 중) → 다시 대기
+     *   1초 후 getBatchResults() → status_id 3 (완료!) → 결과 반환
+     */
+    private List<Judge0SubmitResponse> runJudge(List<Judge0SubmitRequest> batchRequests) {
+        try {
+            List<String> tokens = judge0Client.submitBatch(batchRequests); // 제출 → 토큰 받기
+            for (int i = 0; i < MAX_POLL_ATTEMPTS; i++) { // 최대 10회
+                List<Judge0SubmitResponse> results = judge0Client.getBatchResults(tokens); // 결과 조회
+                if (results.stream().allMatch(Judge0SubmitResponse::isCompleted)) {
+                    return results; // 모두 완료했으면 반환
+                }
+                Thread.sleep(POLL_INTERVAL_MS); // 아직 처리중이면 1초 대기
+            }
+            // 10초 지나도 안 끝나면 타임아웃
+            log.warn("Judge0 polling timed out after {} attempts", MAX_POLL_ATTEMPTS);
+            return List.of();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Judge0 polling interrupted", e);
+            return List.of();
+        } catch (Exception e) {
+            log.error("Judge0 judging failed", e);
+            return List.of();
+        }
+    }
+
+    /**
+     * 우선순위: CE > RE > TLE > WA > AC
+     */
+    private SubmissionResult aggregateResult(List<Judge0SubmitResponse> results, int totalCount) {
+        if (results.isEmpty()) return SubmissionResult.RE;
+
+        if (results.stream().anyMatch(r -> r.status() != null && r.status().id() == 6)) {
+            return SubmissionResult.CE;
+        }
+        if (results.stream().anyMatch(r -> r.status() != null && r.status().id() >= 7)) {
+            return SubmissionResult.RE;
+        }
+        if (results.stream().anyMatch(r -> r.status() != null && r.status().id() == 5)) {
+            return SubmissionResult.TLE;
+        }
+        long passed = results.stream()
+                .filter(r -> r.status() != null && r.status().id() == 3)
+                .count();
+        if (passed == totalCount) return SubmissionResult.AC;
+
+        return SubmissionResult.WA;
+    }
+
+    private int getLanguageId(String language) {
+        return switch (language.toLowerCase()) {
+            case "python", "python3" -> 71;
+            case "java" -> 62;
+            case "cpp", "c++" -> 54;
+            case "c" -> 50;
+            case "javascript", "js" -> 63;
+            default -> throw new IllegalArgumentException("지원하지 않는 언어: " + language);
+        };
+    }
+}

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
 import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
@@ -22,6 +24,7 @@ import com.back.domain.problem.submission.repository.SubmissionRepository;
 import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.global.judge.dto.Judge0SubmitRequest;
 import com.back.global.judge.dto.Judge0SubmitResponse;
+import com.back.global.judge.event.JudgeRequestedEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,28 +46,43 @@ public class JudgeService {
     private final SimpMessagingTemplate messagingTemplate;
 
     /**
-     * 비동기 채점 실행. SubmissionService에서 저장 직후 호출된다.
-     * testCases는 SubmissionService 트랜잭션 안에서 미리 로드된 데이터이며,
-     * 직접 컬럼 필드(input, expectedOutput)만 사용하므로 detach 후에도 안전하다.
+     * 트랜잭션 커밋 후 비동기 채점 실행.
+     * @TransactionalEventListener(AFTER_COMMIT) 으로 커밋 확정 후 실행이 보장되므로
+     * 이후 findById(submissionId) 호출 시 레코드가 반드시 존재한다.
      */
     @Async
-    public void judge(
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onJudgeRequested(JudgeRequestedEvent event) {
+        judge(
+                event.submissionId(),
+                event.roomId(),
+                event.memberId(),
+                event.code(),
+                event.language(),
+                event.testCases());
+    }
+
+    private void judge(
             Long submissionId, Long roomId, Long memberId, String code, String language, List<TestCase> testCases) {
 
+        // 문제에 있는 테스트 케이스의 총 개수
         int totalCount = testCases.size();
         SubmissionResult judgeResult;
         int passedCount = 0;
 
+        // 테스트케이스가 0개의 경우 WA처리
         if (totalCount == 0) {
             log.warn("Submission {} has no test cases, marking as WA", submissionId);
             judgeResult = SubmissionResult.WA;
-        } else {
+        } else { // 테스트 케이스가 1개 이상의 경우
             int languageId = getLanguageId(language);
+
+            // 배치 요청 구성
             List<Judge0SubmitRequest> batchRequests = testCases.stream()
                     .map(tc -> new Judge0SubmitRequest(
                             code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
                     .toList();
-
+            // judge 실행 (10초간 1초마다 풀링)
             List<Judge0SubmitResponse> results = runJudge(batchRequests);
             results.forEach(r -> log.info(
                     "Judge0 result: token={}, statusId={}, stderr={}, compileOutput={}, message={}",
@@ -73,13 +91,16 @@ public class JudgeService {
                     r.stderr(),
                     r.compileOutput(),
                     r.message()));
+            // 결과 집계
+            // 우선순위: CE(6) > RE(7~14) > TLE(5) > WA > AC(3)
+            //  passedCount = status.id == 3 인 케이스 수
             judgeResult = aggregateResult(results, totalCount);
             passedCount = (int) results.stream()
                     .filter(r -> r.status() != null && r.status().id() == 3)
                     .count();
         }
 
-        // 결과 저장 — 폴링 완료 시점에는 SubmissionService 트랜잭션이 반드시 커밋된 상태
+        // 결과 저장 — @TransactionalEventListener(AFTER_COMMIT) 으로 커밋 확정 후 실행되므로 안전
         Submission submission = submissionRepository
                 .findById(submissionId)
                 .orElseThrow(() -> new IllegalStateException("Submission not found: " + submissionId));

--- a/src/main/java/com/back/global/judge/dto/Judge0SubmitRequest.java
+++ b/src/main/java/com/back/global/judge/dto/Judge0SubmitRequest.java
@@ -1,0 +1,9 @@
+package com.back.global.judge.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Judge0SubmitRequest(
+        @JsonProperty("source_code") String sourceCode,
+        @JsonProperty("language_id") int languageId,
+        String stdin,
+        @JsonProperty("expected_output") String expectedOutput) {}

--- a/src/main/java/com/back/global/judge/dto/Judge0SubmitResponse.java
+++ b/src/main/java/com/back/global/judge/dto/Judge0SubmitResponse.java
@@ -1,0 +1,19 @@
+package com.back.global.judge.dto;
+
+public record Judge0SubmitResponse(
+        String token,
+        Status status,
+        String stdout,
+        String stderr,
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compile_output")
+        String compileOutput,
+
+        String message) {
+
+    public record Status(int id, String description) {}
+
+    public boolean isCompleted() {
+        return status != null && status.id() >= 3;
+    }
+}

--- a/src/main/java/com/back/global/judge/event/JudgeRequestedEvent.java
+++ b/src/main/java/com/back/global/judge/event/JudgeRequestedEvent.java
@@ -1,0 +1,8 @@
+package com.back.global.judge.event;
+
+import java.util.List;
+
+import com.back.domain.problem.testcase.entity.TestCase;
+
+public record JudgeRequestedEvent(
+        Long submissionId, Long roomId, Long memberId, String code, String language, List<TestCase> testCases) {}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,3 +14,6 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
+
+judge0:
+  url: http://${JUDGE0_EC2_IP}:2358

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -9,3 +9,6 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+judge0:
+  url: http://JUDGE0_EC2_IP:2358

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   application:
     name: back
   profiles:


### PR DESCRIPTION
### 전체 흐름

```java
1. 진입점 — SubmissionService.submit()

POST /api/submissions { roomId, memberId, code, language }

  - BattleRoom 상태 검증 (PLAYING + 타이머 미만료)
  - BattleParticipant 상태 검증 (PLAYING)
  - Submission.create() → DB 저장 (result = null)
  - room.getProblem().getTestCases()를 new ArrayList<>()로 강제 초기화 → 트랜잭션 종료 후 세션이 닫혀도 안전하게 전달 가능
  - judgeService.judge(...) 호출 → 즉시 { status: "JUDGING" } 응답 반환

---

2. 비동기 채점 — JudgeService.judge() @Async

별도 스레드(judge-async-1)에서 실행

1) 언어 ID 변환
  "python" → 71, "java" → 62, "cpp" → 54 ...

2) Batch 요청 구성
  테스트케이스마다 Judge0SubmitRequest 생성:
  { "source_code": "...", "language_id": 71, "stdin": "1 2", "expected_output": "3" }

3) Judge0Client.submitBatch() 호출
  POST {JUDGE0_EC2_IP}:2358/submissions/batch
  → 토큰 목록 반환 ["abc123", "def456"]

4) 폴링 — Judge0Client.getBatchResults()
  GET {JUDGE0_EC2_IP}:2358/submissions/batch?tokens=abc123,def456
  1초 간격, 최대 10회
  status.id >= 3 이면 완료 (isCompleted())
  타임아웃 시 빈 리스트 반환 → RE 처리

5) 결과 집계 — aggregateResult()
  우선순위: CE(6) > RE(7~14) > TLE(5) > WA > AC(3)
  passedCount = status.id == 3 인 케이스 수

---

3. 결과 저장 + WebSocket 브로드캐스트

submission.applyJudgeResult(judgeResult, passedCount, totalCount)
submissionRepository.save(submission)

→ /topic/room/{roomId}
  { type: "SUBMISSION", userId, result, passedCount, totalCount }

---

4. AC 처리 — handleAc()

participant.complete(LocalDateTime.now())  // status = EXIT, finishTime 기록
→ /topic/room/{roomId}
  { type: "PARTICIPANT_DONE", userId, rank: completedCount }

전원 EXIT이면 → battleResultService.settle(roomId)

---

전체 타임라인 요약

HTTP 요청 (메인 스레드)          비동기 스레드 (judge-async-1)
───────────────────────────     ──────────────────────────────
Submission 저장 (result=null)
TestCase 로드 (ArrayList 변환)
judgeService.judge() 호출      →  Judge0 EC2로 Batch 제출
즉시 "JUDGING" 응답               폴링 (1초 × 최대 10회)
                                  결과 집계
                                  DB 저장 (result 업데이트)
                                  WebSocket SUBMISSION 브로드캐스트
                                  AC면 PARTICIPANT_DONE 브로드캐스트
                                  전원 완료면 settle() 호출
```