### PR TITLE
[feat] solo run과 submission

### DIFF
--- a/src/main/java/com/back/domain/problem/solo/run/controller/SoloRunController.java
+++ b/src/main/java/com/back/domain/problem/solo/run/controller/SoloRunController.java
@@ -1,0 +1,28 @@
+package com.back.domain.problem.solo.run.controller;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.problem.solo.run.dto.SoloRunRequest;
+import com.back.domain.problem.solo.run.service.SoloRunService;
+import com.back.global.rq.Rq;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/solo/run")
+@RequiredArgsConstructor
+public class SoloRunController {
+
+    private final SoloRunService soloRunService;
+    private final Rq rq;
+
+    @PostMapping
+    public Map<String, String> run(@RequestBody SoloRunRequest request) {
+        return soloRunService.run(request, rq.getActor().getId());
+    }
+}

--- a/src/main/java/com/back/domain/problem/solo/run/dto/SoloRunRequest.java
+++ b/src/main/java/com/back/domain/problem/solo/run/dto/SoloRunRequest.java
@@ -1,0 +1,3 @@
+package com.back.domain.problem.solo.run.dto;
+
+public record SoloRunRequest(Long problemId, String code, String language) {}

--- a/src/main/java/com/back/domain/problem/solo/run/service/SoloRunService.java
+++ b/src/main/java/com/back/domain/problem/solo/run/service/SoloRunService.java
@@ -1,0 +1,42 @@
+package com.back.domain.problem.solo.run.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.domain.problem.solo.run.dto.SoloRunRequest;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.event.SoloRunRequestedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SoloRunService {
+
+    private final ProblemRepository problemRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public Map<String, String> run(SoloRunRequest request, Long memberId) {
+
+        Problem problem = problemRepository
+                .findById(request.problemId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 문제입니다."));
+
+        // 샘플 테스트케이스만 필터링 (isSample=true)
+        List<TestCase> sampleTestCases = new ArrayList<>(problem.getTestCases())
+                .stream().filter(tc -> Boolean.TRUE.equals(tc.getIsSample())).toList();
+
+        eventPublisher.publishEvent(
+                new SoloRunRequestedEvent(memberId, request.code(), request.language(), sampleTestCases));
+
+        return Map.of("message", "RUNNING");
+    }
+}

--- a/src/main/java/com/back/domain/problem/solo/submission/controller/SoloSubmissionController.java
+++ b/src/main/java/com/back/domain/problem/solo/submission/controller/SoloSubmissionController.java
@@ -1,0 +1,30 @@
+package com.back.domain.problem.solo.submission.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.problem.solo.submission.dto.SoloSubmitRequest;
+import com.back.domain.problem.solo.submission.service.SoloSubmissionService;
+import com.back.domain.problem.submission.dto.SubmissionResponse;
+import com.back.global.rq.Rq;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/solo/submissions")
+@RequiredArgsConstructor
+public class SoloSubmissionController {
+
+    private final SoloSubmissionService soloSubmissionService;
+    private final Rq rq;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SubmissionResponse submit(@RequestBody SoloSubmitRequest request) {
+        return soloSubmissionService.submit(request, rq.getActor().getId());
+    }
+}

--- a/src/main/java/com/back/domain/problem/solo/submission/dto/SoloSubmitRequest.java
+++ b/src/main/java/com/back/domain/problem/solo/submission/dto/SoloSubmitRequest.java
@@ -1,0 +1,3 @@
+package com.back.domain.problem.solo.submission.dto;
+
+public record SoloSubmitRequest(Long problemId, String code, String language) {}

--- a/src/main/java/com/back/domain/problem/solo/submission/entity/SoloSubmission.java
+++ b/src/main/java/com/back/domain/problem/solo/submission/entity/SoloSubmission.java
@@ -1,0 +1,57 @@
+package com.back.domain.problem.solo.submission.entity;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.submission.entity.SubmissionResult;
+import com.back.global.jpa.entity.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "solo_submissions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SoloSubmission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "solo_submission_seq_gen")
+    @SequenceGenerator(name = "solo_submission_seq_gen", sequenceName = "solo_submission_id_seq", allocationSize = 50)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+
+    @Column(columnDefinition = "TEXT")
+    private String code;
+
+    private String language;
+
+    @Enumerated(EnumType.STRING)
+    private SubmissionResult result;
+
+    private Integer passedCount;
+    private Integer totalCount;
+
+    public static SoloSubmission create(Member member, Problem problem, String code, String language) {
+        SoloSubmission s = new SoloSubmission();
+        s.member = member;
+        s.problem = problem;
+        s.code = code;
+        s.language = language;
+        return s;
+    }
+
+    public void applyJudgeResult(SubmissionResult result, int passedCount, int totalCount) {
+        this.result = result;
+        this.passedCount = passedCount;
+        this.totalCount = totalCount;
+    }
+}

--- a/src/main/java/com/back/domain/problem/solo/submission/repository/SoloSubmissionRepository.java
+++ b/src/main/java/com/back/domain/problem/solo/submission/repository/SoloSubmissionRepository.java
@@ -1,0 +1,7 @@
+package com.back.domain.problem.solo.submission.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.problem.solo.submission.entity.SoloSubmission;
+
+public interface SoloSubmissionRepository extends JpaRepository<SoloSubmission, Long> {}

--- a/src/main/java/com/back/domain/problem/solo/submission/service/SoloSubmissionService.java
+++ b/src/main/java/com/back/domain/problem/solo/submission/service/SoloSubmissionService.java
@@ -1,0 +1,53 @@
+package com.back.domain.problem.solo.submission.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.domain.problem.solo.submission.dto.SoloSubmitRequest;
+import com.back.domain.problem.solo.submission.entity.SoloSubmission;
+import com.back.domain.problem.solo.submission.repository.SoloSubmissionRepository;
+import com.back.domain.problem.submission.dto.SubmissionResponse;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.event.SoloJudgeRequestedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SoloSubmissionService {
+
+    private final ProblemRepository problemRepository;
+    private final MemberRepository memberRepository;
+    private final SoloSubmissionRepository soloSubmissionRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public SubmissionResponse submit(SoloSubmitRequest request, Long memberId) {
+
+        Problem problem = problemRepository
+                .findById(request.problemId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 문제입니다."));
+
+        Member member =
+                memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        SoloSubmission submission = SoloSubmission.create(member, problem, request.code(), request.language());
+        soloSubmissionRepository.save(submission);
+
+        // 전체 테스트케이스 로드 (숨김 포함)
+        List<TestCase> testCases = new ArrayList<>(problem.getTestCases());
+
+        eventPublisher.publishEvent(new SoloJudgeRequestedEvent(
+                submission.getId(), memberId, request.code(), request.language(), testCases));
+
+        return new SubmissionResponse(submission.getId(), "JUDGING", 0, 0);
+    }
+}

--- a/src/main/java/com/back/domain/problem/submission/entity/SubmissionResult.java
+++ b/src/main/java/com/back/domain/problem/submission/entity/SubmissionResult.java
@@ -6,5 +6,6 @@ public enum SubmissionResult {
     TLE, // Time Limit Exceeded
     MLE, // Memory Limit Exceeded
     RE, // Runtime Error
-    CE // Compile Error
+    CE, // Compile Error
+    JUDGE_ERROR // Judge0 서버 오류 (타임아웃, 연결 실패 등)
 }

--- a/src/main/java/com/back/global/judge/Judge0ExecutionService.java
+++ b/src/main/java/com/back/global/judge/Judge0ExecutionService.java
@@ -1,0 +1,59 @@
+package com.back.global.judge;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.back.global.judge.dto.Judge0SubmitRequest;
+import com.back.global.judge.dto.Judge0SubmitResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class Judge0ExecutionService {
+
+    private static final int MAX_POLL_ATTEMPTS = 10;
+    private static final int POLL_INTERVAL_MS = 1000;
+
+    private final Judge0Client judge0Client;
+
+    /**
+     * Judge0에 배치 제출 후 폴링하여 결과 반환.
+     * 타임아웃(10초) 또는 오류 시 빈 리스트 반환.
+     */
+    public List<Judge0SubmitResponse> execute(List<Judge0SubmitRequest> batchRequests) {
+        try {
+            List<String> tokens = judge0Client.submitBatch(batchRequests);
+            for (int i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+                List<Judge0SubmitResponse> results = judge0Client.getBatchResults(tokens);
+                if (results.stream().allMatch(Judge0SubmitResponse::isCompleted)) {
+                    return results;
+                }
+                Thread.sleep(POLL_INTERVAL_MS);
+            }
+            log.warn("Judge0 polling timed out after {} attempts", MAX_POLL_ATTEMPTS);
+            return List.of();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Judge0 polling interrupted", e);
+            return List.of();
+        } catch (Exception e) {
+            log.error("Judge0 execution failed", e);
+            return List.of();
+        }
+    }
+
+    public int getLanguageId(String language) {
+        return switch (language.toLowerCase()) {
+            case "python", "python3" -> 71;
+            case "java" -> 62;
+            case "cpp", "c++" -> 54;
+            case "c" -> 50;
+            case "javascript", "js" -> 63;
+            default -> throw new IllegalArgumentException("지원하지 않는 언어: " + language);
+        };
+    }
+}

--- a/src/main/java/com/back/global/judge/Judge0ExecutionService.java
+++ b/src/main/java/com/back/global/judge/Judge0ExecutionService.java
@@ -24,6 +24,8 @@ public class Judge0ExecutionService {
      * Judge0에 배치 제출 후 폴링하여 결과 반환.
      * 타임아웃(10초) 또는 오류 시 빈 리스트 반환.
      */
+    // TODO: 채점 폴링 10초 실패해서 빈 리스트를 반환하게되어서 WA로 된다면
+    // 그건 나중에 점수 결산에서 빼야하는것 아닌가? (WA에서20초 추가되는거)
     public List<Judge0SubmitResponse> execute(List<Judge0SubmitRequest> batchRequests) {
         try {
             List<String> tokens = judge0Client.submitBatch(batchRequests);

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -34,10 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class JudgeService {
 
-    private static final int MAX_POLL_ATTEMPTS = 10;
-    private static final int POLL_INTERVAL_MS = 1000;
-
-    private final Judge0Client judge0Client;
+    private final Judge0ExecutionService judge0ExecutionService;
     private final SubmissionRepository submissionRepository;
     private final BattleParticipantRepository battleParticipantRepository;
     private final BattleRoomRepository battleRoomRepository;
@@ -75,17 +72,15 @@ public class JudgeService {
             log.warn("Submission {} has no test cases, marking as WA", submissionId);
             judgeResult = SubmissionResult.WA;
         } else { // 테스트 케이스가 1개 이상의 경우
-            int languageId = getLanguageId(language);
+            int languageId = judge0ExecutionService.getLanguageId(language);
 
             // TODO: 함수형 코드 지원 시 driverCode 합치기
             // String fullCode = code + "\n" + problem.getDriverCode().get(language);
-            // 배치 요청 구성
             List<Judge0SubmitRequest> batchRequests = testCases.stream()
                     .map(tc -> new Judge0SubmitRequest(
                             code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
                     .toList();
-            // judge 실행 (10초간 1초마다 풀링)
-            List<Judge0SubmitResponse> results = runJudge(batchRequests);
+            List<Judge0SubmitResponse> results = judge0ExecutionService.execute(batchRequests);
             results.forEach(r -> log.info(
                     "Judge0 result: token={}, statusId={}, stderr={}, compileOutput={}, message={}",
                     r.token(),
@@ -173,38 +168,6 @@ public class JudgeService {
     }
 
     /**
-     * 폴링 부분 (Judge0 worker가 코드를 실행 완료할 때까지 1초 간격으로 계속 물어보는 것)
-     *   submitBatch() → 토큰 발급 ["abc", "def"]
-     *        │
-     *        ▼
-     *   1초 후 getBatchResults() → status_id 1 (처리 중) → 다시 대기
-     *   1초 후 getBatchResults() → status_id 1 (처리 중) → 다시 대기
-     *   1초 후 getBatchResults() → status_id 3 (완료!) → 결과 반환
-     */
-    private List<Judge0SubmitResponse> runJudge(List<Judge0SubmitRequest> batchRequests) {
-        try {
-            List<String> tokens = judge0Client.submitBatch(batchRequests); // 제출 → 토큰 받기
-            for (int i = 0; i < MAX_POLL_ATTEMPTS; i++) { // 최대 10회
-                List<Judge0SubmitResponse> results = judge0Client.getBatchResults(tokens); // 결과 조회
-                if (results.stream().allMatch(Judge0SubmitResponse::isCompleted)) {
-                    return results; // 모두 완료했으면 반환
-                }
-                Thread.sleep(POLL_INTERVAL_MS); // 아직 처리중이면 1초 대기
-            }
-            // 10초 지나도 안 끝나면 타임아웃
-            log.warn("Judge0 polling timed out after {} attempts", MAX_POLL_ATTEMPTS);
-            return List.of();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("Judge0 polling interrupted", e);
-            return List.of();
-        } catch (Exception e) {
-            log.error("Judge0 judging failed", e);
-            return List.of();
-        }
-    }
-
-    /**
      * 우선순위: CE > RE > TLE > WA > AC
      */
     private SubmissionResult aggregateResult(List<Judge0SubmitResponse> results, int totalCount) {
@@ -225,16 +188,5 @@ public class JudgeService {
         if (passed == totalCount) return SubmissionResult.AC;
 
         return SubmissionResult.WA;
-    }
-
-    private int getLanguageId(String language) {
-        return switch (language.toLowerCase()) {
-            case "python", "python3" -> 71;
-            case "java" -> 62;
-            case "cpp", "c++" -> 54;
-            case "c" -> 50;
-            case "javascript", "js" -> 63;
-            default -> throw new IllegalArgumentException("지원하지 않는 언어: " + language);
-        };
     }
 }

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -171,7 +171,7 @@ public class JudgeService {
      * 우선순위: CE > RE > TLE > WA > AC
      */
     private SubmissionResult aggregateResult(List<Judge0SubmitResponse> results, int totalCount) {
-        if (results.isEmpty()) return SubmissionResult.RE;
+        if (results.isEmpty()) return SubmissionResult.JUDGE_ERROR;
 
         if (results.stream().anyMatch(r -> r.status() != null && r.status().id() == 6)) {
             return SubmissionResult.CE;

--- a/src/main/java/com/back/global/judge/RunJudgeService.java
+++ b/src/main/java/com/back/global/judge/RunJudgeService.java
@@ -71,8 +71,12 @@ public class RunJudgeService {
 
         if (judgeResponses.isEmpty()) {
             return testCases.stream()
-                    .map(tc ->
-                            new RunTestCaseResult(tc.getInput(), tc.getExpectedOutput(), null, "RE", "실행 시간이 초과되었습니다."))
+                    .map(tc -> new RunTestCaseResult(
+                            tc.getInput(),
+                            tc.getExpectedOutput(),
+                            null,
+                            "JUDGE_ERROR",
+                            "채점 서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."))
                     .toList();
         }
 

--- a/src/main/java/com/back/global/judge/RunJudgeService.java
+++ b/src/main/java/com/back/global/judge/RunJudgeService.java
@@ -23,19 +23,22 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RunJudgeService {
 
-    private static final int MAX_POLL_ATTEMPTS = 10;
-    private static final int POLL_INTERVAL_MS = 1000;
-
-    private final Judge0Client judge0Client;
+    private final Judge0ExecutionService judge0ExecutionService;
     private final SimpMessagingTemplate messagingTemplate;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onRunRequested(RunRequestedEvent event) {
-        run(event.roomId(), event.memberId(), event.code(), event.language(), event.testCases());
+        run(
+                event.roomId(),
+                event.memberId(),
+                event.code(),
+                event.language(),
+                event.testCases(),
+                "/topic/room/" + event.roomId() + "/run");
     }
 
-    private void run(Long roomId, Long memberId, String code, String language, List<TestCase> testCases) {
+    void run(Long roomId, Long memberId, String code, String language, List<TestCase> testCases, String topic) {
 
         List<RunTestCaseResult> results;
 
@@ -43,7 +46,7 @@ public class RunJudgeService {
             log.warn("Run request for room {} has no sample test cases", roomId);
             results = List.of();
         } else {
-            int languageId = getLanguageId(language);
+            int languageId = judge0ExecutionService.getLanguageId(language);
 
             // TODO: 함수형 코드 지원 시 driverCode 합치기
             // String fullCode = code + "\n" + problem.getDriverCode().get(language);
@@ -52,23 +55,20 @@ public class RunJudgeService {
                             code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
                     .toList();
 
-            List<Judge0SubmitResponse> judgeResponses = runJudge(batchRequests);
-
+            List<Judge0SubmitResponse> judgeResponses = judge0ExecutionService.execute(batchRequests);
             results = buildResults(testCases, judgeResponses);
         }
 
-        // WebSocket: 케이스별 실행 결과 push
         messagingTemplate.convertAndSend(
-                "/topic/room/" + roomId + "/run",
+                topic,
                 Map.of(
                         "type", "RUN_RESULT",
                         "userId", memberId,
                         "results", results));
     }
 
-    private List<RunTestCaseResult> buildResults(List<TestCase> testCases, List<Judge0SubmitResponse> judgeResponses) {
+    public List<RunTestCaseResult> buildResults(List<TestCase> testCases, List<Judge0SubmitResponse> judgeResponses) {
 
-        // 폴링 타임아웃 등으로 결과가 없을 경우 전체 RE 처리
         if (judgeResponses.isEmpty()) {
             return testCases.stream()
                     .map(tc ->
@@ -91,7 +91,7 @@ public class RunJudgeService {
                 .toList();
     }
 
-    private String resolveStatus(Judge0SubmitResponse r) {
+    public String resolveStatus(Judge0SubmitResponse r) {
         if (r.status() == null) return "RE";
         return switch (r.status().id()) {
             case 3 -> "AC";
@@ -99,39 +99,6 @@ public class RunJudgeService {
             case 5 -> "TLE";
             case 6 -> "CE";
             default -> "RE";
-        };
-    }
-
-    private List<Judge0SubmitResponse> runJudge(List<Judge0SubmitRequest> batchRequests) {
-        try {
-            List<String> tokens = judge0Client.submitBatch(batchRequests);
-            for (int i = 0; i < MAX_POLL_ATTEMPTS; i++) {
-                List<Judge0SubmitResponse> results = judge0Client.getBatchResults(tokens);
-                if (results.stream().allMatch(Judge0SubmitResponse::isCompleted)) {
-                    return results;
-                }
-                Thread.sleep(POLL_INTERVAL_MS);
-            }
-            log.warn("Judge0 run polling timed out after {} attempts", MAX_POLL_ATTEMPTS);
-            return List.of();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("Judge0 run polling interrupted", e);
-            return List.of();
-        } catch (Exception e) {
-            log.error("Judge0 run failed", e);
-            return List.of();
-        }
-    }
-
-    private int getLanguageId(String language) {
-        return switch (language.toLowerCase()) {
-            case "python", "python3" -> 71;
-            case "java" -> 62;
-            case "cpp", "c++" -> 54;
-            case "c" -> 50;
-            case "javascript", "js" -> 63;
-            default -> throw new IllegalArgumentException("지원하지 않는 언어: " + language);
         };
     }
 }

--- a/src/main/java/com/back/global/judge/SoloJudgeService.java
+++ b/src/main/java/com/back/global/judge/SoloJudgeService.java
@@ -1,0 +1,102 @@
+package com.back.global.judge;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.back.domain.problem.solo.submission.entity.SoloSubmission;
+import com.back.domain.problem.solo.submission.repository.SoloSubmissionRepository;
+import com.back.domain.problem.submission.entity.SubmissionResult;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.dto.Judge0SubmitRequest;
+import com.back.global.judge.dto.Judge0SubmitResponse;
+import com.back.global.judge.event.SoloJudgeRequestedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SoloJudgeService {
+
+    private final Judge0ExecutionService judge0ExecutionService;
+    private final SoloSubmissionRepository soloSubmissionRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onSoloJudgeRequested(SoloJudgeRequestedEvent event) {
+        judge(event.soloSubmissionId(), event.memberId(), event.code(), event.language(), event.testCases());
+    }
+
+    private void judge(Long soloSubmissionId, Long memberId, String code, String language, List<TestCase> testCases) {
+
+        int totalCount = testCases.size();
+        SubmissionResult judgeResult;
+        int passedCount = 0;
+
+        if (totalCount == 0) {
+            log.warn("SoloSubmission {} has no test cases, marking as WA", soloSubmissionId);
+            judgeResult = SubmissionResult.WA;
+        } else {
+            int languageId = judge0ExecutionService.getLanguageId(language);
+
+            // TODO: 함수형 코드 지원 시 driverCode 합치기
+            // String fullCode = code + "\n" + problem.getDriverCode().get(language);
+            List<Judge0SubmitRequest> batchRequests = testCases.stream()
+                    .map(tc -> new Judge0SubmitRequest(
+                            code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
+                    .toList();
+
+            List<Judge0SubmitResponse> results = judge0ExecutionService.execute(batchRequests);
+            judgeResult = aggregateResult(results, totalCount);
+            passedCount = (int) results.stream()
+                    .filter(r -> r.status() != null && r.status().id() == 3)
+                    .count();
+        }
+
+        SoloSubmission submission = soloSubmissionRepository
+                .findById(soloSubmissionId)
+                .orElseThrow(() -> new IllegalStateException("SoloSubmission not found: " + soloSubmissionId));
+        submission.applyJudgeResult(judgeResult, passedCount, totalCount);
+        soloSubmissionRepository.save(submission);
+
+        messagingTemplate.convertAndSend(
+                "/topic/solo/" + memberId,
+                Map.of(
+                        "type", "SUBMISSION",
+                        "userId", memberId,
+                        "result", judgeResult.name(),
+                        "passedCount", passedCount,
+                        "totalCount", totalCount));
+    }
+
+    /**
+     * 우선순위: CE > RE > TLE > WA > AC
+     */
+    private SubmissionResult aggregateResult(List<Judge0SubmitResponse> results, int totalCount) {
+        if (results.isEmpty()) return SubmissionResult.RE;
+
+        if (results.stream().anyMatch(r -> r.status() != null && r.status().id() == 6)) {
+            return SubmissionResult.CE;
+        }
+        if (results.stream().anyMatch(r -> r.status() != null && r.status().id() >= 7)) {
+            return SubmissionResult.RE;
+        }
+        if (results.stream().anyMatch(r -> r.status() != null && r.status().id() == 5)) {
+            return SubmissionResult.TLE;
+        }
+        long passed = results.stream()
+                .filter(r -> r.status() != null && r.status().id() == 3)
+                .count();
+        if (passed == totalCount) return SubmissionResult.AC;
+
+        return SubmissionResult.WA;
+    }
+}

--- a/src/main/java/com/back/global/judge/SoloJudgeService.java
+++ b/src/main/java/com/back/global/judge/SoloJudgeService.java
@@ -81,7 +81,7 @@ public class SoloJudgeService {
      * 우선순위: CE > RE > TLE > WA > AC
      */
     private SubmissionResult aggregateResult(List<Judge0SubmitResponse> results, int totalCount) {
-        if (results.isEmpty()) return SubmissionResult.RE;
+        if (results.isEmpty()) return SubmissionResult.JUDGE_ERROR;
 
         if (results.stream().anyMatch(r -> r.status() != null && r.status().id() == 6)) {
             return SubmissionResult.CE;

--- a/src/main/java/com/back/global/judge/SoloRunJudgeService.java
+++ b/src/main/java/com/back/global/judge/SoloRunJudgeService.java
@@ -1,0 +1,60 @@
+package com.back.global.judge;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.global.judge.dto.Judge0SubmitRequest;
+import com.back.global.judge.dto.Judge0SubmitResponse;
+import com.back.global.judge.event.SoloRunRequestedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SoloRunJudgeService {
+
+    private final Judge0ExecutionService judge0ExecutionService;
+    private final RunJudgeService runJudgeService; // buildResults, resolveStatus 재사용
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onSoloRunRequested(SoloRunRequestedEvent event) {
+        run(event.memberId(), event.code(), event.language(), event.testCases());
+    }
+
+    private void run(Long memberId, String code, String language, List<TestCase> testCases) {
+
+        var results = testCases.isEmpty() ? List.of() : buildAndRun(code, language, testCases);
+
+        messagingTemplate.convertAndSend(
+                "/topic/solo/" + memberId + "/run",
+                Map.of(
+                        "type", "RUN_RESULT",
+                        "userId", memberId,
+                        "results", results));
+    }
+
+    private List<?> buildAndRun(String code, String language, List<TestCase> testCases) {
+        int languageId = judge0ExecutionService.getLanguageId(language);
+
+        // TODO: 함수형 코드 지원 시 driverCode 합치기
+        // String fullCode = code + "\n" + problem.getDriverCode().get(language);
+        List<Judge0SubmitRequest> batchRequests = testCases.stream()
+                .map(tc -> new Judge0SubmitRequest(
+                        code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
+                .toList();
+
+        List<Judge0SubmitResponse> judgeResponses = judge0ExecutionService.execute(batchRequests);
+        return runJudgeService.buildResults(testCases, judgeResponses);
+    }
+}

--- a/src/main/java/com/back/global/judge/event/SoloJudgeRequestedEvent.java
+++ b/src/main/java/com/back/global/judge/event/SoloJudgeRequestedEvent.java
@@ -1,0 +1,8 @@
+package com.back.global.judge.event;
+
+import java.util.List;
+
+import com.back.domain.problem.testcase.entity.TestCase;
+
+public record SoloJudgeRequestedEvent(
+        Long soloSubmissionId, Long memberId, String code, String language, List<TestCase> testCases) {}

--- a/src/main/java/com/back/global/judge/event/SoloRunRequestedEvent.java
+++ b/src/main/java/com/back/global/judge/event/SoloRunRequestedEvent.java
@@ -1,0 +1,7 @@
+package com.back.global.judge.event;
+
+import java.util.List;
+
+import com.back.domain.problem.testcase.entity.TestCase;
+
+public record SoloRunRequestedEvent(Long memberId, String code, String language, List<TestCase> testCases) {}

--- a/src/test/java/com/back/global/judge/JudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/JudgeServiceTest.java
@@ -36,7 +36,7 @@ import com.back.global.judge.event.JudgeRequestedEvent;
 
 class JudgeServiceTest {
 
-    private final Judge0Client judge0Client = mock(Judge0Client.class);
+    private final Judge0ExecutionService judge0ExecutionService = mock(Judge0ExecutionService.class);
     private final SubmissionRepository submissionRepository = mock(SubmissionRepository.class);
     private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
     private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
@@ -45,7 +45,7 @@ class JudgeServiceTest {
     private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
 
     private final JudgeService judgeService = new JudgeService(
-            judge0Client,
+            judge0ExecutionService,
             submissionRepository,
             battleParticipantRepository,
             battleRoomRepository,
@@ -72,6 +72,7 @@ class JudgeServiceTest {
         participant = mock(BattleParticipant.class);
 
         when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
+        when(judge0ExecutionService.getLanguageId("python")).thenReturn(71);
     }
 
     private TestCase mockTestCase(String input, String expectedOutput) {
@@ -86,8 +87,7 @@ class JudgeServiceTest {
     }
 
     private void stubJudge0(Judge0SubmitResponse... responses) {
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any())).thenReturn(List.of(responses));
+        when(judge0ExecutionService.execute(any())).thenReturn(List.of(responses));
     }
 
     /** AC 흐름에서 필요한 handleAc() 관련 Mock 설정 */
@@ -182,11 +182,10 @@ class JudgeServiceTest {
     }
 
     @Test
-    @DisplayName("Judge0 폴링 타임아웃 시 submission result가 RE로 저장된다")
+    @DisplayName("Judge0 타임아웃 시 submission result가 RE로 저장된다")
     void judge_judge0Timeout_savedAsRe() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(1, null))); // 미완료 상태
+        when(judge0ExecutionService.execute(any())).thenReturn(List.of()); // 타임아웃 → 빈 리스트
 
         judgeService.onJudgeRequested(event(List.of(tc)));
 
@@ -250,7 +249,7 @@ class JudgeServiceTest {
         BattleParticipant p1 = mock(BattleParticipant.class);
         BattleParticipant p2 = mock(BattleParticipant.class);
         when(p1.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
-        when(p2.getStatus()).thenReturn(BattleParticipantStatus.PLAYING); // 아직 풀이 중
+        when(p2.getStatus()).thenReturn(BattleParticipantStatus.PLAYING);
         stubHandleAc(List.of(p1, p2));
 
         judgeService.onJudgeRequested(event(List.of(tc)));

--- a/src/test/java/com/back/global/judge/JudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/JudgeServiceTest.java
@@ -182,14 +182,14 @@ class JudgeServiceTest {
     }
 
     @Test
-    @DisplayName("Judge0 타임아웃 시 submission result가 RE로 저장된다")
-    void judge_judge0Timeout_savedAsRe() {
+    @DisplayName("Judge0 타임아웃 시 submission result가 JUDGE_ERROR로 저장된다")
+    void judge_judge0Timeout_savedAsJudgeError() {
         TestCase tc = mockTestCase("1 2", "3");
         when(judge0ExecutionService.execute(any())).thenReturn(List.of()); // 타임아웃 → 빈 리스트
 
         judgeService.onJudgeRequested(event(List.of(tc)));
 
-        assertThat(submission.getResult()).isEqualTo(SubmissionResult.RE);
+        assertThat(submission.getResult()).isEqualTo(SubmissionResult.JUDGE_ERROR);
         verify(submissionRepository).save(submission);
     }
 

--- a/src/test/java/com/back/global/judge/RunJudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/RunJudgeServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -23,12 +24,17 @@ import com.back.global.judge.event.RunRequestedEvent;
 
 class RunJudgeServiceTest {
 
-    private final Judge0Client judge0Client = mock(Judge0Client.class);
+    private final Judge0ExecutionService judge0ExecutionService = mock(Judge0ExecutionService.class);
     private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
 
-    private final RunJudgeService runJudgeService = new RunJudgeService(judge0Client, messagingTemplate);
+    private final RunJudgeService runJudgeService = new RunJudgeService(judge0ExecutionService, messagingTemplate);
 
     // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+    @BeforeEach
+    void setUp() {
+        when(judge0ExecutionService.getLanguageId("python")).thenReturn(71);
+    }
 
     private TestCase mockTestCase(String input, String expectedOutput) {
         TestCase tc = mock(TestCase.class);
@@ -40,6 +46,10 @@ class RunJudgeServiceTest {
 
     private Judge0SubmitResponse response(int statusId, String stdout, String stderr, String compileOutput) {
         return new Judge0SubmitResponse("token", new Status(statusId, ""), stdout, stderr, compileOutput, null);
+    }
+
+    private void stubJudge0(Judge0SubmitResponse... responses) {
+        when(judge0ExecutionService.execute(any())).thenReturn(List.of(responses));
     }
 
     @SuppressWarnings("unchecked")
@@ -55,8 +65,7 @@ class RunJudgeServiceTest {
     @DisplayName("정답이면 status AC, actualOutput이 stdout으로 채워진다")
     void run_ac() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(3, "3\n", null, null)));
+        stubJudge0(response(3, "3\n", null, null));
 
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "print(3)", "python", List.of(tc)));
 
@@ -72,8 +81,7 @@ class RunJudgeServiceTest {
     @DisplayName("출력이 다르면 status WA")
     void run_wa() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(4, "5\n", null, null)));
+        stubJudge0(response(4, "5\n", null, null));
 
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "print(5)", "python", List.of(tc)));
 
@@ -86,9 +94,7 @@ class RunJudgeServiceTest {
     @DisplayName("컴파일 에러면 status CE, stderr에 compileOutput이 담긴다")
     void run_ce() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any()))
-                .thenReturn(List.of(response(6, null, null, "SyntaxError: invalid syntax")));
+        stubJudge0(response(6, null, null, "SyntaxError: invalid syntax"));
 
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "prnit(3)", "python", List.of(tc)));
 
@@ -101,8 +107,7 @@ class RunJudgeServiceTest {
     @DisplayName("시간 초과면 status TLE")
     void run_tle() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(5, null, null, null)));
+        stubJudge0(response(5, null, null, null));
 
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "while True: pass", "python", List.of(tc)));
 
@@ -114,8 +119,7 @@ class RunJudgeServiceTest {
     @DisplayName("런타임 에러면 status RE, stderr가 채워진다")
     void run_re() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(11, null, "ZeroDivisionError", null)));
+        stubJudge0(response(11, null, "ZeroDivisionError", null));
 
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "print(1/0)", "python", List.of(tc)));
 
@@ -129,9 +133,7 @@ class RunJudgeServiceTest {
     void run_mixed_results() {
         TestCase tc1 = mockTestCase("1 2", "3");
         TestCase tc2 = mockTestCase("5 7", "12");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token1", "token2"));
-        when(judge0Client.getBatchResults(any()))
-                .thenReturn(List.of(response(3, "3\n", null, null), response(4, "13\n", null, null)));
+        stubJudge0(response(3, "3\n", null, null), response(4, "13\n", null, null));
 
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "code", "python", List.of(tc1, tc2)));
 
@@ -154,13 +156,10 @@ class RunJudgeServiceTest {
     }
 
     @Test
-    @DisplayName("Judge0 폴링 타임아웃 시 전체 케이스를 RE로 반환한다")
+    @DisplayName("Judge0 타임아웃 시 전체 케이스를 RE로 반환한다")
     void run_judge0Timeout() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        // 계속 미완료 상태 반환 → 타임아웃
-        when(judge0Client.getBatchResults(any()))
-                .thenReturn(List.of(response(1, null, null, null))); // status 1 = In Queue (미완료)
+        when(judge0ExecutionService.execute(any())).thenReturn(List.of()); // 타임아웃 → 빈 리스트
 
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "code", "python", List.of(tc)));
 
@@ -174,8 +173,7 @@ class RunJudgeServiceTest {
     @DisplayName("결과는 /topic/room/{roomId}/run 토픽으로 전송된다")
     void run_sendsToCorrectTopic() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(3, "3\n", null, null)));
+        stubJudge0(response(3, "3\n", null, null));
 
         runJudgeService.onRunRequested(new RunRequestedEvent(42L, 1L, "code", "python", List.of(tc)));
 
@@ -186,8 +184,7 @@ class RunJudgeServiceTest {
     @DisplayName("WebSocket 메시지 type은 RUN_RESULT, userId가 포함된다")
     void run_messageContainsTypeAndUserId() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0Client.submitBatch(any())).thenReturn(List.of("token"));
-        when(judge0Client.getBatchResults(any())).thenReturn(List.of(response(3, "3\n", null, null)));
+        stubJudge0(response(3, "3\n", null, null));
 
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 99L, "code", "python", List.of(tc)));
 

--- a/src/test/java/com/back/global/judge/RunJudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/RunJudgeServiceTest.java
@@ -156,7 +156,7 @@ class RunJudgeServiceTest {
     }
 
     @Test
-    @DisplayName("Judge0 타임아웃 시 전체 케이스를 RE로 반환한다")
+    @DisplayName("Judge0 타임아웃 시 전체 케이스를 JUDGE_ERROR로 반환한다")
     void run_judge0Timeout() {
         TestCase tc = mockTestCase("1 2", "3");
         when(judge0ExecutionService.execute(any())).thenReturn(List.of()); // 타임아웃 → 빈 리스트
@@ -164,7 +164,8 @@ class RunJudgeServiceTest {
         runJudgeService.onRunRequested(new RunRequestedEvent(1L, 1L, "code", "python", List.of(tc)));
 
         List<RunTestCaseResult> results = captureResults();
-        assertThat(results.get(0).status()).isEqualTo("RE");
+        assertThat(results.get(0).status()).isEqualTo("JUDGE_ERROR");
+        assertThat(results.get(0).stderr()).isEqualTo("채점 서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
     }
 
     // ── WebSocket 전송 검증 ───────────────────────────────────────────────────


### PR DESCRIPTION
현재 JudgeService와 RunJudgeService에 runJudge(), getLanguageId()가 중복되어 있어서 먼저 공통 추출

```java
global/judge/
└── Judge0ExecutionService.java  ← runJudge(), getLanguageId() 이동
```

JudgeService, RunJudgeService 양쪽에서 주입받아 사용하도록 수정.

---

2단계: Solo Run 구현

```java
domain/problem/solo/run/
├── controller/SoloRunController.java     POST /api/v1/solo/run
├── service/SoloRunService.java           problemId로 샘플 케이스 조회 + 이벤트 발행
└── dto/SoloRunRequest.java               (problemId, code, language)

global/judge/
├── event/SoloRunRequestedEvent.java
└── SoloRunJudgeService.java              Judge0 실행 → WebSocket push
```

WebSocket 결과 topic: /topic/solo/{memberId}/run
(배틀은 room 기준, 개인은 member 기준)

---

3단계: Solo Submit 구현

```java
domain/problem/solo/submission/
├── controller/SoloSubmissionController.java   POST /api/v1/solo/submissions
├── service/SoloSubmissionService.java
├── entity/SoloSubmission.java                 battleRoom FK 없는 별도 엔티티
├── repository/SoloSubmissionRepository.java
└── dto/SoloSubmitRequest.java                 (problemId, code, language)

global/judge/
├── event/SoloJudgeRequestedEvent.java
└── SoloJudgeService.java                      전체 케이스 채점 → DB 저장 → WebSocket push
```

WebSocket 결과 topic: /topic/solo/{memberId}