### PR TITLE
[feat] run 기능 추가

### DIFF
--- a/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
+++ b/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
@@ -1,6 +1,7 @@
 package com.back.domain.battle.battleroom.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,11 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
-import com.back.domain.battle.battleroom.dto.JoinRoomRequest;
 import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
 import com.back.domain.battle.battleroom.dto.RoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.service.MatchingQueueService;
+import com.back.global.security.SecurityUser;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,11 +35,12 @@ public class BattleRoomController {
     }
 
     @PostMapping("/{roomId}/join")
-    public JoinRoomResponse joinRoom(@PathVariable Long roomId, @RequestBody JoinRoomRequest request) {
-        JoinRoomResponse response = battleRoomService.joinRoom(roomId, request.memberId());
+    public JoinRoomResponse joinRoom(@PathVariable Long roomId, @AuthenticationPrincipal SecurityUser securityUser) {
+        Long memberId = securityUser.getId();
+        JoinRoomResponse response = battleRoomService.joinRoom(roomId, memberId);
 
         // 이 유저는 이제 실제로 방 입장까지 끝났으므로 매칭 결과 정리
-        matchingQueueService.clearMatchedRoom(request.memberId(), roomId);
+        matchingQueueService.clearMatchedRoom(memberId, roomId);
         return response;
     }
 

--- a/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
+++ b/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
@@ -1,7 +1,6 @@
 package com.back.domain.battle.battleroom.controller;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,7 +15,7 @@ import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
 import com.back.domain.battle.battleroom.dto.RoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.service.MatchingQueueService;
-import com.back.global.security.SecurityUser;
+import com.back.global.rq.Rq;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,6 +26,7 @@ public class BattleRoomController {
 
     private final BattleRoomService battleRoomService;
     private final MatchingQueueService matchingQueueService;
+    private final Rq rq;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -35,8 +35,8 @@ public class BattleRoomController {
     }
 
     @PostMapping("/{roomId}/join")
-    public JoinRoomResponse joinRoom(@PathVariable Long roomId, @AuthenticationPrincipal SecurityUser securityUser) {
-        Long memberId = securityUser.getId();
+    public JoinRoomResponse joinRoom(@PathVariable Long roomId) {
+        Long memberId = rq.getActor().getId();
         JoinRoomResponse response = battleRoomService.joinRoom(roomId, memberId);
 
         // 이 유저는 이제 실제로 방 입장까지 끝났으므로 매칭 결과 정리

--- a/src/main/java/com/back/domain/battle/battleroom/dto/JoinRoomRequest.java
+++ b/src/main/java/com/back/domain/battle/battleroom/dto/JoinRoomRequest.java
@@ -1,7 +1,0 @@
-package com.back.domain.battle.battleroom.dto;
-
-/**
- * 임시: Security 미연동 상태에서 memberId를 body로 받음
- * TODO: Security 연동 후 @AuthenticationPrincipal로 교체
- */
-public record JoinRoomRequest(Long memberId) {}

--- a/src/main/java/com/back/domain/problem/run/controller/RunController.java
+++ b/src/main/java/com/back/domain/problem/run/controller/RunController.java
@@ -1,0 +1,29 @@
+package com.back.domain.problem.run.controller;
+
+import java.util.Map;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.problem.run.dto.RunRequest;
+import com.back.domain.problem.run.service.RunService;
+import com.back.global.security.SecurityUser;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/run")
+@RequiredArgsConstructor
+public class RunController {
+
+    private final RunService runService;
+
+    @PostMapping
+    public Map<String, String> run(
+            @RequestBody RunRequest request, @AuthenticationPrincipal SecurityUser securityUser) {
+        return runService.run(request, securityUser.getId());
+    }
+}

--- a/src/main/java/com/back/domain/problem/run/controller/RunController.java
+++ b/src/main/java/com/back/domain/problem/run/controller/RunController.java
@@ -2,7 +2,6 @@ package com.back.domain.problem.run.controller;
 
 import java.util.Map;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.problem.run.dto.RunRequest;
 import com.back.domain.problem.run.service.RunService;
-import com.back.global.security.SecurityUser;
+import com.back.global.rq.Rq;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,10 +19,10 @@ import lombok.RequiredArgsConstructor;
 public class RunController {
 
     private final RunService runService;
+    private final Rq rq;
 
     @PostMapping
-    public Map<String, String> run(
-            @RequestBody RunRequest request, @AuthenticationPrincipal SecurityUser securityUser) {
-        return runService.run(request, securityUser.getId());
+    public Map<String, String> run(@RequestBody RunRequest request) {
+        return runService.run(request, rq.getActor().getId());
     }
 }

--- a/src/main/java/com/back/domain/problem/run/dto/RunRequest.java
+++ b/src/main/java/com/back/domain/problem/run/dto/RunRequest.java
@@ -1,0 +1,3 @@
+package com.back.domain.problem.run.dto;
+
+public record RunRequest(Long roomId, String code, String language) {}

--- a/src/main/java/com/back/domain/problem/run/dto/RunTestCaseResult.java
+++ b/src/main/java/com/back/domain/problem/run/dto/RunTestCaseResult.java
@@ -1,0 +1,4 @@
+package com.back.domain.problem.run.dto;
+
+public record RunTestCaseResult(
+        String input, String expectedOutput, String actualOutput, String status, String stderr) {}

--- a/src/main/java/com/back/domain/problem/run/service/RunService.java
+++ b/src/main/java/com/back/domain/problem/run/service/RunService.java
@@ -1,0 +1,54 @@
+package com.back.domain.problem.run.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.problem.run.dto.RunRequest;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.event.RunRequestedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RunService {
+
+    private final BattleRoomRepository battleRoomRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public Map<String, String> run(RunRequest request, Long memberId) {
+
+        // 1. BattleRoom 조회 + PLAYING 상태 검증 + 타이머 만료 검증
+        BattleRoom room = battleRoomRepository
+                .findById(request.roomId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+
+        if (room.getStatus() != BattleRoomStatus.PLAYING) {
+            throw new IllegalStateException("진행 중인 배틀이 아닙니다. 현재 상태: " + room.getStatus());
+        }
+
+        if (room.isExpired()) {
+            throw new IllegalStateException("배틀 시간이 종료되었습니다.");
+        }
+
+        // 2. 샘플 테스트케이스만 필터링 (isSample=true)
+        // new ArrayList<>()로 강제 초기화: PersistentBag을 트랜잭션 안에서 일반 List로 변환
+        List<TestCase> sampleTestCases = new ArrayList<>(room.getProblem().getTestCases())
+                .stream().filter(tc -> Boolean.TRUE.equals(tc.getIsSample())).toList();
+
+        // 3. 이벤트 발행 → 트랜잭션 커밋 후 비동기 실행 → 즉시 RUNNING 응답
+        eventPublisher.publishEvent(
+                new RunRequestedEvent(room.getId(), memberId, request.code(), request.language(), sampleTestCases));
+
+        return Map.of("message", "RUNNING");
+    }
+}

--- a/src/main/java/com/back/domain/problem/submission/controller/SubmissionController.java
+++ b/src/main/java/com/back/domain/problem/submission/controller/SubmissionController.java
@@ -1,6 +1,7 @@
 package com.back.domain.problem.submission.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.back.domain.problem.submission.dto.SubmissionResponse;
 import com.back.domain.problem.submission.dto.SubmitRequest;
 import com.back.domain.problem.submission.service.SubmissionService;
+import com.back.global.security.SecurityUser;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,7 +24,8 @@ public class SubmissionController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public SubmissionResponse submit(@RequestBody SubmitRequest request) {
-        return submissionService.submit(request);
+    public SubmissionResponse submit(
+            @RequestBody SubmitRequest request, @AuthenticationPrincipal SecurityUser securityUser) {
+        return submissionService.submit(request, securityUser.getId());
     }
 }

--- a/src/main/java/com/back/domain/problem/submission/controller/SubmissionController.java
+++ b/src/main/java/com/back/domain/problem/submission/controller/SubmissionController.java
@@ -1,7 +1,6 @@
 package com.back.domain.problem.submission.controller;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.back.domain.problem.submission.dto.SubmissionResponse;
 import com.back.domain.problem.submission.dto.SubmitRequest;
 import com.back.domain.problem.submission.service.SubmissionService;
-import com.back.global.security.SecurityUser;
+import com.back.global.rq.Rq;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,11 +20,11 @@ import lombok.RequiredArgsConstructor;
 public class SubmissionController {
 
     private final SubmissionService submissionService;
+    private final Rq rq;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public SubmissionResponse submit(
-            @RequestBody SubmitRequest request, @AuthenticationPrincipal SecurityUser securityUser) {
-        return submissionService.submit(request, securityUser.getId());
+    public SubmissionResponse submit(@RequestBody SubmitRequest request) {
+        return submissionService.submit(request, rq.getActor().getId());
     }
 }

--- a/src/main/java/com/back/domain/problem/submission/dto/SubmitRequest.java
+++ b/src/main/java/com/back/domain/problem/submission/dto/SubmitRequest.java
@@ -1,7 +1,3 @@
 package com.back.domain.problem.submission.dto;
 
-/**
- * 임시: Security 미연동 상태에서 memberId를 body로 받음
- * TODO: Security 연동 후 @AuthenticationPrincipal로 교체
- */
-public record SubmitRequest(Long roomId, Long memberId, String code, String language) {}
+public record SubmitRequest(Long roomId, String code, String language) {}

--- a/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
+++ b/src/main/java/com/back/domain/problem/submission/service/SubmissionService.java
@@ -35,7 +35,7 @@ public class SubmissionService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public SubmissionResponse submit(SubmitRequest request) {
+    public SubmissionResponse submit(SubmitRequest request, Long memberId) {
 
         // 1. BattleRoom 조회 + PLAYING 상태 검증 + 타이머 만료 검증
         BattleRoom room = battleRoomRepository
@@ -51,9 +51,8 @@ public class SubmissionService {
         }
 
         // 2. Member 조회
-        Member member = memberRepository
-                .findById(request.memberId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        Member member =
+                memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
         // 3. BattleParticipant 조회 + 제출 가능 상태(PLAYING) 검증
         BattleParticipant participant = battleParticipantRepository

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -77,6 +77,8 @@ public class JudgeService {
         } else { // 테스트 케이스가 1개 이상의 경우
             int languageId = getLanguageId(language);
 
+            // TODO: 함수형 코드 지원 시 driverCode 합치기
+            // String fullCode = code + "\n" + problem.getDriverCode().get(language);
             // 배치 요청 구성
             List<Judge0SubmitRequest> batchRequests = testCases.stream()
                     .map(tc -> new Judge0SubmitRequest(

--- a/src/main/java/com/back/global/judge/RunJudgeService.java
+++ b/src/main/java/com/back/global/judge/RunJudgeService.java
@@ -1,0 +1,137 @@
+package com.back.global.judge;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.back.domain.problem.run.dto.RunTestCaseResult;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.dto.Judge0SubmitRequest;
+import com.back.global.judge.dto.Judge0SubmitResponse;
+import com.back.global.judge.event.RunRequestedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RunJudgeService {
+
+    private static final int MAX_POLL_ATTEMPTS = 10;
+    private static final int POLL_INTERVAL_MS = 1000;
+
+    private final Judge0Client judge0Client;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onRunRequested(RunRequestedEvent event) {
+        run(event.roomId(), event.memberId(), event.code(), event.language(), event.testCases());
+    }
+
+    private void run(Long roomId, Long memberId, String code, String language, List<TestCase> testCases) {
+
+        List<RunTestCaseResult> results;
+
+        if (testCases.isEmpty()) {
+            log.warn("Run request for room {} has no sample test cases", roomId);
+            results = List.of();
+        } else {
+            int languageId = getLanguageId(language);
+
+            // TODO: 함수형 코드 지원 시 driverCode 합치기
+            // String fullCode = code + "\n" + problem.getDriverCode().get(language);
+            List<Judge0SubmitRequest> batchRequests = testCases.stream()
+                    .map(tc -> new Judge0SubmitRequest(
+                            code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
+                    .toList();
+
+            List<Judge0SubmitResponse> judgeResponses = runJudge(batchRequests);
+
+            results = buildResults(testCases, judgeResponses);
+        }
+
+        // WebSocket: 케이스별 실행 결과 push
+        messagingTemplate.convertAndSend(
+                "/topic/room/" + roomId + "/run",
+                Map.of(
+                        "type", "RUN_RESULT",
+                        "userId", memberId,
+                        "results", results));
+    }
+
+    private List<RunTestCaseResult> buildResults(List<TestCase> testCases, List<Judge0SubmitResponse> judgeResponses) {
+
+        // 폴링 타임아웃 등으로 결과가 없을 경우 전체 RE 처리
+        if (judgeResponses.isEmpty()) {
+            return testCases.stream()
+                    .map(tc ->
+                            new RunTestCaseResult(tc.getInput(), tc.getExpectedOutput(), null, "RE", "실행 시간이 초과되었습니다."))
+                    .toList();
+        }
+
+        return java.util.stream.IntStream.range(0, testCases.size())
+                .mapToObj(i -> {
+                    TestCase tc = testCases.get(i);
+                    if (i >= judgeResponses.size()) {
+                        return new RunTestCaseResult(tc.getInput(), tc.getExpectedOutput(), null, "RE", null);
+                    }
+                    Judge0SubmitResponse r = judgeResponses.get(i);
+                    String status = resolveStatus(r);
+                    String actualOutput = r.stdout() != null ? r.stdout().stripTrailing() : null;
+                    String stderr = r.stderr() != null ? r.stderr() : r.compileOutput();
+                    return new RunTestCaseResult(tc.getInput(), tc.getExpectedOutput(), actualOutput, status, stderr);
+                })
+                .toList();
+    }
+
+    private String resolveStatus(Judge0SubmitResponse r) {
+        if (r.status() == null) return "RE";
+        return switch (r.status().id()) {
+            case 3 -> "AC";
+            case 4 -> "WA";
+            case 5 -> "TLE";
+            case 6 -> "CE";
+            default -> "RE";
+        };
+    }
+
+    private List<Judge0SubmitResponse> runJudge(List<Judge0SubmitRequest> batchRequests) {
+        try {
+            List<String> tokens = judge0Client.submitBatch(batchRequests);
+            for (int i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+                List<Judge0SubmitResponse> results = judge0Client.getBatchResults(tokens);
+                if (results.stream().allMatch(Judge0SubmitResponse::isCompleted)) {
+                    return results;
+                }
+                Thread.sleep(POLL_INTERVAL_MS);
+            }
+            log.warn("Judge0 run polling timed out after {} attempts", MAX_POLL_ATTEMPTS);
+            return List.of();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Judge0 run polling interrupted", e);
+            return List.of();
+        } catch (Exception e) {
+            log.error("Judge0 run failed", e);
+            return List.of();
+        }
+    }
+
+    private int getLanguageId(String language) {
+        return switch (language.toLowerCase()) {
+            case "python", "python3" -> 71;
+            case "java" -> 62;
+            case "cpp", "c++" -> 54;
+            case "c" -> 50;
+            case "javascript", "js" -> 63;
+            default -> throw new IllegalArgumentException("지원하지 않는 언어: " + language);
+        };
+    }
+}

--- a/src/main/java/com/back/global/judge/event/RunRequestedEvent.java
+++ b/src/main/java/com/back/global/judge/event/RunRequestedEvent.java
@@ -1,0 +1,7 @@
+package com.back.global.judge.event;
+
+import java.util.List;
+
+import com.back.domain.problem.testcase.entity.TestCase;
+
+public record RunRequestedEvent(Long roomId, Long memberId, String code, String language, List<TestCase> testCases) {}

--- a/src/main/java/com/back/global/websocket/BattleWebSocketHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleWebSocketHandler.java
@@ -5,8 +5,10 @@ import java.util.Map;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
+import com.back.global.security.SecurityUser;
 import com.back.global.websocket.dto.CodeUpdateMessage;
 
 import lombok.RequiredArgsConstructor;
@@ -20,19 +22,21 @@ public class BattleWebSocketHandler {
     /**
      * 참여자가 코드 변경 시 호출
      * STOMP SEND /app/room/{roomId}/code
-     * Body: { "userId": 1, "code": "..." }
+     * Body: { "code": "..." }
      *
      * 관전자 채널로만 브로드캐스트 (참여자끼리는 서로 코드 못 봄)
-     * TODO: Security 연동 후 userId를 Principal에서 추출하도록 변경
      */
     @MessageMapping("/room/{roomId}/code")
-    public void handleCodeUpdate(@DestinationVariable Long roomId, CodeUpdateMessage message) {
+    public void handleCodeUpdate(
+            @DestinationVariable Long roomId,
+            CodeUpdateMessage message,
+            @AuthenticationPrincipal SecurityUser securityUser) {
 
         messagingTemplate.convertAndSend(
                 "/topic/room/" + roomId + "/spectate",
                 Map.of(
                         "type", "CODE_UPDATE",
-                        "userId", message.userId(),
+                        "userId", securityUser.getId(),
                         "code", message.code()));
     }
 }

--- a/src/main/java/com/back/global/websocket/dto/CodeUpdateMessage.java
+++ b/src/main/java/com/back/global/websocket/dto/CodeUpdateMessage.java
@@ -1,7 +1,3 @@
 package com.back.global.websocket.dto;
 
-/**
- * 참여자가 코드 변경 시 서버로 전송하는 메시지
- * TODO: Security 연동 후 userId 제거하고 Principal에서 추출
- */
-public record CodeUpdateMessage(Long userId, String code) {}
+public record CodeUpdateMessage(String code) {}

--- a/src/test/java/com/back/global/judge/JudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/JudgeServiceTest.java
@@ -1,0 +1,281 @@
+package com.back.global.judge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.submission.entity.Submission;
+import com.back.domain.problem.submission.entity.SubmissionResult;
+import com.back.domain.problem.submission.repository.SubmissionRepository;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.dto.Judge0SubmitResponse;
+import com.back.global.judge.dto.Judge0SubmitResponse.Status;
+import com.back.global.judge.event.JudgeRequestedEvent;
+
+class JudgeServiceTest {
+
+    private final Judge0Client judge0Client = mock(Judge0Client.class);
+    private final SubmissionRepository submissionRepository = mock(SubmissionRepository.class);
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+
+    private final JudgeService judgeService = new JudgeService(
+            judge0Client,
+            submissionRepository,
+            battleParticipantRepository,
+            battleRoomRepository,
+            memberRepository,
+            battleResultService,
+            messagingTemplate);
+
+    private static final Long SUBMISSION_ID = 1L;
+    private static final Long ROOM_ID = 10L;
+    private static final Long MEMBER_ID = 100L;
+
+    private Submission submission;
+    private BattleRoom room;
+    private Member member;
+    private BattleParticipant participant;
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+    @BeforeEach
+    void setUp() {
+        submission = Submission.create(mock(BattleRoom.class), mock(Member.class), "code", "python");
+        room = mock(BattleRoom.class);
+        member = mock(Member.class);
+        participant = mock(BattleParticipant.class);
+
+        when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
+    }
+
+    private TestCase mockTestCase(String input, String expectedOutput) {
+        TestCase tc = mock(TestCase.class);
+        when(tc.getInput()).thenReturn(input);
+        when(tc.getExpectedOutput()).thenReturn(expectedOutput);
+        return tc;
+    }
+
+    private Judge0SubmitResponse response(int statusId, String stdout) {
+        return new Judge0SubmitResponse("token", new Status(statusId, ""), stdout, null, null, null);
+    }
+
+    private void stubJudge0(Judge0SubmitResponse... responses) {
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any())).thenReturn(List.of(responses));
+    }
+
+    /** AC 흐름에서 필요한 handleAc() 관련 Mock 설정 */
+    private void stubHandleAc(List<BattleParticipant> allParticipants) {
+        when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+        when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
+                .thenReturn(Optional.of(participant));
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(allParticipants);
+    }
+
+    private JudgeRequestedEvent event(List<TestCase> testCases) {
+        return new JudgeRequestedEvent(SUBMISSION_ID, ROOM_ID, MEMBER_ID, "code", "python", testCases);
+    }
+
+    // ── 채점 결과 저장 ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("전체 통과 시 submission result가 AC로 저장된다")
+    void judge_allPass_savedAsAc() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(3, "3\n"));
+
+        BattleParticipant exitParticipant = mock(BattleParticipant.class);
+        when(exitParticipant.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        stubHandleAc(List.of(exitParticipant));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        assertThat(submission.getResult()).isEqualTo(SubmissionResult.AC);
+        assertThat(submission.getPassedCount()).isEqualTo(1);
+        assertThat(submission.getTotalCount()).isEqualTo(1);
+        verify(submissionRepository).save(submission);
+    }
+
+    @Test
+    @DisplayName("오답이면 submission result가 WA로 저장된다")
+    void judge_wrongAnswer_savedAsWa() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(4, "5\n"));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        assertThat(submission.getResult()).isEqualTo(SubmissionResult.WA);
+        assertThat(submission.getPassedCount()).isEqualTo(0);
+        verify(submissionRepository).save(submission);
+    }
+
+    @Test
+    @DisplayName("컴파일 에러면 submission result가 CE로 저장된다")
+    void judge_compileError_savedAsCe() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(6, null));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        assertThat(submission.getResult()).isEqualTo(SubmissionResult.CE);
+        verify(submissionRepository).save(submission);
+    }
+
+    @Test
+    @DisplayName("시간 초과면 submission result가 TLE로 저장된다")
+    void judge_timeLimitExceeded_savedAsTle() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(5, null));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        assertThat(submission.getResult()).isEqualTo(SubmissionResult.TLE);
+        verify(submissionRepository).save(submission);
+    }
+
+    @Test
+    @DisplayName("런타임 에러면 submission result가 RE로 저장된다")
+    void judge_runtimeError_savedAsRe() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(11, null));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        assertThat(submission.getResult()).isEqualTo(SubmissionResult.RE);
+        verify(submissionRepository).save(submission);
+    }
+
+    @Test
+    @DisplayName("테스트케이스가 없으면 submission result가 WA로 저장된다")
+    void judge_noTestCases_savedAsWa() {
+        judgeService.onJudgeRequested(event(List.of()));
+
+        assertThat(submission.getResult()).isEqualTo(SubmissionResult.WA);
+        verify(submissionRepository).save(submission);
+    }
+
+    @Test
+    @DisplayName("Judge0 폴링 타임아웃 시 submission result가 RE로 저장된다")
+    void judge_judge0Timeout_savedAsRe() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(1, null))); // 미완료 상태
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        assertThat(submission.getResult()).isEqualTo(SubmissionResult.RE);
+        verify(submissionRepository).save(submission);
+    }
+
+    // ── AC 처리 (handleAc) ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("AC이면 participant가 complete() 처리되고 저장된다")
+    void judge_ac_participantCompleted() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(3, "3\n"));
+
+        BattleParticipant exitParticipant = mock(BattleParticipant.class);
+        when(exitParticipant.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        stubHandleAc(List.of(exitParticipant));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        verify(participant).complete(any());
+        verify(battleParticipantRepository).save(participant);
+    }
+
+    @Test
+    @DisplayName("AC가 아니면 participant 상태 변경이 없다")
+    void judge_notAc_participantNotChanged() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(4, "5\n")); // WA
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        verify(battleParticipantRepository, never()).save(any());
+        verify(battleResultService, never()).settle(any());
+    }
+
+    @Test
+    @DisplayName("AC이고 전원 완료 시 배틀 정산이 호출된다")
+    void judge_ac_allFinished_settlesCalled() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(3, "3\n"));
+
+        BattleParticipant p1 = mock(BattleParticipant.class);
+        BattleParticipant p2 = mock(BattleParticipant.class);
+        when(p1.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(p2.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        stubHandleAc(List.of(p1, p2));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        verify(battleResultService).settle(ROOM_ID);
+    }
+
+    @Test
+    @DisplayName("AC이지만 아직 남은 참여자가 있으면 배틀 정산이 호출되지 않는다")
+    void judge_ac_notAllFinished_settlesNotCalled() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(3, "3\n"));
+
+        BattleParticipant p1 = mock(BattleParticipant.class);
+        BattleParticipant p2 = mock(BattleParticipant.class);
+        when(p1.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(p2.getStatus()).thenReturn(BattleParticipantStatus.PLAYING); // 아직 풀이 중
+        stubHandleAc(List.of(p1, p2));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        verify(battleResultService, never()).settle(any());
+    }
+
+    // ── WebSocket 브로드캐스트 ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("채점 완료 후 SUBMISSION 타입으로 WebSocket 브로드캐스트된다")
+    void judge_broadcastsSubmissionResult() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(4, "5\n")); // WA
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/room/" + ROOM_ID), captor.capture());
+
+        Map<String, Object> message = captor.getValue();
+        assertThat(message.get("type")).isEqualTo("SUBMISSION");
+        assertThat(message.get("userId")).isEqualTo(MEMBER_ID);
+        assertThat(message.get("result")).isEqualTo("WA");
+        assertThat(message.get("passedCount")).isEqualTo(0);
+        assertThat(message.get("totalCount")).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/back/global/judge/RunJudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/RunJudgeServiceTest.java
@@ -1,0 +1,201 @@
+package com.back.global.judge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.back.domain.problem.run.dto.RunTestCaseResult;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.dto.Judge0SubmitResponse;
+import com.back.global.judge.dto.Judge0SubmitResponse.Status;
+import com.back.global.judge.event.RunRequestedEvent;
+
+class RunJudgeServiceTest {
+
+    private final Judge0Client judge0Client = mock(Judge0Client.class);
+    private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+
+    private final RunJudgeService runJudgeService = new RunJudgeService(judge0Client, messagingTemplate);
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+    private TestCase mockTestCase(String input, String expectedOutput) {
+        TestCase tc = mock(TestCase.class);
+        when(tc.getInput()).thenReturn(input);
+        when(tc.getExpectedOutput()).thenReturn(expectedOutput);
+        when(tc.getIsSample()).thenReturn(true);
+        return tc;
+    }
+
+    private Judge0SubmitResponse response(int statusId, String stdout, String stderr, String compileOutput) {
+        return new Judge0SubmitResponse("token", new Status(statusId, ""), stdout, stderr, compileOutput, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<RunTestCaseResult> captureResults() {
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(messagingTemplate).convertAndSend(any(String.class), captor.capture());
+        return (List<RunTestCaseResult>) captor.getValue().get("results");
+    }
+
+    // ── 정상 케이스 ───────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("정답이면 status AC, actualOutput이 stdout으로 채워진다")
+    void run_ac() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(3, "3\n", null, null)));
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "print(3)", "python", List.of(tc)));
+
+        List<RunTestCaseResult> results = captureResults();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).status()).isEqualTo("AC");
+        assertThat(results.get(0).actualOutput()).isEqualTo("3");
+        assertThat(results.get(0).input()).isEqualTo("1 2");
+        assertThat(results.get(0).expectedOutput()).isEqualTo("3");
+    }
+
+    @Test
+    @DisplayName("출력이 다르면 status WA")
+    void run_wa() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(4, "5\n", null, null)));
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "print(5)", "python", List.of(tc)));
+
+        List<RunTestCaseResult> results = captureResults();
+        assertThat(results.get(0).status()).isEqualTo("WA");
+        assertThat(results.get(0).actualOutput()).isEqualTo("5");
+    }
+
+    @Test
+    @DisplayName("컴파일 에러면 status CE, stderr에 compileOutput이 담긴다")
+    void run_ce() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any()))
+                .thenReturn(List.of(response(6, null, null, "SyntaxError: invalid syntax")));
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "prnit(3)", "python", List.of(tc)));
+
+        List<RunTestCaseResult> results = captureResults();
+        assertThat(results.get(0).status()).isEqualTo("CE");
+        assertThat(results.get(0).stderr()).isEqualTo("SyntaxError: invalid syntax");
+    }
+
+    @Test
+    @DisplayName("시간 초과면 status TLE")
+    void run_tle() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(5, null, null, null)));
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "while True: pass", "python", List.of(tc)));
+
+        List<RunTestCaseResult> results = captureResults();
+        assertThat(results.get(0).status()).isEqualTo("TLE");
+    }
+
+    @Test
+    @DisplayName("런타임 에러면 status RE, stderr가 채워진다")
+    void run_re() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(11, null, "ZeroDivisionError", null)));
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "print(1/0)", "python", List.of(tc)));
+
+        List<RunTestCaseResult> results = captureResults();
+        assertThat(results.get(0).status()).isEqualTo("RE");
+        assertThat(results.get(0).stderr()).isEqualTo("ZeroDivisionError");
+    }
+
+    @Test
+    @DisplayName("여러 케이스 중 일부만 통과해도 케이스별 개별 status를 반환한다")
+    void run_mixed_results() {
+        TestCase tc1 = mockTestCase("1 2", "3");
+        TestCase tc2 = mockTestCase("5 7", "12");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token1", "token2"));
+        when(judge0Client.getBatchResults(any()))
+                .thenReturn(List.of(response(3, "3\n", null, null), response(4, "13\n", null, null)));
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "code", "python", List.of(tc1, tc2)));
+
+        List<RunTestCaseResult> results = captureResults();
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).status()).isEqualTo("AC");
+        assertThat(results.get(1).status()).isEqualTo("WA");
+        assertThat(results.get(1).actualOutput()).isEqualTo("13");
+    }
+
+    // ── 예외 케이스 ───────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("샘플 테스트케이스가 없으면 빈 results를 WebSocket으로 전송한다")
+    void run_noTestCases() {
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "code", "python", List.of()));
+
+        List<RunTestCaseResult> results = captureResults();
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Judge0 폴링 타임아웃 시 전체 케이스를 RE로 반환한다")
+    void run_judge0Timeout() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        // 계속 미완료 상태 반환 → 타임아웃
+        when(judge0Client.getBatchResults(any()))
+                .thenReturn(List.of(response(1, null, null, null))); // status 1 = In Queue (미완료)
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "code", "python", List.of(tc)));
+
+        List<RunTestCaseResult> results = captureResults();
+        assertThat(results.get(0).status()).isEqualTo("RE");
+    }
+
+    // ── WebSocket 전송 검증 ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("결과는 /topic/room/{roomId}/run 토픽으로 전송된다")
+    void run_sendsToCorrectTopic() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(3, "3\n", null, null)));
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(42L, 1L, "code", "python", List.of(tc)));
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/room/42/run"), any(Object.class));
+    }
+
+    @Test
+    @DisplayName("WebSocket 메시지 type은 RUN_RESULT, userId가 포함된다")
+    void run_messageContainsTypeAndUserId() {
+        TestCase tc = mockTestCase("1 2", "3");
+        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
+        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(3, "3\n", null, null)));
+
+        runJudgeService.onRunRequested(new RunRequestedEvent(1L, 99L, "code", "python", List.of(tc)));
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(messagingTemplate).convertAndSend(any(String.class), captor.capture());
+
+        Map<String, Object> message = captor.getValue();
+        assertThat(message.get("type")).isEqualTo("RUN_RESULT");
+        assertThat(message.get("userId")).isEqualTo(99L);
+    }
+}


### PR DESCRIPTION
```java
POST /api/v1/run
  ↓
RunService
  ├─ BattleRoom, Member 조회
  ├─ 샘플 테스트케이스 로드
  └─ PublishEvent(RunRequestedEvent) → 즉시 200 반환
  ↓
[After Transaction Commit - Async]
RunJudgeService.onRunRequested()
  ├─ Judge0Client.submitBatch()
  ├─ 폴링 (최대 10회)
  ├─ 케이스별 결과 집계
  └─ WebSocket push → /topic/room/{roomId}/run

Submit과 다른 점:
- Submission 엔티티 저장 없음
- 게임 상태 변경 없음 (handleAc() 호출 없음)
- 결과 형식: 전체 pass/fail 대신 케이스별 상세 결과
```