### PR TITLE
[refactor] 매칭 상태 저장소를 store로 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ scripts/__pycache__/
 .claude
 myContext
 .gradle-user-home/
+.gradle-home/

--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -25,11 +25,8 @@ public class QueueProblemPicker {
             throw new IllegalArgumentException("queueKey는 필수입니다.");
         }
 
-        //        return problemPickService.pickProblemId(
-        //                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
-
-        // TODO : 이거 지금 위에 주석 뺴야됨 현재는 1번 만 출제
-        return 1L;
+        return problemPickService.pickProblemId(
+                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
     }
 
     private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {

--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -25,8 +25,11 @@ public class QueueProblemPicker {
             throw new IllegalArgumentException("queueKey는 필수입니다.");
         }
 
-        return problemPickService.pickProblemId(
-                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+        //        return problemPickService.pickProblemId(
+        //                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+
+        // TODO : 이거 지금 위에 주석 뺴야됨 현재는 1번 만 출제
+        return 1L;
     }
 
     private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -1,11 +1,6 @@
 package com.back.domain.matching.queue.service;
 
-import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.springframework.stereotype.Service;
 
@@ -19,6 +14,7 @@ import com.back.domain.matching.queue.dto.QueueStateResponse;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.domain.matching.queue.store.MatchStateStore;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,63 +23,21 @@ import lombok.RequiredArgsConstructor;
 public class MatchingQueueService {
 
     // TODO: 지금 현재 인메모리 방식임 redis로 전환하면 좋음 MVP 이기 때문
-    /**
-     * 카테고리 + 난이도별 대기열
-     *
-     * 예:
-     * ARRAY + EASY -> [1번 유저, 7번 유저]
-     * GRAPH + HARD -> [3번 유저]
-     */
-    private final Map<QueueKey, Deque<WaitingUser>> waitingQueues = new ConcurrentHashMap<>();
-
-    /**
-     * 특정 유저가 이미 대기열에 들어가 있는지 빠르게 확인하기 위한 맵
-     *
-     * 예:
-     * 1L -> (ARRAY, EASY)
-     * 7L -> (ARRAY, EASY)
-     */
-    private final Map<Long, QueueKey> userQueueMap = new ConcurrentHashMap<>();
-
-    /**
-     * 매칭 시작 요청 처리
-     *
-     * 1. 이미 대기열에 참가 중인지 확인
-     * 2. category + difficulty 로 QueueKey 생성
-     * 3. 해당 QueueKey의 큐가 없으면 생성
-     * 4. 유저를 대기열에 추가
-     * 5. userQueueMap에도 기록
-     */
 
     // 매칭 성사 시 방 생성 호출용 서비스
     private final BattleRoomService battleRoomService;
 
     private final QueueProblemPicker queueProblemPicker;
 
-    // 매칭 완료 후 유저가 어느 방으로 가야 하는지 저장
-    // 예: 1L -> 10L (user1 은 room10 으로 이동해야 함)
-    private final Map<Long, Long> matchedRoomMap = new ConcurrentHashMap<>();
+    // 인메모리 상태 저장 책임을 별도 store로 분리
+    private final MatchStateStore matchStateStore;
 
     public QueueStatusResponse joinQueue(Long userId, QueueJoinRequest request) {
         // 이미 대기열에 들어가 있는 유저는 다시 참가할 수 없다.
         QueueKey queueKey = new QueueKey(request.getCategory(), request.getDifficulty());
 
-        // putIfAbsent를 사용하여 중복 참가를 원자적으로 방지합니다.
-        if (userQueueMap.putIfAbsent(userId, queueKey) != null) {
-            throw new IllegalStateException("이미 매칭 대기열에 참가 중인 사용자입니다.");
-        }
-
-        // 해당 큐가 없으면 새로 만들고, 있으면 기존 큐를 가져온다.
-        Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
-
-        WaitingUser waitingUser = new WaitingUser(userId, queueKey);
-
-        // 큐의 맨 뒤에 추가
-        int currentSize;
-        synchronized (queue) {
-            queue.addLast(waitingUser);
-            currentSize = queue.size();
-        }
+        // 큐 참가와 현재 대기 인원 계산
+        int currentSize = matchStateStore.enqueue(userId, queueKey);
 
         // 1차 빠른 체크: 4명 미만이면 굳이 매칭 함수까지 안 들어감
         if (currentSize < 4) {
@@ -96,7 +50,7 @@ public class MatchingQueueService {
         }
 
         // 4명 이상일 때만 실제 매칭 시도
-        CreateRoomResponse room = tryMatchAndCreateRoom(queueKey, queue);
+        CreateRoomResponse room = tryMatchAndCreateRoom(queueKey);
 
         if (room != null) {
             return new QueueStatusResponse(
@@ -108,10 +62,7 @@ public class MatchingQueueService {
         }
 
         // 아직 인원 부족이면 대기 상태 응답
-        int remainingSize; //  응답 직전 다시 읽을 값은 락으로 보호해서 조회
-        synchronized (queue) {
-            remainingSize = queue.size();
-        }
+        int remainingSize = matchStateStore.getWaitingCount(queueKey);
 
         return new QueueStatusResponse(
                 "매칭 대기열에 참가했습니다.",
@@ -122,80 +73,21 @@ public class MatchingQueueService {
     }
 
     public QueueStatusResponse cancelQueue(Long userId) {
-        // 1. 유저가 어느 큐에 들어가 있는지 찾는다.
-        QueueKey queueKey = userQueueMap.get(userId);
+        // cancel 처리 결과는 store가 반환
+        MatchStateStore.CancelResult cancelResult = matchStateStore.cancel(userId);
+        QueueKey queueKey = cancelResult.queueKey();
 
-        // 2. 대기열에 없는 유저면 예외 발생
-        if (queueKey == null) {
-            throw new IllegalStateException("현재 매칭 대기열에 참가 중이 아닙니다.");
-        }
-
-        // 3. 해당 큐를 가져온다.
-        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
-
-        // 4. 큐 자체가 없으면 비정상 상태
-        if (queue == null) {
-            userQueueMap.remove(userId);
-            throw new IllegalStateException("대기열 정보를 찾을 수 없습니다.");
-        }
-
-        int currentSize;
-        boolean removed;
-
-        synchronized (queue) {
-            // 5. 큐에서 해당 userId를 가진 WaitingUser 제거
-            removed = queue.removeIf(waitingUser -> waitingUser.getUserId().equals(userId));
-
-            // 7. 큐에서 제거 실패 시 예외
-            if (!removed) {
-                throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
-            }
-
-            // 6. userQueueMap에서도 제거
-            userQueueMap.remove(userId);
-            currentSize = queue.size();
-
-            // 8. 해당 큐가 비어 있으면 삭제하고, 안 비어 있으면 그대로 둬라
-            if (currentSize == 0) { //  빈 큐 정리를 락 안으로 이동
-                waitingQueues.remove(queueKey, queue); //  내가 잡고 있는 바로 그 queue일 때만 제거
-            }
-        }
-
-        // 9. 응답 반환
         return new QueueStatusResponse(
-                "매칭 대기열에서 취소되었습니다.", queueKey.category(), queueKey.difficulty().name(), currentSize);
+                "매칭 대기열에서 취소했습니다.", queueKey.category(), queueKey.difficulty().name(), cancelResult.waitingCount());
     }
 
     // 4인 매칭 + 방 생성
-    private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey, Deque<WaitingUser> queue) {
+    private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey) {
 
-        List<WaitingUser> matchedUsers;
+        List<WaitingUser> matchedUsers = matchStateStore.pollMatchCandidates(queueKey, 4);
 
-        // 락 안에서는 4명 확인 + 4명 추출까지만 수행
-        synchronized (queue) {
-            // 2차 체크: 바깥에서 4명 이상이었더라도
-            // 이 시점에는 다른 스레드가 먼저 가져갔을 수 있으므로 다시 확인 필요
-            // 4명 미만이면 매칭 X
-            if (queue.size() < 4) {
-                return null;
-            }
-
-            // FIFO 순서대로 앞에서 4명 추출
-            matchedUsers = new ArrayList<>(4);
-            for (int i = 0; i < 4; i++) {
-                WaitingUser user = queue.pollFirst();
-                if (user != null) {
-                    matchedUsers.add(user);
-                }
-            }
-
-            // 비정상 안전장치: 추출 인원이 4명 미만이면 원상복구 후 중단
-            if (matchedUsers.size() < 4) {
-                for (int i = matchedUsers.size() - 1; i >= 0; i--) {
-                    queue.addFirst(matchedUsers.get(i));
-                }
-                return null;
-            }
+        if (matchedUsers == null) {
+            return null;
         }
 
         // 4) 방 생성 API에 넘길 참가자 ID 목록 생성
@@ -203,101 +95,38 @@ public class MatchingQueueService {
                 matchedUsers.stream().map(WaitingUser::getUserId).toList();
 
         try {
-            // 5) 문제 번호는 외부(찬의님 파트) 연동 함수에서 결정
             Long problemId = resolveProblemIdForMatch(queueKey, participantIds);
 
-            // 6) 배틀룸 생성 요청 (MVP: maxPlayers=4 고정)
             CreateRoomResponse response =
                     battleRoomService.createRoom(new CreateRoomRequest(problemId, participantIds, 4));
 
-            // 7) 방 생성 성공 시에만 "유저-큐 맵"에서 매칭된 유저 제거
-            //    (실패했는데 먼저 제거하면 상태 꼬임 발생)
-            // 매칭 성공 시 4명 모두 큐에서는 제거하고, roomId를 저장
-            Long roomId = response.roomId();
-
-            matchedUsers.forEach(user -> {
-                userQueueMap.remove(user.getUserId());
-                matchedRoomMap.put(user.getUserId(), roomId);
-            });
-
-            // 8) 이 큐가 비었으면 waitingQueues 맵에서 키 제거(메모리 정리)
-            synchronized (queue) { //  성공 후 같은 queue 락 안에서 직접 확인 후 제거
-                if (queue.isEmpty()) { //  플래그 대신 현재 시점의 실제 상태 확인
-                    waitingQueues.remove(queueKey, queue); // 내가 처리한 바로 그 queue일 때만 제거
-                }
-            }
+            // EARCHING -> MATCHED 전환도 store가 담당
+            matchStateStore.markMatched(queueKey, matchedUsers, response.roomId());
 
             return response;
         } catch (RuntimeException e) {
-            // 생성 실패 시 큐 원복: 뽑았던 4명을 원래 순서대로 되돌리기
-            // 롤백도 큐 변경이므로 같은 락으로 보호
-            synchronized (queue) {
-                for (int i = matchedUsers.size() - 1; i >= 0; i--) {
-                    queue.addFirst(matchedUsers.get(i));
-                }
-            }
+            matchStateStore.rollbackPolledUsers(queueKey, matchedUsers);
             throw e;
         }
     }
 
     public QueueStateResponse getMyQueueState(Long userId) {
-        QueueKey queueKey = userQueueMap.get(userId);
-
-        // 현재 어떤 큐에도 들어가 있지 않으면 false 반환
-        if (queueKey == null) {
-            return new QueueStateResponse(false, null, null, 0);
-        }
-
-        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
-
-        // 맵에는 있는데 실제 큐가 없으면 비정상 상태지만, 조회는 안전하게 false 처리
-        // 불일치 발견: userQueueMap에는 있으나 실제 대기열(waitingQueues)에는 없음
-        if (queue == null) {
-            // 원자적으로 제거 (내가 확인했던 그 queueKey일 때만 제거하여 동시성 이슈 방지)
-            userQueueMap.remove(userId, queueKey);
-
-            // 로그를 남겨 추적 가능하게 함
-            // log.warn("Inconsistency detected: User {} was in userQueueMap but queue {} was missing. Cleaned up.",
-            // userId, queueKey);
-
-            return new QueueStateResponse(false, null, null, 0);
-        }
-
-        return new QueueStateResponse(
-                true, queueKey.category(), queueKey.difficulty().name(), queue.size());
+        return matchStateStore.getQueueState(userId);
     }
 
-    // 현재 사용자의 매칭 상태 조회
     public MatchStateResponse getMyMatchState(Long userId) {
-        Long roomId = matchedRoomMap.get(userId);
-
-        // 이미 방이 배정된 상태
-        if (roomId != null) {
-            return new MatchStateResponse("MATCHED", roomId);
-        }
-
-        // 아직 큐에서 기다리는 중
-        if (userQueueMap.containsKey(userId)) {
-            return new MatchStateResponse("SEARCHING", null);
-        }
-
-        // 큐에도 없고, 배정된 방도 없는 상태
-        return new MatchStateResponse("IDLE", null);
+        return matchStateStore.getMatchState(userId);
     }
 
-    // 방 입장 성공 후 해당 유저의 매칭 결과 정리
     public void clearMatchedRoom(Long userId, Long roomId) {
-        // userId 에 저장된 roomId 가 지금 입장한 roomId 일 때만 제거
-        matchedRoomMap.remove(userId, roomId);
+        matchStateStore.clearMatchedRoom(userId, roomId);
     }
 
-    // 찬의님 연동 지점 (여기만 나중에 연결하면 됨)
     private Long resolveProblemIdForMatch(QueueKey queueKey, List<Long> participantIds) {
         return queueProblemPicker.pick(queueKey, participantIds);
     }
 
-    // 테스트에서 큐 정리 여부를 확인하기 위한 package-private 조회 메서드
     boolean hasQueue(QueueKey queueKey) {
-        return waitingQueues.containsKey(queueKey);
+        return matchStateStore.hasQueue(queueKey);
     }
 }

--- a/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
@@ -1,0 +1,388 @@
+package com.back.domain.matching.queue.store;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import org.springframework.stereotype.Component;
+
+import com.back.domain.matching.queue.dto.MatchStateResponse;
+import com.back.domain.matching.queue.dto.QueueStateResponse;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.WaitingUser;
+
+/**
+ * 현재 MVP용 인메모리 매칭 상태 저장소
+ *
+ * 역할:
+ * - 실제 대기열(waitingQueues)
+ * - 유저별 큐 참여 정보(userQueueMap)
+ * - 유저별 매칭 완료 room 정보(matchedRoomMap)
+ *
+ * 를 한 곳에 모아두고,
+ * MatchingQueueService는 이 저장소를 통해서만 상태를 다루게 만든다.
+ *
+ * 즉,
+ * 서비스는 "큐에 참가", "취소", "매칭 후보 추출", "매칭 완료 처리" 같은 흐름만 담당하고
+ * 실제 자료구조(Map, Deque) 조작은 이 저장소가 담당한다.
+ *
+ * 지금은 인메모리 기반이지만,
+ * 이후 Redis 등 외부 저장소로 바꾸더라도 서비스 로직 변경을 최소화하기 위해
+ * 저장 경계를 먼저 분리한 구조다.
+ */
+@Component
+public class InMemoryMatchStateStore implements MatchStateStore {
+
+    /**
+     * 카테고리 + 난이도별 실제 대기열
+     *
+     * 예:
+     * ARRAY + EASY -> [1번 유저, 7번 유저]
+     * GRAPH + HARD -> [3번 유저]
+     *
+     * key: QueueKey(category + difficulty)
+     * value: 해당 조건으로 매칭을 기다리는 유저들의 순서 있는 큐
+     */
+    private final Map<QueueKey, Deque<WaitingUser>> waitingQueues = new ConcurrentHashMap<>();
+
+    /**
+     * 특정 유저가 현재 어느 큐에 들어가 있는지 저장
+     *
+     * 목적:
+     * - 중복 참가 방지
+     * - 유저 기준 취소/상태조회 빠른 처리
+     *
+     * 예:
+     * 1L -> (ARRAY, EASY)
+     * 7L -> (ARRAY, EASY)
+     */
+    private final Map<Long, QueueKey> userQueueMap = new ConcurrentHashMap<>();
+
+    /**
+     * 매칭 완료 후 유저가 어느 방으로 이동해야 하는지 저장
+     *
+     * 목적:
+     * - /matches/me 조회 시 MATCHED 상태와 roomId 반환
+     * - 방 입장 성공 후 clearMatchedRoom으로 정리
+     *
+     * 예:
+     * 1L -> 101L
+     * 7L -> 101L
+     */
+    private final Map<Long, Long> matchedRoomMap = new ConcurrentHashMap<>();
+
+    /**
+     * 유저를 대기열에 넣는다.
+     *
+     * 동작 순서:
+     * 1. userQueueMap에 먼저 넣어서 "이미 대기 중인지" 검사
+     * 2. queueKey에 해당하는 실제 큐를 가져오거나 새로 생성
+     * 3. 큐 뒤쪽(addLast)에 유저를 넣음
+     * 4. 현재 대기 인원 수 반환
+     *
+     * 왜 userQueueMap을 먼저 넣나?
+     * -> 같은 유저가 동시에 여러 번 참가 요청하는 것을 빠르게 막기 위해서다.
+     *
+     * 왜 synchronized(queue)를 쓰나?
+     * -> ConcurrentLinkedDeque 자체는 단건 연산은 안전하지만,
+     *    add + size 같은 복합 로직은 한 덩어리로 묶어야 일관성이 맞기 때문이다.
+     */
+    @Override
+    public int enqueue(Long userId, QueueKey queueKey) {
+        if (userQueueMap.putIfAbsent(userId, queueKey) != null) {
+            throw new IllegalStateException("이미 매칭 대기열에 참가 중인 사용자입니다.");
+        }
+
+        Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
+
+        synchronized (queue) {
+            queue.addLast(new WaitingUser(userId, queueKey));
+            return queue.size();
+        }
+    }
+
+    /**
+     * SEARCHING 상태 유저를 대기열에서 제거한다.
+     *
+     * 동작 순서:
+     * 1. userQueueMap으로 유저가 어느 큐에 있는지 찾음
+     * 2. 실제 큐를 가져옴
+     * 3. 큐에서 해당 userId 제거
+     * 4. userQueueMap에서도 제거
+     * 5. 큐가 비었으면 waitingQueues에서도 제거
+     *
+     * 주의:
+     * - queue.removeIf(...)
+     * - userQueueMap.remove(...)
+     * - queue.size()
+     * - waitingQueues.remove(...)
+     *
+     * 이런 동작은 서로 논리적으로 연결되어 있기 때문에
+     * 같은 큐 락 안에서 처리해야 상태 불일치를 줄일 수 있다.
+     */
+    @Override
+    public CancelResult cancel(Long userId) {
+        QueueKey queueKey = userQueueMap.get(userId);
+
+        if (queueKey == null) {
+            throw new IllegalStateException("현재 매칭 대기열에 참가 중이 아닙니다.");
+        }
+
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        if (queue == null) {
+            userQueueMap.remove(userId);
+            throw new IllegalStateException("대기열 정보를 찾을 수 없습니다.");
+        }
+
+        int currentSize;
+        boolean removed;
+
+        synchronized (queue) {
+            removed = queue.removeIf(waitingUser -> waitingUser.getUserId().equals(userId));
+
+            if (!removed) {
+                throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
+            }
+
+            userQueueMap.remove(userId);
+            currentSize = queue.size();
+
+            if (currentSize == 0) {
+                waitingQueues.remove(queueKey, queue);
+            }
+        }
+
+        return new CancelResult(queueKey, currentSize);
+    }
+
+    /**
+     * 특정 큐에서 매칭 후보를 count명만큼 앞에서부터 꺼낸다.
+     *
+     * 동작 방식:
+     * - 큐가 없으면 null
+     * - 큐 인원이 부족하면 null
+     * - 충분하면 pollFirst()로 count명 추출
+     *
+     * 왜 pollFirst인가?
+     * -> 먼저 들어온 유저가 먼저 매칭되도록 FIFO 순서를 유지하기 위해서다.
+     *
+     * 왜 null을 반환하나?
+     * -> "아직 매칭 가능한 인원 수가 안 됨"을 서비스가 쉽게 판단하도록 하기 위함이다.
+     *
+     * 왜 중간 실패 시 즉시 롤백하나?
+     * -> count명 추출이 완전히 성공하지 못했다면
+     *    큐 상태를 원래대로 되돌려야 일관성이 유지되기 때문이다.
+     */
+    @Override
+    public List<WaitingUser> pollMatchCandidates(QueueKey queueKey, int count) {
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        if (queue == null) {
+            return null;
+        }
+
+        synchronized (queue) {
+            if (queue.size() < count) {
+                return null;
+            }
+
+            List<WaitingUser> matchedUsers = new ArrayList<>(count);
+
+            for (int i = 0; i < count; i++) {
+                WaitingUser user = queue.pollFirst();
+                if (user != null) {
+                    matchedUsers.add(user);
+                }
+            }
+
+            // poll 중 예상보다 적게 빠졌다면 즉시 롤백
+            if (matchedUsers.size() < count) {
+                for (int i = matchedUsers.size() - 1; i >= 0; i--) {
+                    queue.addFirst(matchedUsers.get(i));
+                }
+                return null;
+            }
+
+            return matchedUsers;
+        }
+    }
+
+    /**
+     * 방 생성 실패 시 poll했던 유저들을 다시 큐 앞으로 되돌린다.
+     *
+     * 왜 앞으로 되돌리나?
+     * -> 원래 pollFirst로 앞에서 꺼냈기 때문에
+     *    실패했다면 기존 대기 순서를 최대한 그대로 복구해야 하기 때문이다.
+     *
+     * 왜 역순으로 addFirst 하나?
+     * -> pollFirst로 꺼낸 순서를 유지하면서 원래 상태를 복원하려면
+     *    마지막 유저부터 addFirst 해야 최종 순서가 맞는다.
+     *
+     * 예:
+     * 꺼낸 순서가 [u1, u2, u3, u4] 라면
+     * 복구는 u4, u3, u2, u1 순으로 addFirst 해야
+     * 최종 큐가 [u1, u2, u3, u4, ...] 형태가 된다.
+     */
+    @Override
+    public void rollbackPolledUsers(QueueKey queueKey, List<WaitingUser> users) {
+        if (users == null || users.isEmpty()) {
+            return;
+        }
+
+        Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
+
+        synchronized (queue) {
+            // pollFirst로 꺼낸 순서를 유지하려면 역순으로 addFirst
+            for (int i = users.size() - 1; i >= 0; i--) {
+                queue.addFirst(users.get(i));
+            }
+        }
+    }
+
+    /**
+     * 방 생성 성공 시 유저들을 SEARCHING -> MATCHED 상태로 전환한다.
+     *
+     * 동작 순서:
+     * 1. userQueueMap에서 제거
+     *    -> 더 이상 대기열 참가 상태가 아님
+     * 2. matchedRoomMap에 roomId 기록
+     *    -> /matches/me 조회 시 MATCHED + roomId 응답 가능
+     * 3. 해당 큐가 비었으면 waitingQueues에서도 제거
+     *
+     * 즉, 이 시점부터 유저는
+     * "대기열에 있는 사용자"가 아니라
+     * "입장해야 할 방이 정해진 사용자"가 된다.
+     */
+    @Override
+    public void markMatched(QueueKey queueKey, List<WaitingUser> matchedUsers, Long roomId) {
+        matchedUsers.forEach(user -> {
+            userQueueMap.remove(user.getUserId());
+            matchedRoomMap.put(user.getUserId(), roomId);
+        });
+
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        if (queue == null) {
+            return;
+        }
+
+        synchronized (queue) {
+            if (queue.isEmpty()) {
+                waitingQueues.remove(queueKey, queue);
+            }
+        }
+    }
+
+    /**
+     * 현재 해당 큐의 대기 인원 수를 반환한다.
+     *
+     * queue.size() 조회도 복합 로직과 섞일 수 있으므로
+     * 큐 락 안에서 읽어서 일관성을 최대한 맞춘다.
+     */
+    @Override
+    public int getWaitingCount(QueueKey queueKey) {
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        if (queue == null) {
+            return 0;
+        }
+
+        synchronized (queue) {
+            return queue.size();
+        }
+    }
+
+    /**
+     * /queue/me 응답용 상태 조회
+     *
+     * 반환 의미:
+     * - isInQueue = true  -> 현재 SEARCHING 상태로 큐에 들어가 있음
+     * - isInQueue = false -> 큐에 들어가 있지 않음
+     *
+     * 왜 userQueueMap과 waitingQueues를 둘 다 확인하나?
+     * -> userQueueMap만 믿으면 논리상 큐 참가 중처럼 보일 수 있지만,
+     *    실제 큐 객체가 없을 수도 있으므로 최종적으로 실제 큐 존재 여부도 확인한다.
+     *
+     * 현재 정책:
+     * - userQueueMap에는 있는데 실제 queue가 없으면
+     *   조회 시 false 처리하고 stale 데이터 정리
+     */
+    @Override
+    public QueueStateResponse getQueueState(Long userId) {
+        QueueKey queueKey = userQueueMap.get(userId);
+
+        if (queueKey == null) {
+            return new QueueStateResponse(false, null, null, 0);
+        }
+
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        // 기존 동작 유지:
+        // userQueueMap에는 있는데 실제 queue가 없으면 조회 시 false 처리하고 정리
+        if (queue == null) {
+            userQueueMap.remove(userId, queueKey);
+            return new QueueStateResponse(false, null, null, 0);
+        }
+
+        synchronized (queue) {
+            return new QueueStateResponse(
+                    true, queueKey.category(), queueKey.difficulty().name(), queue.size());
+        }
+    }
+
+    /**
+     * /matches/me 응답용 상태 조회
+     *
+     * 우선순위:
+     * 1. matchedRoomMap에 있으면 MATCHED
+     * 2. userQueueMap에 있으면 SEARCHING
+     * 3. 둘 다 없으면 IDLE
+     *
+     * 즉 상태 해석은 다음과 같다.
+     * - MATCHED   : 방이 잡혔고 roomId가 있음
+     * - SEARCHING : 아직 큐에서 매칭 대기 중
+     * - IDLE      : 대기 중도 아니고 매칭 완료 상태도 아님
+     */
+    @Override
+    public MatchStateResponse getMatchState(Long userId) {
+        Long roomId = matchedRoomMap.get(userId);
+
+        if (roomId != null) {
+            return new MatchStateResponse("MATCHED", roomId);
+        }
+
+        if (userQueueMap.containsKey(userId)) {
+            return new MatchStateResponse("SEARCHING", null);
+        }
+
+        return new MatchStateResponse("IDLE", null);
+    }
+
+    /**
+     * 방 입장 성공 후 matched 상태를 정리한다.
+     *
+     * remove(userId, roomId) 형태를 사용하면
+     * "해당 유저가 정말 그 roomId로 매칭되어 있을 때만" 제거된다.
+     *
+     * 즉, 잘못된 roomId 요청으로 다른 매칭 정보가 지워지는 것을 막는 안전장치 역할도 한다.
+     */
+    @Override
+    public void clearMatchedRoom(Long userId, Long roomId) {
+        matchedRoomMap.remove(userId, roomId);
+    }
+
+    /**
+     * 테스트 호환용 보조 메서드
+     *
+     * 현재 해당 queueKey에 대한 큐 객체가 존재하는지만 확인한다.
+     * 실서비스 핵심 로직보다는 테스트/검증 성격에 가깝다.
+     */
+    @Override
+    public boolean hasQueue(QueueKey queueKey) {
+        return waitingQueues.containsKey(queueKey);
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
@@ -1,0 +1,74 @@
+package com.back.domain.matching.queue.store;
+
+import java.util.List;
+
+import com.back.domain.matching.queue.dto.MatchStateResponse;
+import com.back.domain.matching.queue.dto.QueueStateResponse;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.WaitingUser;
+
+/**
+ * 매칭 상태 저장소 추상화
+ *
+ * 지금은 인메모리 구현체를 사용하지만,
+ * 이후 Redis 등으로 교체할 수 있도록 저장 경계를 먼저 만든다.
+ */
+public interface MatchStateStore {
+
+    /**
+     * cancel 결과를 서비스 계층이 응답 DTO로 조립하기 쉽도록 최소 정보만 담는다.
+     */
+    record CancelResult(QueueKey queueKey, int waitingCount) {}
+
+    /**
+     * 유저를 큐에 넣고 현재 큐 크기를 반환한다.
+     * 이미 같은 유저가 대기 중이면 예외를 던진다.
+     */
+    int enqueue(Long userId, QueueKey queueKey);
+
+    /**
+     * SEARCHING 상태 유저를 큐에서 제거한다.
+     */
+    CancelResult cancel(Long userId);
+
+    /**
+     * 특정 큐에서 매칭 후보를 count명만큼 poll한다.
+     * 인원이 부족하면 null을 반환한다.
+     */
+    List<WaitingUser> pollMatchCandidates(QueueKey queueKey, int count);
+
+    /**
+     * 방 생성 실패 시 poll했던 유저들을 큐로 되돌린다.
+     */
+    void rollbackPolledUsers(QueueKey queueKey, List<WaitingUser> users);
+
+    /**
+     * 방 생성 성공 시 유저들을 SEARCHING -> MATCHED 상태로 전환한다.
+     */
+    void markMatched(QueueKey queueKey, List<WaitingUser> matchedUsers, Long roomId);
+
+    /**
+     * 현재 해당 큐의 대기 인원 수를 반환한다.
+     */
+    int getWaitingCount(QueueKey queueKey);
+
+    /**
+     * queue/me 응답용 상태 조회
+     */
+    QueueStateResponse getQueueState(Long userId);
+
+    /**
+     * matches/me 응답용 상태 조회
+     */
+    MatchStateResponse getMatchState(Long userId);
+
+    /**
+     * 방 입장 성공 후 matched 상태를 정리한다.
+     */
+    void clearMatchedRoom(Long userId, Long roomId);
+
+    /**
+     * 기존 테스트 호환용
+     */
+    boolean hasQueue(QueueKey queueKey);
+}

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -19,18 +19,23 @@ import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.adapter.QueueProblemPicker;
+import com.back.domain.matching.queue.dto.MatchStateResponse;
 import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStateResponse;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.Difficulty;
 import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
+import com.back.domain.matching.queue.store.MatchStateStore;
 
 class MatchingQueueServiceTest {
 
     private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
     private final QueueProblemPicker queueProblemPicker = mock(QueueProblemPicker.class);
+    private final MatchStateStore matchStateStore = new InMemoryMatchStateStore();
+
     private final MatchingQueueService matchingQueueService =
-            new MatchingQueueService(battleRoomService, queueProblemPicker);
+            new MatchingQueueService(battleRoomService, queueProblemPicker, matchStateStore);
 
     @BeforeEach
     void setUp() {
@@ -82,7 +87,7 @@ class MatchingQueueServiceTest {
         QueueStatusResponse response = matchingQueueService.cancelQueue(userId);
 
         // then
-        assertThat(response.getMessage()).isEqualTo("매칭 대기열에서 취소되었습니다.");
+        assertThat(response.getMessage()).isEqualTo("매칭 대기열에서 취소했습니다.");
         assertThat(response.getCategory()).isEqualTo("ARRAY");
         assertThat(response.getDifficulty()).isEqualTo("EASY");
         assertThat(response.getWaitingCount()).isEqualTo(0);
@@ -285,5 +290,99 @@ class MatchingQueueServiceTest {
         assertThat(response.category()).isNull();
         assertThat(response.difficulty()).isNull();
         assertThat(response.waitingCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("큐에 있는 사용자는 matches/me 조회 시 SEARCHING 상태를 반환한다")
+    void getMyMatchState_returnsSearching_whenUserInQueue() {
+        // given
+        Long userId = 1L;
+        matchingQueueService.joinQueue(userId, createRequest("Array", Difficulty.EASY));
+
+        // when
+        MatchStateResponse response = matchingQueueService.getMyMatchState(userId);
+
+        // then
+        assertThat(response.status()).isEqualTo("SEARCHING");
+        assertThat(response.roomId()).isNull();
+    }
+
+    @Test
+    @DisplayName("4명 매칭이 완료되면 매칭된 4명 모두 MATCHED와 같은 roomId를 반환한다")
+    void getMyMatchState_returnsMatched_whenRoomCreated() {
+        // given
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(4L, createRequest("Array", Difficulty.EASY));
+
+        // when
+        MatchStateResponse response1 = matchingQueueService.getMyMatchState(1L);
+        MatchStateResponse response2 = matchingQueueService.getMyMatchState(2L);
+        MatchStateResponse response3 = matchingQueueService.getMyMatchState(3L);
+        MatchStateResponse response4 = matchingQueueService.getMyMatchState(4L);
+
+        // then
+        assertThat(response1.status()).isEqualTo("MATCHED");
+        assertThat(response2.status()).isEqualTo("MATCHED");
+        assertThat(response3.status()).isEqualTo("MATCHED");
+        assertThat(response4.status()).isEqualTo("MATCHED");
+
+        assertThat(response1.roomId()).isEqualTo(100L);
+        assertThat(response2.roomId()).isEqualTo(100L);
+        assertThat(response3.roomId()).isEqualTo(100L);
+        assertThat(response4.roomId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("clearMatchedRoom은 입장 완료한 사용자만 IDLE로 바꾸고 나머지는 MATCHED를 유지한다")
+    void clearMatchedRoom_removesOnlyTargetUser() {
+        // given
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(4L, createRequest("Array", Difficulty.EASY));
+
+        // when
+        matchingQueueService.clearMatchedRoom(4L, 100L);
+
+        // then
+        assertThat(matchingQueueService.getMyMatchState(4L).status()).isEqualTo("IDLE");
+        assertThat(matchingQueueService.getMyMatchState(4L).roomId()).isNull();
+
+        assertThat(matchingQueueService.getMyMatchState(1L).status()).isEqualTo("MATCHED");
+        assertThat(matchingQueueService.getMyMatchState(2L).status()).isEqualTo("MATCHED");
+        assertThat(matchingQueueService.getMyMatchState(3L).status()).isEqualTo("MATCHED");
+
+        assertThat(matchingQueueService.getMyMatchState(1L).roomId()).isEqualTo(100L);
+        assertThat(matchingQueueService.getMyMatchState(2L).roomId()).isEqualTo(100L);
+        assertThat(matchingQueueService.getMyMatchState(3L).roomId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("clearMatchedRoom은 roomId가 다르면 매칭 상태를 지우지 않는다")
+    void clearMatchedRoom_doesNothing_whenRoomIdDoesNotMatch() {
+        // given
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(4L, createRequest("Array", Difficulty.EASY));
+
+        // when
+        matchingQueueService.clearMatchedRoom(1L, 999L);
+
+        // then
+        MatchStateResponse response = matchingQueueService.getMyMatchState(1L);
+        assertThat(response.status()).isEqualTo("MATCHED");
+        assertThat(response.roomId()).isEqualTo(100L);
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #73 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #73 

---

<html>
<body>
<hr>

<h1>매칭 상태 저장소 분리 및 QueueProblemPicker 실제 로직 복구</h1>

<p>이번 PR은 기존 <code>MatchingQueueService</code> 내부에 직접 존재하던 인메모리 매칭 상태 저장 로직을 별도 <code>store</code> 계층으로 분리한 리팩터링입니다.</p>
<p>핵심 목적은 현재 <code>/api/v1</code> 매칭 동작은 유지하면서, 이후 롤 매칭 상태 모델 확장이나 Redis 저장소 교체가 가능하도록 저장 경계를 먼저 만드는 것입니다.</p>
<p>또한 중간에 임시로 고정했던 <code>problemId = 1</code> 처리 대신, 최종적으로는 <code>QueueProblemPicker</code>가 다시 <code>ProblemPickService</code>를 호출하도록 복구해 테스트 및 실제 흐름과 맞추었습니다.</p>

<hr>

<h3>관련 커밋</h3>
<ul>
<li><code>c977ae1</code> <code>refactor: 매칭 상태 저장소를 store로 분리하고 problemId 1만 저장되도록 임시 처리</code></li>
<li><code>a0f2359</code> <code>fix: QueueProblemPicker가 실제 문제 선택 서비스를 호출하도록 복구</code></li>
</ul>

<hr>

<h3>1. 왜 이 작업을 했는가</h3>
<p>기존 매칭 코드는 <code>MatchingQueueService</code> 안에서 아래 상태를 모두 직접 들고 있었습니다.</p>
<ul>
<li><code>waitingQueues</code>: 카테고리/난이도별 실제 대기열</li>
<li><code>userQueueMap</code>: 특정 유저가 현재 어느 큐에 있는지</li>
<li><code>matchedRoomMap</code>: 매칭 완료 후 유저가 어느 방으로 가야 하는지</li>
</ul>

<p>이 구조는 MVP 단계에서는 동작하지만, 이후 아래와 같은 확장을 생각하면 서비스가 너무 많은 책임을 지게 됩니다.</p>
<ul>
<li>롤 매칭 상태 모델 도입</li>
<li><code>matchId</code> 기반 그룹 상태 관리</li>
<li>수락/거절/만료 상태 추가</li>
<li>인메모리에서 Redis 저장소로 교체</li>
</ul>

<p>그래서 이번 PR에서는 외부 API를 바꾸기보다, 먼저 <strong>서비스와 저장 구현을 분리하는 1차 구조 정리</strong>를 진행했습니다.</p>

<hr>

<h3>2. MatchStateStore 계층 도입</h3>

<h4>2-1. MatchStateStore 인터페이스 추가</h4>
<p>매칭 상태 저장 책임을 추상화하기 위해 <code>MatchStateStore</code> 인터페이스를 추가했습니다.</p>
<p>이 인터페이스는 매칭 흐름에 필요한 최소한의 저장 연산만 제공합니다.</p>

<ul>
<li><code>enqueue()</code></li>
<li><code>cancel()</code></li>
<li><code>pollMatchCandidates()</code></li>
<li><code>rollbackPolledUsers()</code></li>
<li><code>markMatched()</code></li>
<li><code>getWaitingCount()</code></li>
<li><code>getQueueState()</code></li>
<li><code>getMatchState()</code></li>
<li><code>clearMatchedRoom()</code></li>
<li><code>hasQueue()</code></li>
</ul>

<p>즉 서비스는 이제 매칭 흐름을 제어하고, 저장 구현은 store가 맡는 구조로 바뀌었습니다.</p>

<h4>2-2. InMemoryMatchStateStore 구현체 추가</h4>
<p>현재는 기존과 동일하게 인메모리 기반 매칭을 유지하므로, 첫 구현체로 <code>InMemoryMatchStateStore</code>를 추가했습니다.</p>
<p>기존 서비스 안에 있던 아래 상태 저장소를 이 구현체로 이동했습니다.</p>

<ul>
<li><code>waitingQueues</code></li>
<li><code>userQueueMap</code></li>
<li><code>matchedRoomMap</code></li>
</ul>

<p>동시성 측면에서도 기존 정책을 유지했습니다. 큐 단위 복합 연산은 <code>synchronized(queue)</code>로 보호하여 다음 동작을 한 덩어리로 처리합니다.</p>
<ul>
<li>큐 참가 시 <code>addLast + size</code></li>
<li>취소 시 <code>removeIf + size + empty queue cleanup</code></li>
<li>매칭 후보 추출 시 <code>size check + pollFirst</code></li>
<li>방 생성 실패 시 rollback</li>
<li><code>queue/me</code> 조회 시 waitingCount 계산</li>
</ul>

<p>즉 이번 PR은 동시성 정책을 새로 만든 것이 아니라, <strong>기존 인메모리 정책을 store 안으로 이동</strong>한 작업입니다.</p>

<hr>

<h3>3. MatchingQueueService 책임 축소</h3>
<p>기존 <code>MatchingQueueService</code>는 직접 상태 맵을 조작하면서 비즈니스 흐름과 저장 구현을 동시에 알고 있었습니다.</p>
<p>이번 PR 이후 서비스는 store를 주입받아 아래 흐름 중심 책임만 갖습니다.</p>

<ul>
<li><code>joinQueue()</code>: 큐 참가 요청 처리 및 매칭 시도 여부 판단</li>
<li><code>cancelQueue()</code>: 취소 요청 처리 및 응답 조립</li>
<li><code>tryMatchAndCreateRoom()</code>: 4명 후보 추출, 문제 선택, 방 생성 호출</li>
<li><code>getMyQueueState()</code>: queue 상태 조회 위임</li>
<li><code>getMyMatchState()</code>: match 상태 조회 위임</li>
<li><code>clearMatchedRoom()</code>: 방 입장 후 matched 상태 정리 위임</li>
</ul>

<p>특히 아래 변경이 핵심입니다.</p>
<ul>
<li>서비스 내부 직접적인 <code>Map</code>/<code>Deque</code> 조작 제거</li>
<li>4명 추출을 <code>pollMatchCandidates()</code>로 위임</li>
<li>방 생성 실패 rollback을 <code>rollbackPolledUsers()</code>로 위임</li>
<li>방 생성 성공 후 <code>SEARCHING -&gt; MATCHED</code> 전환을 <code>markMatched()</code>로 위임</li>
</ul>

<p>즉 서비스는 “무엇을 할지”를, store는 “어떻게 저장할지”를 담당하도록 정리했습니다.</p>

<hr>

<h3>4. QueueProblemPicker 실제 로직 복구</h3>
<p>초기 리팩터링 과정에서는 매칭 흐름을 빠르게 확인하기 위해 <code>QueueProblemPicker</code>가 임시로 <code>1L</code>만 반환하도록 고정한 상태가 있었습니다.</p>
<p>하지만 이 방식은 기존 테스트 및 실제 문제 선택 흐름과 어긋나기 때문에, 최종적으로는 다시 아래 형태로 복구했습니다.</p>

<ul>
<li><code>queueKey</code>와 참가자 목록을 사용</li>
<li><code>Difficulty</code>를 <code>DifficultyLevel</code>로 변환</li>
<li><code>ProblemPickService.pickProblemId(...)</code> 호출</li>
</ul>

<p>즉 현재 브랜치 기준으로는 <strong>임시 problemId 고정 로직이 남아 있지 않고, 실제 문제 선택 서비스 연동 구조를 유지</strong>합니다.</p>

<hr>

<h3>5. 테스트 코드 보강</h3>
<p>기존 <code>MatchingQueueServiceTest</code>는 주로 아래 시나리오를 검증하고 있었습니다.</p>
<ul>
<li>join 성공</li>
<li>중복 join 방지</li>
<li>cancel 성공/실패</li>
<li>빈 큐 정리</li>
<li>4번째 유저에서 방 생성</li>
<li>방 생성 실패 rollback</li>
<li><code>queue/me</code> 응답</li>
</ul>

<p>이번 PR에서는 store 분리 구조에 맞게 생성자를 변경하고, 실제 <code>InMemoryMatchStateStore</code>를 붙여 서비스+store 조합을 검증하도록 수정했습니다.</p>

<p>또한 match state 생명주기 테스트를 추가했습니다.</p>
<ul>
<li>큐에 있는 사용자는 <code>SEARCHING</code> 상태를 반환하는지</li>
<li>4명 매칭 후 4명 모두 <code>MATCHED</code>와 동일한 <code>roomId</code>를 가지는지</li>
<li><code>clearMatchedRoom()</code> 호출 시 해당 사용자만 <code>IDLE</code>로 바뀌는지</li>
<li>잘못된 <code>roomId</code>로는 matched 상태가 지워지지 않는지</li>
</ul>

<p>즉 이번 PR은 단순히 store를 분리한 것뿐 아니라, <strong>store 분리 후 중요해진 match state 동작까지 테스트 범위를 확장</strong>한 작업입니다.</p>

<hr>

<h3>6. 외부 API 관점 변화</h3>
<p>이번 PR의 중심은 내부 구조 리팩터링이므로, 외부 API 계약은 유지했습니다.</p>
<ul>
<li><code>/api/v1/queue/join</code> 유지</li>
<li><code>/api/v1/queue/cancel</code> 유지</li>
<li><code>/api/v1/queue/me</code> 유지</li>
<li><code>/api/v1/matches/me</code> 유지</li>
</ul>

<p>즉 프론트는 API 경로나 응답 스키마를 바꾸지 않고 기존 연동 흐름을 그대로 유지할 수 있습니다.</p>

<hr>

<h3>7. 정리</h3>
<ul>
<li><code>MatchingQueueService</code> 내부 상태 저장 로직을 별도 <code>store</code> 계층으로 분리</li>
<li><code>MatchStateStore</code> 인터페이스와 <code>InMemoryMatchStateStore</code> 구현체 추가</li>
<li>서비스는 흐름 제어, store는 자료구조 조작으로 책임 분리</li>
<li>기존 인메모리 매칭 동작과 큐 단위 동시성 정책은 유지</li>
<li><code>QueueProblemPicker</code>는 임시 고정 로직을 제거하고 실제 <code>ProblemPickService</code> 호출로 복구</li>
<li><code>MatchingQueueServiceTest</code>를 store 분리 구조에 맞게 수정하고 <code>matches/me</code> 관련 테스트 추가</li>
<li>외부 API는 그대로 유지하여 <code>/api/v1</code> 계약은 깨지지 않음</li>
</ul>

<p>즉 이번 PR은 <strong>현재 매칭 기능을 유지한 채 저장 책임을 store로 분리하고, 이후 롤 매칭 상태 모델 확장이나 Redis 저장소 교체를 위한 구조적 기반을 마련한 리팩터링</strong>이며, 문제 선택 로직도 최종적으로 실제 서비스 호출 방식으로 정리한 작업입니다.</p>

</body>
</html>

