### PR TITLE
[feat] websocket 메시지를 트랜잭션 커밋 전에 전송하는 문제 수정

### DIFF
--- a/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
+++ b/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
@@ -2,11 +2,19 @@ package com.back.domain.battle.battleroom.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 
 public interface BattleRoomRepository extends JpaRepository<BattleRoom, Long> {
 
@@ -15,4 +23,13 @@ public interface BattleRoomRepository extends JpaRepository<BattleRoom, Long> {
 
     // 특정 상태의 방 목록 조회 (관전용)
     List<BattleRoom> findByStatus(BattleRoomStatus status);
+
+    // joinRoom 동시 요청 직렬화용 비관적 락 조회
+    // 타임아웃 1000ms: 정상 joinRoom 트랜잭션은 수백ms 내 완료되므로 충분한 여유.
+    // 배포 후 실제 응답시간 측정 후 조정 권장.
+    // PostgreSQL에서 Hibernate가 SET LOCAL lock_timeout = 1000 으로 변환하여 처리.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000"))
+    @Query("SELECT r FROM BattleRoom r WHERE r.id = :id")
+    Optional<BattleRoom> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
 import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
@@ -91,13 +93,14 @@ public class BattleRoomService {
 
         if (allPlaying) {
             room.startBattle(Duration.ofMinutes(30));
-            messagingTemplate.convertAndSend(
-                    "/topic/room/" + roomId,
-                    Map.of(
-                            "type",
-                            "BATTLE_STARTED",
-                            "timerEnd",
-                            room.getTimerEnd().toString()));
+            String timerEnd = room.getTimerEnd().toString();
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    messagingTemplate.convertAndSend(
+                            "/topic/room/" + roomId, Map.of("type", "BATTLE_STARTED", "timerEnd", timerEnd));
+                }
+            });
         }
 
         return JoinRoomResponse.from(room);

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -26,7 +26,9 @@ import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.repository.ProblemRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BattleRoomService {
@@ -67,9 +69,10 @@ public class BattleRoomService {
     @Transactional
     public JoinRoomResponse joinRoom(Long roomId, Long memberId) {
 
-        // 1. BattleRoom 조회 + WAITING 상태 검증
-        BattleRoom room =
-                battleRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+        // 1. BattleRoom 조회 + WAITING 상태 검증 (비관적 락으로 동시 joinRoom 직렬화)
+        BattleRoom room = battleRoomRepository
+                .findByIdWithLock(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
 
         if (room.getStatus() != BattleRoomStatus.WAITING) {
             throw new IllegalStateException("입장할 수 없는 상태의 방입니다. 현재 상태: " + room.getStatus());
@@ -86,6 +89,7 @@ public class BattleRoomService {
 
         // 4. READY → PLAYING 상태 바꾸기
         participant.join();
+        battleParticipantRepository.save(participant);
 
         // 5. 모든 참여자가 PLAYING이면 배틀 시작
         List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
@@ -93,12 +97,20 @@ public class BattleRoomService {
 
         if (allPlaying) {
             room.startBattle(Duration.ofMinutes(30));
+            battleRoomRepository.save(room);
             String timerEnd = room.getTimerEnd().toString();
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    messagingTemplate.convertAndSend(
-                            "/topic/room/" + roomId, Map.of("type", "BATTLE_STARTED", "timerEnd", timerEnd));
+                    // 커밋 후이므로 예외를 전파해도 트랜잭션 롤백이 불가능하고,
+                    // 클라이언트에게 500이 반환되어 DB는 성공했는데 실패로 인식하는 혼란을 유발함.
+                    // WebSocket은 실시간 알림 역할이므로 전송 실패가 치명적이지 않아 예외를 삼키고 로그만 남김.
+                    try {
+                        messagingTemplate.convertAndSend(
+                                "/topic/room/" + roomId, Map.of("type", "BATTLE_STARTED", "timerEnd", timerEnd));
+                    } catch (Exception e) {
+                        log.error("BATTLE_STARTED WebSocket 전송 실패 roomId={}", roomId, e);
+                    }
                 }
             });
         }

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
 import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
@@ -96,11 +98,20 @@ public class BattleResultService {
         // 6. BattleRoom 종료
         room.finish();
 
-        // 7. WebSocket 브로드캐스트
-        // TODO: 리팩토링 - 트랜잭션 커밋 전 메시지 전송 문제
-        //   현재 @Transactional 안에서 convertAndSend 호출 시 커밋 전에 메시지가 전송됨
-        //   → TransactionSynchronizationManager.registerSynchronization의 afterCommit()으로 개선 필요
-        messagingTemplate.convertAndSend("/topic/room/" + roomId, Map.of("type", "BATTLE_FINISHED"));
+        // 7. WebSocket 브로드캐스트 — 커밋 후 전송으로 프론트가 확정된 DB 상태를 읽도록 보장
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                // 커밋 후이므로 예외를 전파해도 트랜잭션 롤백이 불가능하고,
+                // 클라이언트에게 500이 반환되어 DB는 성공했는데 실패로 인식하는 혼란을 유발함.
+                // WebSocket은 실시간 알림 역할이므로 전송 실패가 치명적이지 않아 예외를 삼키고 로그만 남김.
+                try {
+                    messagingTemplate.convertAndSend("/topic/room/" + roomId, Map.of("type", "BATTLE_FINISHED"));
+                } catch (Exception e) {
+                    log.error("BATTLE_FINISHED WebSocket 전송 실패 roomId={}", roomId, e);
+                }
+            }
+        });
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.back.global.globalExceptionHandler;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -77,5 +78,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<RsData<Void>> handle(ServiceException ex) {
         RsData<Void> rsData = ex.getRsData();
         return ResponseEntity.status(rsData.statusCode()).body(rsData);
+    }
+
+    // 7. 비관적 락 타임아웃 (joinRoom 동시 요청 과부하 시)
+    //    락 대기 1초 초과 시 발생. 500 대신 409로 명확한 의미 전달.
+    @ExceptionHandler(PessimisticLockingFailureException.class)
+    public ResponseEntity<RsData<Void>> handle(PessimisticLockingFailureException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(RsData.of("409-1", "현재 입장 처리 중입니다. 잠시 후 다시 시도해 주세요."));
     }
 }


### PR DESCRIPTION
### 명시적 save 추가

BattleRoomService.joinRoom() 에서

- participant.join() 직후 → battleParticipantRepository.save(participant)
- room.startBattle() 직후 → battleRoomRepository.save(room)

dirty checking 의존을 제거해서 findByBattleRoom 쿼리 실행 전에 변경사항이 DB에 반영됨을 명시적으로 보장하는 것

```java
save() 호출 시점
- Spring Data JPA의 save()는 내부적으로 persist() 또는 merge()를 호출
- 이 시점에 Hibernate가 flush를 하지는 않지만, 영속성 컨텍스트에 변경사항이 확실히 등록된다.

flush 시점 (실제 DB 반영)
- findByBattleRoom() 같은 쿼리 실행 직전 - AUTO flush mode
  (dirty 엔티티가 쿼리 결과에 영향을 줄 수 있을 때 자동 flush)
- 트랜잭션 커밋 직전

커밋 시점
- 트랜잭션이 끝날 때 실제 DB에 영구 반영
```

현재 코드의 문제는 커밋 타이밍이 아니라 flush 타이밍이다.

```java
participant.join();  // dirty 상태
// findByBattleRoom 쿼리 실행 전에 flush가 일어나야
// 이 participant의 PLAYING 상태가 쿼리 결과에 반영됨
List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
```

Hibernate AUTO flush는 **쿼리에 영향을 줄 수 있는 dirty 엔티티** 가 있을 때 flush. 대부분은 잘 동작하지만, 이것이 보장되지 않는 엣지 케이스가 있다.
save()를 명시적으로 호출하면 그 보장을 코드 레벨에서 확실히 하는 것이고, 의도를 드러내는 효과도 있긴 하지만 **주목적은 flush 보장**에 가깝다.

---

### joinRoom 시 race condition 방지 - 비관적 락 적용

- BattleRoomRepository.java — PESSIMISTIC_WRITE 락 쿼리 메서드 추가
BattleRoomRepository.java — findByIdWithLock() 추가 (PESSIMISTIC_WRITE = SELECT ... FOR UPDATE)
- BattleRoomService.java — joinRoom 진입 시 기존 findById 대신 락 쿼리로 BattleRoom 조회
BattleRoomService.java — joinRoom 진입 시 findById → findByIdWithLock 으로 교체

`joinRoom` 시작 시점에 `BattleRoom` 레코드에 락을 걸어, 같은 방에 대한 동시 요청이 들어와도 한 트랜잭션씩 순서대로 처리되도록 함

`@Lock`만 쓰면 락을 획득할 때까지 무한 대기한다. `@QueryHints`로 타임아웃을 추가해주었다.