### PR TITLE
[feat] 문제 전체 조회 API 추가

### DIFF
--- a/src/main/java/com/back/domain/problem/problem/controller/ProblemController.java
+++ b/src/main/java/com/back/domain/problem/problem/controller/ProblemController.java
@@ -3,9 +3,11 @@ package com.back.domain.problem.problem.controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.problem.problem.dto.ProblemDetailResponse;
+import com.back.domain.problem.problem.dto.ProblemListResponse;
 import com.back.domain.problem.problem.service.ProblemService;
 
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,13 @@ import lombok.RequiredArgsConstructor;
 public class ProblemController {
 
     private final ProblemService problemService;
+
+    @GetMapping
+    public ProblemListResponse getProblems(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size) {
+        return problemService.getProblems(page, size);
+    }
 
     @GetMapping("/{problemId}")
     public ProblemDetailResponse getProblem(@PathVariable("problemId") Long problemId) {

--- a/src/main/java/com/back/domain/problem/problem/dto/ProblemListResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/ProblemListResponse.java
@@ -1,0 +1,25 @@
+package com.back.domain.problem.problem.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.back.domain.problem.problem.entity.Problem;
+
+public record ProblemListResponse(List<ProblemSummaryResponse> problems, PageInfo pageInfo) {
+
+    public record PageInfo(int page, int size, long totalElements, int totalPages, boolean hasNext) {
+        public static PageInfo from(Page<?> page) {
+            return new PageInfo(
+                    page.getNumber(), page.getSize(), page.getTotalElements(), page.getTotalPages(), page.hasNext());
+        }
+    }
+
+    public static ProblemListResponse from(Page<Problem> problemPage) {
+        List<ProblemSummaryResponse> items = problemPage.getContent().stream()
+                .map(ProblemSummaryResponse::from)
+                .toList();
+
+        return new ProblemListResponse(items, PageInfo.from(problemPage));
+    }
+}

--- a/src/main/java/com/back/domain/problem/problem/dto/ProblemSummaryResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/ProblemSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.back.domain.problem.problem.dto;
+
+import com.back.domain.problem.problem.entity.Problem;
+
+public record ProblemSummaryResponse(
+        Long problemId,
+        String title,
+        String difficulty,
+        Integer difficultyRating,
+        Long timeLimitMs,
+        Long memoryLimitMb) {
+
+    public static ProblemSummaryResponse from(Problem problem) {
+        return new ProblemSummaryResponse(
+                problem.getId(),
+                problem.getTitle(),
+                problem.getDifficulty().name(),
+                problem.getDifficultyRating(),
+                problem.getTimeLimitMs(),
+                problem.getMemoryLimitMb());
+    }
+}

--- a/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
+++ b/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
@@ -1,9 +1,13 @@
 package com.back.domain.problem.problem.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.back.domain.problem.problem.dto.ProblemDetailResponse;
+import com.back.domain.problem.problem.dto.ProblemListResponse;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.repository.ProblemRepository;
 import com.back.global.exception.ServiceException;
@@ -15,7 +19,23 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class ProblemService {
 
+    private static final int MAX_PAGE_SIZE = 100;
+
     private final ProblemRepository problemRepository;
+
+    public ProblemListResponse getProblems(int page, int size) {
+        if (page < 0) {
+            throw new ServiceException("400-2", "page는 0 이상이어야 합니다.");
+        }
+        if (size <= 0 || size > MAX_PAGE_SIZE) {
+            throw new ServiceException("400-3", "size는 1 이상 100 이하여야 합니다.");
+        }
+
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<Problem> problemPage = problemRepository.findAll(pageable);
+
+        return ProblemListResponse.from(problemPage);
+    }
 
     public ProblemDetailResponse getProblem(Long problemId) {
         if (problemId == null) {

--- a/src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java
@@ -5,16 +5,37 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.back.domain.problem.problem.dto.ProblemDetailResponse;
+import com.back.domain.problem.problem.dto.ProblemListResponse;
+import com.back.domain.problem.problem.dto.ProblemSummaryResponse;
 import com.back.domain.problem.problem.service.ProblemService;
 
 class ProblemControllerTest {
 
     private final ProblemService problemService = mock(ProblemService.class);
     private final ProblemController problemController = new ProblemController(problemService);
+
+    @Test
+    @DisplayName("문제 목록 조회 컨트롤러는 서비스 결과를 그대로 반환한다")
+    void getProblems_returnsServiceResult() {
+        // given
+        ProblemListResponse response = new ProblemListResponse(
+                List.of(new ProblemSummaryResponse(1L, "A + B", "EASY", 800, 1000L, 256L)),
+                new ProblemListResponse.PageInfo(0, 20, 1L, 1, false));
+        when(problemService.getProblems(0, 20)).thenReturn(response);
+
+        // when
+        ProblemListResponse actual = problemController.getProblems(0, 20);
+
+        // then
+        assertThat(actual).isEqualTo(response);
+        verify(problemService).getProblems(0, 20);
+    }
 
     @Test
     @DisplayName("문제 단건 조회 컨트롤러는 서비스 결과를 그대로 반환한다")

--- a/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
@@ -2,15 +2,22 @@ package com.back.domain.problem.problem.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import com.back.domain.problem.problem.dto.ProblemDetailResponse;
+import com.back.domain.problem.problem.dto.ProblemListResponse;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.problem.problem.repository.ProblemRepository;
@@ -20,6 +27,58 @@ class ProblemServiceTest {
 
     private final ProblemRepository problemRepository = mock(ProblemRepository.class);
     private final ProblemService problemService = new ProblemService(problemRepository);
+
+    @Test
+    @DisplayName("문제 목록 조회 시 페이지 정보와 요약 목록을 반환한다")
+    void getProblems_returnsPagedSummary() {
+        // given
+        Problem problem = mock(Problem.class);
+        when(problem.getId()).thenReturn(1L);
+        when(problem.getTitle()).thenReturn("A + B");
+        when(problem.getDifficulty()).thenReturn(DifficultyLevel.EASY);
+        when(problem.getDifficultyRating()).thenReturn(800);
+        when(problem.getTimeLimitMs()).thenReturn(1000L);
+        when(problem.getMemoryLimitMb()).thenReturn(256L);
+
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Problem> page = new PageImpl<>(List.of(problem), pageable, 1);
+        when(problemRepository.findAll(any(Pageable.class))).thenReturn(page);
+
+        // when
+        ProblemListResponse response = problemService.getProblems(0, 20);
+
+        // then
+        assertThat(response.problems()).hasSize(1);
+        assertThat(response.problems().get(0).problemId()).isEqualTo(1L);
+        assertThat(response.problems().get(0).title()).isEqualTo("A + B");
+        assertThat(response.problems().get(0).difficulty()).isEqualTo("EASY");
+        assertThat(response.problems().get(0).difficultyRating()).isEqualTo(800);
+        assertThat(response.pageInfo().page()).isEqualTo(0);
+        assertThat(response.pageInfo().size()).isEqualTo(20);
+        assertThat(response.pageInfo().totalElements()).isEqualTo(1L);
+        assertThat(response.pageInfo().totalPages()).isEqualTo(1);
+        assertThat(response.pageInfo().hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("문제 목록 조회 시 page가 음수면 예외를 던진다")
+    void getProblems_throws_whenPageIsNegative() {
+        assertThatThrownBy(() -> problemService.getProblems(-1, 20))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage("400-2 : page는 0 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("문제 목록 조회 시 size가 1~100 범위를 벗어나면 예외를 던진다")
+    void getProblems_throws_whenSizeIsOutOfRange() {
+        assertThatThrownBy(() -> problemService.getProblems(0, 0))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage("400-3 : size는 1 이상 100 이하여야 합니다.");
+
+        assertThatThrownBy(() -> problemService.getProblems(0, 101))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage("400-3 : size는 1 이상 100 이하여야 합니다.");
+    }
 
     @Test
     @DisplayName("문제 ID로 단건 조회 시 프론트 전달용 상세 정보를 반환한다")


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #69
closes #69

---

## 📝 작업 내용
기존 `GET /api/v1/problems/{problemId}`(상세 조회)만 있던 구조에 목록 조회 API를 추가했습니다.  
MVP 단계에서 프론트 문제 목록 화면에 바로 쓸 수 있도록, 상세 본문(`content`)은 제외한 요약 DTO + 페이지 메타를 반환하도록 분리했습니다.

1. `GET /api/v1/problems?page=&size=` 엔드포인트 추가
```java
@GetMapping
public ProblemListResponse getProblems(
        @RequestParam(value = "page", defaultValue = "0") int page,
        @RequestParam(value = "size", defaultValue = "20") int size) {
    return problemService.getProblems(page, size);
}
```

2. 서비스 페이징/검증 로직 추가
```java
if (page < 0) {
    throw new ServiceException("400-2", "page는 0 이상이어야 합니다.");
}
if (size <= 0 || size > MAX_PAGE_SIZE) {
    throw new ServiceException("400-3", "size는 1 이상 100 이하여야 합니다.");
}

PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
Page<Problem> problemPage = problemRepository.findAll(pageable);
return ProblemListResponse.from(problemPage);
```

3. 목록 응답 DTO 분리
```java
public record ProblemListResponse(List<ProblemSummaryResponse> problems, PageInfo pageInfo) {}
public record ProblemSummaryResponse(
        Long problemId,
        String title,
        String difficulty,
        Integer difficultyRating,
        Long timeLimitMs,
        Long memoryLimitMb) {}
```

---

## ✅ 주요 변경 사항
1) 문제 목록 조회 API `GET /api/v1/problems` 추가 (`page`, `size` 지원)
2) 목록/상세 응답 DTO 분리 (`ProblemSummaryResponse`, `ProblemListResponse`)
3) 입력값 검증 추가 (`page >= 0`, `1 <= size <= 100`)
4) 기존 상세 조회 API (`GET /api/v1/problems/{problemId}`) 동작 유지
5) 컨트롤러/서비스 단위 테스트 보강

---

## 🧪 테스트 결과
```bash
./gradlew test --tests "com.back.domain.problem.problem.controller.ProblemControllerTest" --tests "com.back.domain.problem.problem.service.ProblemServiceTest"
./gradlew spotlessCheck
```

- [x] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
- 목록 조회 파라미터 검증 기준 (`size` 상한 100)이 팀 정책에 맞는지
- 목록 정렬 기준을 현재 `id DESC`로 고정했는데, 향후 요구사항(난이도/최근성)에 맞게 확장 가능한지
- 예외 코드(`400-2`, `400-3`) 명명 규칙 일관성

---

## 📎 참고 사항 (선택)
- 상세 조회와 목록 조회는 역할을 분리했습니다.
  - 상세: 문제 본문 포함 (`ProblemDetailResponse`)
  - 목록: 카드/리스트 렌더링용 요약 + 페이지 메타
