### PR TITLE
[Feat] matchsession 도입으로 매칭 상태를 그룹 중심 구조로 전환

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/model/MatchSession.java
+++ b/src/main/java/com/back/domain/matching/queue/model/MatchSession.java
@@ -1,0 +1,41 @@
+package com.back.domain.matching.queue.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 하나의 매치 그룹 상태를 표현하는 모델
+ *
+ * 기존에는 userId -> roomId 형태로만 매칭 완료 상태를 저장했기 때문에
+ * "이 사용자들이 하나의 매치였다"는 그룹 정보를 표현하기 어려웠다.
+ *
+ * 이번 단계에서는 MatchSession을 도입해서
+ * 매칭 완료 상태를 유저 단위가 아니라 매치 단위로 저장한다.
+ *
+ * 현재는 프론트 변경 없이 기존 MATCHED 흐름을 유지하는 단계라
+ * roomId가 이미 존재하는 MATCHED 상태만 다룬다.
+ */
+public record MatchSession(
+        Long matchId, List<Long> participantIds, MatchSessionStatus status, Long roomId, LocalDateTime createdAt) {
+
+    /**
+     * 현재 단계에서는 4명 매칭이 끝나고 roomId까지 생성된 시점에만
+     * MatchSession을 만들기 때문에 status=MATCHED, roomId!=null 을 기본 규칙으로 둔다.
+     */
+    public static MatchSession matched(Long matchId, List<Long> participantIds, Long roomId) {
+        if (matchId == null) {
+            throw new IllegalArgumentException("matchId는 필수입니다.");
+        }
+
+        if (participantIds == null || participantIds.isEmpty()) {
+            throw new IllegalArgumentException("participantIds는 비어 있을 수 없습니다.");
+        }
+
+        if (roomId == null) {
+            throw new IllegalArgumentException("MATCHED 상태의 roomId는 필수입니다.");
+        }
+
+        return new MatchSession(
+                matchId, List.copyOf(participantIds), MatchSessionStatus.MATCHED, roomId, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/model/MatchSessionStatus.java
+++ b/src/main/java/com/back/domain/matching/queue/model/MatchSessionStatus.java
@@ -1,0 +1,18 @@
+package com.back.domain.matching.queue.model;
+
+/**
+ * 매치 세션의 현재 상태를 나타낸다.
+ *
+ * 이번 단계에서는 프론트/API를 바꾸지 않는 것이 목표이므로
+ * 최소 상태만 먼저 도입한다.
+ *
+ * - MATCHED: 4명 매칭이 완료되고 roomId까지 배정된 상태
+ * - CLOSED:  모든 참가자의 매칭 연결이 정리되어 더 이상 조회 대상이 아닌 상태
+ *
+ * 이후 롤 매칭 단계로 확장할 때
+ * ACCEPT_PENDING, DECLINED, EXPIRED 같은 상태를 여기에 추가할 수 있다.
+ */
+public enum MatchSessionStatus {
+    MATCHED,
+    CLOSED
+}

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -100,7 +100,7 @@ public class MatchingQueueService {
             CreateRoomResponse response =
                     battleRoomService.createRoom(new CreateRoomRequest(problemId, participantIds, 4));
 
-            // EARCHING -> MATCHED 전환도 store가 담당
+            // SEARCHING -> MATCHED 전환도 store가 담당
             matchStateStore.markMatched(queueKey, matchedUsers, response.roomId());
 
             return response;

--- a/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
@@ -6,11 +6,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.springframework.stereotype.Component;
 
 import com.back.domain.matching.queue.dto.MatchStateResponse;
 import com.back.domain.matching.queue.dto.QueueStateResponse;
+import com.back.domain.matching.queue.model.MatchSession;
+import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
 
@@ -20,7 +23,8 @@ import com.back.domain.matching.queue.model.WaitingUser;
  * 역할:
  * - 실제 대기열(waitingQueues)
  * - 유저별 큐 참여 정보(userQueueMap)
- * - 유저별 매칭 완료 room 정보(matchedRoomMap)
+ * - 유저별 매치 연결 정보(userMatchMap)
+ * - 매치 그룹 상태 본문(matchSessionMap)
  *
  * 를 한 곳에 모아두고,
  * MatchingQueueService는 이 저장소를 통해서만 상태를 다루게 만든다.
@@ -62,17 +66,34 @@ public class InMemoryMatchStateStore implements MatchStateStore {
     private final Map<Long, QueueKey> userQueueMap = new ConcurrentHashMap<>();
 
     /**
-     * 매칭 완료 후 유저가 어느 방으로 이동해야 하는지 저장
+     * 특정 유저가 현재 어느 매치 세션에 연결되어 있는지 찾는 인덱스
      *
-     * 목적:
-     * - /matches/me 조회 시 MATCHED 상태와 roomId 반환
-     * - 방 입장 성공 후 clearMatchedRoom으로 정리
+     * 기존에는 userId -> roomId 만 저장했지만,
+     * 이제는 유저가 "어느 매치 그룹에 속하는지"를 먼저 찾고
+     * 실제 매치 상태는 MatchSession 본문에서 조회한다.
      *
      * 예:
-     * 1L -> 101L
-     * 7L -> 101L
+     * 1L -> 10L
+     * 2L -> 10L
      */
-    private final Map<Long, Long> matchedRoomMap = new ConcurrentHashMap<>();
+    private final Map<Long, Long> userMatchMap = new ConcurrentHashMap<>();
+
+    /**
+     * matchId 기준 실제 매치 그룹 상태를 저장하는 본문
+     *
+     * 지금 단계에서는 MATCHED 상태와 roomId만 담지만,
+     * 이후 ready-check 단계로 가면 acceptedUsers, deadline 같은 상태를
+     * 여기에 확장해서 넣을 수 있다.
+     */
+    private final Map<Long, MatchSession> matchSessionMap = new ConcurrentHashMap<>();
+
+    /**
+     * 인메모리 환경에서 matchId를 순차적으로 발급하기 위한 시퀀스
+     *
+     * 지금은 단일 서버 MVP 기준이라 AtomicLong으로 충분하고,
+     * 이후 Redis 전환 시에는 외부 저장소 기준 ID 생성 전략으로 교체할 수 있다.
+     */
+    private final AtomicLong matchSequence = new AtomicLong(1L);
 
     /**
      * 유저를 대기열에 넣는다.
@@ -249,19 +270,30 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      * 동작 순서:
      * 1. userQueueMap에서 제거
      *    -> 더 이상 대기열 참가 상태가 아님
-     * 2. matchedRoomMap에 roomId 기록
-     *    -> /matches/me 조회 시 MATCHED + roomId 응답 가능
+     * 2. MatchSession을 생성하고 각 유저를 해당 matchId에 연결
+     *    -> /matches/me 조회 시 userId -> matchId -> MatchSession 순서로 MATCHED + roomId 응답 가능
      * 3. 해당 큐가 비었으면 waitingQueues에서도 제거
      *
      * 즉, 이 시점부터 유저는
      * "대기열에 있는 사용자"가 아니라
-     * "입장해야 할 방이 정해진 사용자"가 된다.
+     * "어느 매치 그룹에 속해 있고, 그 결과로 입장해야 할 방이 정해진 사용자"가 된다.
      */
     @Override
     public void markMatched(QueueKey queueKey, List<WaitingUser> matchedUsers, Long roomId) {
+        Long matchId = matchSequence.getAndIncrement();
+
+        List<Long> participantIds =
+                matchedUsers.stream().map(WaitingUser::getUserId).toList();
+
+        MatchSession matchSession = MatchSession.matched(matchId, participantIds, roomId);
+
+        // 세션 본문을 먼저 저장해두면, 이후 userMatchMap 연결 시점에
+        // /matches/me 조회가 들어와도 matchId -> session 조회가 가능하다.
+        matchSessionMap.put(matchId, matchSession);
+
         matchedUsers.forEach(user -> {
             userQueueMap.remove(user.getUserId());
-            matchedRoomMap.put(user.getUserId(), roomId);
+            userMatchMap.put(user.getUserId(), matchId);
         });
 
         Deque<WaitingUser> queue = waitingQueues.get(queueKey);
@@ -338,9 +370,11 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      * /matches/me 응답용 상태 조회
      *
      * 우선순위:
-     * 1. matchedRoomMap에 있으면 MATCHED
-     * 2. userQueueMap에 있으면 SEARCHING
-     * 3. 둘 다 없으면 IDLE
+     * 1. userMatchMap에 연결된 matchId가 있으면 MatchSession 조회
+     * 2. session이 살아 있고 MATCHED 상태면 MATCHED
+     * 3. userMatchMap은 있는데 session이 없으면 stale 상태로 보고 정리
+     * 4. userQueueMap에 있으면 SEARCHING
+     * 5. 둘 다 없으면 IDLE
      *
      * 즉 상태 해석은 다음과 같다.
      * - MATCHED   : 방이 잡혔고 roomId가 있음
@@ -349,10 +383,18 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      */
     @Override
     public MatchStateResponse getMatchState(Long userId) {
-        Long roomId = matchedRoomMap.get(userId);
+        Long matchId = userMatchMap.get(userId);
 
-        if (roomId != null) {
-            return new MatchStateResponse("MATCHED", roomId);
+        if (matchId != null) {
+            MatchSession matchSession = matchSessionMap.get(matchId);
+
+            if (matchSession != null && matchSession.status() == MatchSessionStatus.MATCHED) {
+                return new MatchStateResponse("MATCHED", matchSession.roomId());
+            }
+
+            // userMatchMap에는 연결이 남아 있는데 실제 세션이 없으면
+            // 더 이상 유효한 매칭 상태가 아니므로 조회 시점에 정리한다.
+            cleanupStaleUserMatch(userId, matchId);
         }
 
         if (userQueueMap.containsKey(userId)) {
@@ -365,14 +407,37 @@ public class InMemoryMatchStateStore implements MatchStateStore {
     /**
      * 방 입장 성공 후 matched 상태를 정리한다.
      *
-     * remove(userId, roomId) 형태를 사용하면
-     * "해당 유저가 정말 그 roomId로 매칭되어 있을 때만" 제거된다.
+     * 지금 단계에서는 "방 입장을 끝낸 사용자"만 userMatchMap에서 분리하고,
+     * 같은 matchId를 참조하는 사용자가 더 이상 없을 때만 MatchSession 본문도 제거한다.
      *
-     * 즉, 잘못된 roomId 요청으로 다른 매칭 정보가 지워지는 것을 막는 안전장치 역할도 한다.
+     * roomId를 함께 검증하는 이유:
+     * 잘못된 roomId 요청으로 다른 매치 연결이 지워지지 않도록 하기 위해서다.
      */
     @Override
     public void clearMatchedRoom(Long userId, Long roomId) {
-        matchedRoomMap.remove(userId, roomId);
+        if (roomId == null) {
+            return;
+        }
+
+        Long matchId = userMatchMap.get(userId);
+
+        if (matchId == null) {
+            return;
+        }
+
+        MatchSession matchSession = matchSessionMap.get(matchId);
+
+        if (matchSession == null) {
+            userMatchMap.remove(userId, matchId);
+            return;
+        }
+
+        if (!roomId.equals(matchSession.roomId())) {
+            return;
+        }
+
+        userMatchMap.remove(userId, matchId);
+        removeMatchSessionIfUnreferenced(matchId);
     }
 
     /**
@@ -384,5 +449,28 @@ public class InMemoryMatchStateStore implements MatchStateStore {
     @Override
     public boolean hasQueue(QueueKey queueKey) {
         return waitingQueues.containsKey(queueKey);
+    }
+
+    /**
+     * userMatchMap에는 연결이 남아 있지만 실제 MatchSession이 없을 때
+     * 조회 시점에 해당 사용자의 stale 연결을 정리한다.
+     */
+    private void cleanupStaleUserMatch(Long userId, Long matchId) {
+        userMatchMap.remove(userId, matchId);
+        removeMatchSessionIfUnreferenced(matchId);
+    }
+
+    /**
+     * 같은 matchId를 참조하는 사용자가 더 이상 없으면
+     * MatchSession 본문도 함께 제거한다.
+     *
+     * 현재는 한 매치 최대 인원이 작고(4명), 인메모리 MVP 단계라
+     * containsValue 기반 선형 확인으로도 충분하다.
+     * 이후 Redis 단계에서는 더 적합한 카운트/집합 구조로 바꿀 수 있다.
+     */
+    private void removeMatchSessionIfUnreferenced(Long matchId) {
+        if (!userMatchMap.containsValue(matchId)) {
+            matchSessionMap.remove(matchId);
+        }
     }
 }

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingQueueServiceTest.java
@@ -190,6 +190,10 @@ class MatchingQueueServiceTest {
         // 원복 확인: 1번 사용자를 취소하면 4명 중 1명만 빠져 3명이 남아야 한다.
         QueueStatusResponse cancelResponse = matchingQueueService.cancelQueue(1L);
         assertThat(cancelResponse.getWaitingCount()).isEqualTo(3);
+
+        // 매칭 세션이 만들어지지 않았으므로 여전히 SEARCHING 상태여야 한다.
+        assertThat(matchingQueueService.getMyMatchState(2L).status()).isEqualTo("SEARCHING");
+        assertThat(matchingQueueService.getMyMatchState(2L).roomId()).isNull();
     }
 
     @Test
@@ -384,5 +388,30 @@ class MatchingQueueServiceTest {
         MatchStateResponse response = matchingQueueService.getMyMatchState(1L);
         assertThat(response.status()).isEqualTo("MATCHED");
         assertThat(response.roomId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("매칭된 모든 사용자가 roomId를 소비하면 전원 IDLE 상태가 된다")
+    void clearMatchedRoom_returnsAllUsersToIdle_whenAllUsersEnter() {
+        // given
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        matchingQueueService.joinQueue(1L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(2L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(3L, createRequest("Array", Difficulty.EASY));
+        matchingQueueService.joinQueue(4L, createRequest("Array", Difficulty.EASY));
+
+        // when
+        matchingQueueService.clearMatchedRoom(1L, 100L);
+        matchingQueueService.clearMatchedRoom(2L, 100L);
+        matchingQueueService.clearMatchedRoom(3L, 100L);
+        matchingQueueService.clearMatchedRoom(4L, 100L);
+
+        // then
+        assertThat(matchingQueueService.getMyMatchState(1L).status()).isEqualTo("IDLE");
+        assertThat(matchingQueueService.getMyMatchState(2L).status()).isEqualTo("IDLE");
+        assertThat(matchingQueueService.getMyMatchState(3L).status()).isEqualTo("IDLE");
+        assertThat(matchingQueueService.getMyMatchState(4L).status()).isEqualTo("IDLE");
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #79 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #79 

---

<html>
<body>
<h1>MatchSession 도입으로 매칭 상태를 그룹 중심 구조로 전환</h1>

<p>이번 PR은 기존의 <code>matchedRoomMap(userId -&gt; roomId)</code> 중심 매칭 완료 상태를
<code>userMatchMap(userId -&gt; matchId)</code> + <code>matchSessionMap(matchId -&gt; MatchSession)</code> 구조로 전환한 리팩터링입니다.</p>

<p>핵심 목적은 현재 <code>/api/v1</code> 흐름과 프론트 동작은 그대로 유지하면서,
매칭 완료 상태를 유저별 조각 정보가 아니라 <strong>매치 그룹 단위 상태</strong>로 관리할 수 있게 만드는 것입니다.</p>

<p>즉 이번 PR은 ready-check, accept/decline, Redis 전환 같은 다음 단계를 위한
<strong>상태 모델 정리</strong>에 가깝습니다.</p>

<hr>

<h3>관련 커밋</h3>
<ul>
<li><code>5cec7a4</code> <code>refactor: MatchSession 모델과 상태 enum 추가</code></li>
<li><code>d672abe</code> <code>refactor: matchedRoomMap을 userMatchMap과 matchSessionMap 구조로 전환</code></li>
</ul>

<hr>

<h3>1. 왜 이 작업을 했는가</h3>

<p>기존 매칭 완료 상태는 아래처럼 각 유저별로 roomId만 저장하고 있었습니다.</p>

<pre><code>matchedRoomMap
1 -&gt; 100
2 -&gt; 100
3 -&gt; 100
4 -&gt; 100
</code></pre>

<p>이 구조는 현재 MVP에서는 충분히 동작합니다.</p>
<ul>
<li>4명 모이면 즉시 방 생성</li>
<li><code>/matches/me</code> 에서 <code>MATCHED + roomId</code> 반환</li>
<li>프론트는 roomId를 보고 바로 배틀룸 이동</li>
</ul>

<p>하지만 이 방식은 아래 정보를 자연스럽게 표현하기 어렵습니다.</p>
<ul>
<li>이 4명이 하나의 매치 그룹이었다는 사실</li>
<li>매치 자체의 ID</li>
<li>매치의 상태</li>
<li>향후 수락/거절/만료 같은 중간 상태</li>
</ul>

<p>즉 기존 구조는 <strong>유저별 결과 조각</strong>은 저장할 수 있지만,
<strong>매치 자체</strong>를 저장하는 구조는 아니었습니다.</p>

<p>그래서 이번 PR에서는 매칭 완료 상태를 유저 단위가 아니라
<strong>매치 그룹 단위</strong>로 표현할 수 있도록 상태 모델을 한 단계 올렸습니다.</p>

<hr>

<h3>2. MatchSession 모델 도입</h3>

<h4>2-1. MatchSession 추가</h4>
<p>새 타입 <code>MatchSession</code>을 추가했습니다.</p>

<p>이 객체는 하나의 매치 그룹 상태를 표현합니다.</p>

<ul>
<li><code>matchId</code>: 매치 ID</li>
<li><code>participantIds</code>: 매치 참가자 목록</li>
<li><code>status</code>: 현재 매치 상태</li>
<li><code>roomId</code>: 현재 단계에서 매칭 완료 후 연결된 방 ID</li>
<li><code>createdAt</code>: 세션 생성 시각</li>
</ul>

<p>또한 <code>MatchSession.matched(...)</code> 팩토리 메서드를 추가해,
현재 단계의 기본 규칙인 <code>status=MATCHED</code>, <code>roomId!=null</code> 을 코드 레벨에서 명확히 표현하도록 했습니다.</p>

<h4>2-2. MatchSessionStatus 추가</h4>
<p><code>MatchSessionStatus</code> enum도 함께 추가했습니다.</p>

<p>현재 단계에서는 최소 상태만 먼저 도입했습니다.</p>
<ul>
<li><code>MATCHED</code>: 4명 매칭이 완료되고 roomId까지 배정된 상태</li>
<li><code>CLOSED</code>: 모든 참가자의 매칭 연결이 정리되어 더 이상 조회 대상이 아닌 상태</li>
</ul>

<p>즉 지금은 프론트를 바꾸지 않는 단계이므로 최소 상태만 두고,
이후 ready-check 단계에서 <code>ACCEPT_PENDING</code>, <code>DECLINED</code>, <code>EXPIRED</code> 같은 상태를 확장할 수 있도록 준비한 구조입니다.</p>

<hr>

<h3>3. InMemoryMatchStateStore 구조 전환</h3>

<h4>3-1. 기존 구조</h4>
<ul>
<li><code>waitingQueues</code></li>
<li><code>userQueueMap</code></li>
<li><code>matchedRoomMap</code></li>
</ul>

<p>이 중 매칭 완료 상태를 들고 있던 <code>matchedRoomMap</code> 을 제거하고,
아래 두 단계 구조로 바꿨습니다.</p>

<h4>3-2. 변경 후 구조</h4>
<ul>
<li><code>userMatchMap&lt;userId, matchId&gt;</code></li>
<li><code>matchSessionMap&lt;matchId, MatchSession&gt;</code></li>
<li><code>AtomicLong matchSequence</code> 추가</li>
</ul>

<p>즉 이제는 유저가 직접 roomId를 들고 있는 대신,
먼저 자신이 어느 매치에 연결돼 있는지 찾고,
그 다음 MatchSession 본문에서 상태와 roomId를 조회하는 구조입니다.</p>

<pre><code>userMatchMap
1 -&gt; 10
2 -&gt; 10
3 -&gt; 10
4 -&gt; 10

matchSessionMap
10 -&gt; MatchSession(matchId=10, participantIds=[1,2,3,4], status=MATCHED, roomId=100)
</code></pre>

<p>이 구조는 이후 Redis key 설계나 ready-check 상태 확장에도 더 자연스럽게 이어질 수 있습니다.</p>

<hr>

<h3>4. 핵심 메서드 변경</h3>

<h4>4-1. markMatched()</h4>
<p>기존 <code>markMatched()</code> 는 매칭 성공 시 각 유저별로 roomId를 직접 저장했습니다.</p>

<pre><code>userQueueMap.remove(userId)
matchedRoomMap.put(userId, roomId)
</code></pre>

<p>이번 PR에서는 이 부분을 아래처럼 바꿨습니다.</p>

<pre><code>matchId 생성
→ participantIds 추출
→ MatchSession 생성
→ matchSessionMap.put(matchId, session)
→ userQueueMap.remove(userId)
→ userMatchMap.put(userId, matchId)
</code></pre>

<p>즉 이 시점부터 유저는 단순히 "입장해야 할 roomId가 있는 사용자"가 아니라,
<strong>어느 매치 그룹에 속해 있는 사용자</strong>로 상태가 전환됩니다.</p>

<h4>4-2. getMatchState()</h4>
<p>기존 <code>/matches/me</code> 조회는 <code>matchedRoomMap.get(userId)</code> 만 확인하면 됐습니다.</p>

<p>이제는 다음 순서로 조회합니다.</p>

<ol>
<li><code>userMatchMap</code> 에서 <code>matchId</code> 조회</li>
<li><code>matchSessionMap</code> 에서 <code>MatchSession</code> 조회</li>
<li><code>session.status == MATCHED</code> 이면 <code>MATCHED + roomId</code> 반환</li>
<li>userMatchMap은 있는데 실제 session이 없으면 stale 상태로 보고 정리</li>
<li>그 외 <code>userQueueMap</code> 에 있으면 <code>SEARCHING</code></li>
<li>둘 다 없으면 <code>IDLE</code></li>
</ol>

<p>즉 프론트가 보는 응답은 그대로지만,
백엔드 내부 조회 방식은 유저 → 매치 → 세션 구조로 바뀌었습니다.</p>

<h4>4-3. clearMatchedRoom()</h4>
<p>기존에는 아래 한 줄이면 끝났습니다.</p>

<pre><code>matchedRoomMap.remove(userId, roomId)
</code></pre>

<p>이번 PR에서는 아래 순서로 바뀌었습니다.</p>

<ol>
<li>해당 유저의 <code>matchId</code> 조회</li>
<li><code>MatchSession</code> 조회</li>
<li>session의 roomId가 요청 roomId와 같을 때만 유저 연결 제거</li>
<li>같은 matchId를 참조하는 사용자가 아무도 없으면 MatchSession도 제거</li>
</ol>

<p>즉 한 명이 먼저 방에 들어가도 나머지 사람은 계속 <code>MATCHED + roomId</code> 를 유지할 수 있고,
마지막 사람까지 입장 완료됐을 때 세션 전체를 정리하는 구조가 되었습니다.</p>

<hr>

<h3>5. 외부 동작은 어떻게 유지되는가</h3>

<p>이번 PR의 중요한 조건은 <strong>프론트 수정 없이 현재 흐름을 유지하는 것</strong>이었습니다.</p>

<p>따라서 아래는 바뀌지 않았습니다.</p>
<ul>
<li><code>POST /api/v1/queue/join</code></li>
<li><code>DELETE /api/v1/queue/cancel</code></li>
<li><code>GET /api/v1/queue/me</code></li>
<li><code>GET /api/v1/matches/me</code></li>
</ul>

<p><code>/matches/me</code> 의 의미도 그대로 유지합니다.</p>
<ul>
<li><code>SEARCHING</code>: 큐 대기 중</li>
<li><code>MATCHED</code>: 방 생성 완료, roomId 존재</li>
<li><code>IDLE</code>: 큐에도 없고 매칭 완료 상태도 아님</li>
</ul>

<p>즉 프론트는 여전히:</p>

<pre><code>큐 참가
→ /matches/me 폴링
→ MATCHED + roomId 확인
→ 배틀룸 이동
</code></pre>

<p>이 흐름을 그대로 사용할 수 있습니다.</p>

<hr>

<h3>6. 사용자 흐름 예시</h3>

<p>예를 들어 user1, user2, user3, user4가 같은 큐에 들어왔다고 가정하면:</p>

<pre><code>waitingQueues[(ARRAY, EASY)] = [1,2,3,4]
userQueueMap = {1-&gt;key, 2-&gt;key, 3-&gt;key, 4-&gt;key}
</code></pre>

<p>4명이 충족되면:</p>

<pre><code>userMatchMap = {
  1 -&gt; 1,
  2 -&gt; 1,
  3 -&gt; 1,
  4 -&gt; 1
}

matchSessionMap = {
  1 -&gt; MatchSession(
    matchId = 1,
    participantIds = [1,2,3,4],
    status = MATCHED,
    roomId = 100
  )
}
</code></pre>

<p>이 상태에서 user1이 먼저 배틀룸에 들어오면:</p>

<pre><code>clearMatchedRoom(1, 100)
</code></pre>

<p>결과는:</p>

<pre><code>userMatchMap = {
  2 -&gt; 1,
  3 -&gt; 1,
  4 -&gt; 1
}

matchSessionMap = {
  1 -&gt; MatchSession(...)
}
</code></pre>

<p>즉 user1은 더 이상 <code>/matches/me</code> 대상이 아니므로 <code>IDLE</code> 이 되고,
user2,3,4는 여전히 <code>MATCHED + roomId</code> 를 받을 수 있습니다.</p>

<p>이후 마지막 사용자까지 모두 입장하면,
그때 <code>removeMatchSessionIfUnreferenced(matchId)</code> 가 session까지 제거합니다.</p>

<hr>

<h3>7. 테스트 보강</h3>

<p>기존 테스트에 더해 아래 시나리오를 보강했습니다.</p>

<ul>
<li>방 생성 실패 후 매칭 세션이 만들어지지 않았으므로 여전히 <code>SEARCHING</code> 인지 확인</li>
<li>매칭된 모든 사용자가 roomId를 소비하면 전원 <code>IDLE</code> 상태가 되는지 확인</li>
</ul>

<p>즉 이번 PR은 단순히 상태 저장 구조만 바꾼 것이 아니라,
새 구조가 실제로 기존 SEARCHING / MATCHED / IDLE 흐름을 유지하는지도 테스트로 잠갔습니다.</p>

<hr>

<h3>8. 정리</h3>

<ul>
<li><code>MatchSession</code> 및 <code>MatchSessionStatus</code> 도입</li>
<li><code>matchedRoomMap</code> 제거</li>
<li><code>userMatchMap</code> + <code>matchSessionMap</code> 구조로 매칭 완료 상태 전환</li>
<li><code>markMatched()</code>, <code>getMatchState()</code>, <code>clearMatchedRoom()</code> 를 매치 그룹 중심 흐름으로 변경</li>
<li>외부 API와 프론트 동작은 그대로 유지</li>
<li>향후 ready-check, accept/decline, Redis 전환을 위한 상태 모델 기반 마련</li>
</ul>

<p>즉 이번 PR은 <strong>현재 잘 동작하는 즉시 매칭 흐름은 유지하면서,
매칭 완료 상태를 유저 중심 구조에서 매치 그룹 중심 구조로 리팩터링한 작업</strong>입니다.</p>

</body>
</html>
