### PR TITLE
[feat] api/v2 ready-check 매칭 흐름 추가

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueV2Controller.java
+++ b/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueV2Controller.java
@@ -1,0 +1,64 @@
+package com.back.domain.matching.queue.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
+import com.back.domain.matching.queue.dto.QueueStatusResponse;
+import com.back.domain.matching.queue.service.ReadyCheckService;
+import com.back.domain.member.member.entity.Member;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v2/queue")
+@RequiredArgsConstructor
+/**
+ * v2 큐 관련 API
+ *
+ * queue/me는 SEARCHING UI 전용으로 유지한다.
+ * 즉 "지금 몇 명 찼는지"를 보여주는 역할만 하고,
+ * ready-check나 room 상태는 여기서 다루지 않는다.
+ */
+public class MatchingQueueV2Controller {
+
+    private final ReadyCheckService readyCheckService;
+    private final Rq rq;
+
+    @GetMapping("/me")
+    public QueueStateV2Response getMyQueueState() {
+        // 프론트는 이 endpoint를 폴링하면서 1/4, 2/4 같은 SEARCHING UI를 그린다.
+        return readyCheckService.getMyQueueStateV2(requireActorId());
+    }
+
+    @PostMapping("/join")
+    public QueueStatusResponse joinQueue(@Valid @RequestBody QueueJoinRequest request) {
+        // queue/join은 큐 참가만 담당하고,
+        // ready-check 시작 여부 판단은 서비스에서 처리한다.
+        return readyCheckService.joinQueueV2(requireActorId(), request);
+    }
+
+    @DeleteMapping("/cancel")
+    public QueueStatusResponse cancelQueue() {
+        // 아직 SEARCHING 단계인 사용자만 queue/cancel의 대상이 된다.
+        return readyCheckService.cancelQueueV2(requireActorId());
+    }
+
+    private Long requireActorId() {
+        Member actor = rq.getActor();
+
+        if (actor == null) {
+            throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
+        }
+
+        return actor.getId();
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/controller/MatchingStatusV2Controller.java
+++ b/src/main/java/com/back/domain/matching/queue/controller/MatchingStatusV2Controller.java
@@ -1,0 +1,58 @@
+package com.back.domain.matching.queue.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.matching.queue.dto.MatchStateV2Response;
+import com.back.domain.matching.queue.service.ReadyCheckService;
+import com.back.domain.member.member.entity.Member;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v2/matches")
+@RequiredArgsConstructor
+/**
+ * v2 ready-check / room 준비 상태 API
+ *
+ * matches/me는 queue 진행률이 아니라
+ * "내 ready-check 세션이 지금 어떤 상태인가"를 보여주는 전용 endpoint다.
+ */
+public class MatchingStatusV2Controller {
+
+    private final ReadyCheckService readyCheckService;
+    private final Rq rq;
+
+    @GetMapping("/me")
+    public MatchStateV2Response getMyMatchState() {
+        // queue 단계가 끝난 뒤 프론트는 이 endpoint로 ready-check / room 상태를 본다.
+        return readyCheckService.getMyMatchStateV2(requireActorId());
+    }
+
+    @PostMapping("/{matchId}/accept")
+    public MatchStateV2Response acceptMatch(@PathVariable Long matchId) {
+        // 수락 요청은 현재 로그인 사용자 기준으로만 처리한다.
+        return readyCheckService.acceptMatch(requireActorId(), matchId);
+    }
+
+    @PostMapping("/{matchId}/decline")
+    public MatchStateV2Response declineMatch(@PathVariable Long matchId) {
+        // 거절도 같은 방식으로 현재 로그인 사용자 기준으로 처리한다.
+        return readyCheckService.declineMatch(requireActorId(), matchId);
+    }
+
+    private Long requireActorId() {
+        Member actor = rq.getActor();
+
+        if (actor == null) {
+            throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
+        }
+
+        return actor.getId();
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/dto/MatchStateV2Response.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/MatchStateV2Response.java
@@ -1,0 +1,10 @@
+package com.back.domain.matching.queue.dto;
+
+/**
+ * v2 matches/me 최종 응답 DTO
+ *
+ * 프론트는 이 응답 하나로
+ * ready-check를 보여줄지, 방 이동이 가능한지, 종료 메시지를 띄울지를 판단한다.
+ */
+public record MatchStateV2Response(
+        MatchStatus status, ReadyCheckSnapshot readyCheck, RoomSnapshot room, String message) {}

--- a/src/main/java/com/back/domain/matching/queue/dto/MatchStatus.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/MatchStatus.java
@@ -1,0 +1,15 @@
+package com.back.domain.matching.queue.dto;
+
+/**
+ * v2 matches/me 응답에서 프론트가 직접 해석할 상태값
+ *
+ * 내부 저장소의 MatchSessionStatus와 이름이 일부 비슷하지만,
+ * 이 enum은 "프론트 화면이 무엇을 보여줘야 하는가" 관점의 상태다.
+ */
+public enum MatchStatus {
+    IDLE,
+    ACCEPT_PENDING,
+    ROOM_READY,
+    EXPIRED,
+    CANCELLED
+}

--- a/src/main/java/com/back/domain/matching/queue/dto/QueueStateV2Response.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/QueueStateV2Response.java
@@ -1,0 +1,11 @@
+package com.back.domain.matching.queue.dto;
+
+/**
+ * v2 queue/me 응답 DTO
+ *
+ * 이 DTO는 SEARCHING 화면만 위해 존재한다.
+ * 즉 "지금 몇 명이 모였는가"를 프론트가 그릴 수 있게 해주고,
+ * ready-check나 room 준비 상태는 담지 않는다.
+ */
+public record QueueStateV2Response(
+        boolean inQueue, String category, String difficulty, int waitingCount, int requiredCount) {}

--- a/src/main/java/com/back/domain/matching/queue/dto/ReadyCheckSnapshot.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/ReadyCheckSnapshot.java
@@ -1,0 +1,18 @@
+package com.back.domain.matching.queue.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * ready-check 화면 전체에 필요한 정보 묶음
+ *
+ * MatchStateV2Response 안에 포함되어
+ * 수락 수, 나의 수락 여부, 제한 시간, 참가자 목록을 한 번에 내려준다.
+ */
+public record ReadyCheckSnapshot(
+        Long matchId,
+        int acceptedCount,
+        int requiredCount,
+        boolean acceptedByMe,
+        LocalDateTime deadline,
+        List<ReadyParticipantSnapshot> participants) {}

--- a/src/main/java/com/back/domain/matching/queue/dto/ReadyParticipantSnapshot.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/ReadyParticipantSnapshot.java
@@ -1,0 +1,11 @@
+package com.back.domain.matching.queue.dto;
+
+import com.back.domain.matching.queue.model.ReadyDecision;
+
+/**
+ * ready-check 화면에서 참가자 한 명을 표현하는 응답 조각
+ *
+ * 프론트는 이 배열을 이용해
+ * 누가 수락했고, 누가 아직 대기 중이고, 누가 거절했는지를 바로 그린다.
+ */
+public record ReadyParticipantSnapshot(Long userId, String nickname, ReadyDecision decision) {}

--- a/src/main/java/com/back/domain/matching/queue/dto/RoomSnapshot.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/RoomSnapshot.java
@@ -1,0 +1,8 @@
+package com.back.domain.matching.queue.dto;
+
+/**
+ * ROOM_READY 상태에서만 필요한 roomId 조각
+ *
+ * 프론트는 이 값을 받으면 기존 battle room 입장 API로 이동한다.
+ */
+public record RoomSnapshot(Long roomId) {}

--- a/src/main/java/com/back/domain/matching/queue/model/MatchSession.java
+++ b/src/main/java/com/back/domain/matching/queue/model/MatchSession.java
@@ -1,7 +1,9 @@
 package com.back.domain.matching.queue.model;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * 하나의 매치 그룹 상태를 표현하는 모델
@@ -14,15 +16,28 @@ import java.util.List;
  *
  * 현재는 프론트 변경 없이 기존 MATCHED 흐름을 유지하는 단계라
  * roomId가 이미 존재하는 MATCHED 상태만 다룬다.
+ *
+ * 다만 v2 ready-check를 위해
+ * queueKey, deadline, participantDecisions 같은 필드를 확장해 두었다.
+ * 여기서 participantDecisions를 단일 원본으로 두는 이유는
+ * acceptedUserIds 같은 파생 상태를 따로 저장하지 않고도
+ * acceptedCount / acceptedByMe를 항상 같은 기준에서 계산하기 위해서다.
  */
 public record MatchSession(
-        Long matchId, List<Long> participantIds, MatchSessionStatus status, Long roomId, LocalDateTime createdAt) {
+        Long matchId,
+        QueueKey queueKey,
+        // 이 매치에 원래 묶인 참가자 원본 목록이다.
+        // ready-check 진행 중에도 이 목록 자체는 바뀌지 않는다.
+        List<Long> participantIds,
+        // ready-check의 단일 상태 원본이다.
+        // 누가 ACCEPTED / PENDING / DECLINED 인지는 여기만 보면 된다.
+        Map<Long, ReadyDecision> participantDecisions,
+        MatchSessionStatus status,
+        Long roomId,
+        LocalDateTime deadline,
+        LocalDateTime createdAt) {
 
-    /**
-     * 현재 단계에서는 4명 매칭이 끝나고 roomId까지 생성된 시점에만
-     * MatchSession을 만들기 때문에 status=MATCHED, roomId!=null 을 기본 규칙으로 둔다.
-     */
-    public static MatchSession matched(Long matchId, List<Long> participantIds, Long roomId) {
+    public MatchSession {
         if (matchId == null) {
             throw new IllegalArgumentException("matchId는 필수입니다.");
         }
@@ -31,11 +46,168 @@ public record MatchSession(
             throw new IllegalArgumentException("participantIds는 비어 있을 수 없습니다.");
         }
 
+        if (participantDecisions == null || participantDecisions.isEmpty()) {
+            throw new IllegalArgumentException("participantDecisions는 비어 있을 수 없습니다.");
+        }
+
+        // record로 받은 컬렉션이 바깥에서 수정되지 않도록 방어 복사한다.
+        participantIds = List.copyOf(participantIds);
+        participantDecisions = Map.copyOf(participantDecisions);
+    }
+
+    /**
+     * 현재 단계에서는 4명 매칭이 끝나고 roomId까지 생성된 시점에만
+     * MatchSession을 만들기 때문에 status=MATCHED, roomId!=null 을 기본 규칙으로 둔다.
+     *
+     * v2 응답에서도 동일 세션을 해석할 수 있도록 participant decision은 전원 ACCEPTED로 둔다.
+     * 즉 방이 이미 만들어진 순간은 ready-check 관점에서도 "전원 수락 완료" 상태로 본다.
+     */
+    public static MatchSession matched(Long matchId, QueueKey queueKey, List<Long> participantIds, Long roomId) {
         if (roomId == null) {
             throw new IllegalArgumentException("MATCHED 상태의 roomId는 필수입니다.");
         }
 
+        Map<Long, ReadyDecision> participantDecisions = new LinkedHashMap<>();
+        for (Long participantId : participantIds) {
+            // v1 MATCHED 세션은 이미 방이 준비된 상태이므로
+            // ready-check 관점에서도 전원 ACCEPTED와 같은 결과 상태로 본다.
+            participantDecisions.put(participantId, ReadyDecision.ACCEPTED);
+        }
+
         return new MatchSession(
-                matchId, List.copyOf(participantIds), MatchSessionStatus.MATCHED, roomId, LocalDateTime.now());
+                matchId,
+                queueKey,
+                participantIds,
+                participantDecisions,
+                MatchSessionStatus.MATCHED,
+                roomId,
+                null,
+                LocalDateTime.now());
+    }
+
+    /**
+     * v2 ready-check 세션 팩토리
+     *
+     * 4명이 모인 시점에는 아직 방을 만들지 않고,
+     * 먼저 ACCEPT_PENDING 세션을 만든 뒤 각 참가자의 수락 여부를 기다린다.
+     */
+    public static MatchSession acceptPending(
+            Long matchId, QueueKey queueKey, List<Long> participantIds, LocalDateTime deadline) {
+        if (deadline == null) {
+            throw new IllegalArgumentException("ready-check 세션은 deadline이 필요합니다.");
+        }
+
+        Map<Long, ReadyDecision> participantDecisions = new LinkedHashMap<>();
+        for (Long participantId : participantIds) {
+            // ready-check를 막 시작한 시점이므로 모든 참가자의 초기 상태는 PENDING이다.
+            participantDecisions.put(participantId, ReadyDecision.PENDING);
+        }
+
+        return new MatchSession(
+                matchId,
+                queueKey,
+                participantIds,
+                participantDecisions,
+                MatchSessionStatus.ACCEPT_PENDING,
+                null,
+                deadline,
+                LocalDateTime.now());
+    }
+
+    /**
+     * ready-check는 participantDecisions만 바꾸면 acceptedCount 같은 파생 값을 다시 계산할 수 있으므로,
+     * 유저 단위 응답 상태 변경은 이 메서드 하나로 모은다.
+     */
+    public MatchSession withDecision(Long userId, ReadyDecision decision) {
+        if (!participantDecisions.containsKey(userId)) {
+            throw new IllegalStateException("매치 참가자가 아닌 사용자는 decision을 변경할 수 없습니다.");
+        }
+
+        // 기존 세션을 직접 수정하지 않고 새 세션을 만들어 불변성을 유지한다.
+        Map<Long, ReadyDecision> updatedDecisions = new LinkedHashMap<>(participantDecisions);
+        updatedDecisions.put(userId, decision);
+
+        return new MatchSession(
+                matchId, queueKey, participantIds, updatedDecisions, status, roomId, deadline, createdAt);
+    }
+
+    /**
+     * ready-check 흐름에서는 전원 수락이 끝난 뒤에만 roomId를 세션에 연결한다.
+     */
+    public MatchSession roomReady(Long roomId) {
+        if (roomId == null) {
+            throw new IllegalArgumentException("ROOM_READY 상태의 roomId는 필수입니다.");
+        }
+
+        // ready-check가 끝난 뒤에만 roomId를 세션에 연결한다.
+        return new MatchSession(
+                matchId,
+                queueKey,
+                participantIds,
+                participantDecisions,
+                MatchSessionStatus.ROOM_READY,
+                roomId,
+                deadline,
+                createdAt);
+    }
+
+    public MatchSession expired() {
+        // 누가 어디까지 수락했는지는 프론트가 보여줘야 하므로 decision 정보는 유지한다.
+        return new MatchSession(
+                matchId,
+                queueKey,
+                participantIds,
+                participantDecisions,
+                MatchSessionStatus.EXPIRED,
+                roomId,
+                deadline,
+                createdAt);
+    }
+
+    public MatchSession cancelled() {
+        // CANCELLED 역시 종료 이유를 설명하기 위해 기존 decision들을 유지한다.
+        return new MatchSession(
+                matchId,
+                queueKey,
+                participantIds,
+                participantDecisions,
+                MatchSessionStatus.CANCELLED,
+                roomId,
+                deadline,
+                createdAt);
+    }
+
+    public boolean hasParticipant(Long userId) {
+        return participantDecisions.containsKey(userId);
+    }
+
+    public ReadyDecision decisionOf(Long userId) {
+        // 안전하게 기본값을 PENDING으로 두면 일부 누락이 있어도 계산 로직이 깨지지 않는다.
+        return participantDecisions.getOrDefault(userId, ReadyDecision.PENDING);
+    }
+
+    public int acceptedCount() {
+        // acceptedUserIds를 따로 저장하지 않고 필요할 때마다 계산한다.
+        return (int) participantDecisions.values().stream()
+                .filter(decision -> decision == ReadyDecision.ACCEPTED)
+                .count();
+    }
+
+    public boolean isAcceptedBy(Long userId) {
+        return decisionOf(userId) == ReadyDecision.ACCEPTED;
+    }
+
+    public boolean isAllAccepted() {
+        // 원래 참가자 전원이 ACCEPTED인지 판단한다.
+        return participantIds.stream().allMatch(participantId -> decisionOf(participantId) == ReadyDecision.ACCEPTED);
+    }
+
+    public boolean isExpiredAt(LocalDateTime now) {
+        // ACCEPT_PENDING 상태에서만 deadline이 의미 있다.
+        return status == MatchSessionStatus.ACCEPT_PENDING && deadline != null && !deadline.isAfter(now);
+    }
+
+    public boolean hasDeclinedParticipant() {
+        return participantDecisions.values().stream().anyMatch(decision -> decision == ReadyDecision.DECLINED);
     }
 }

--- a/src/main/java/com/back/domain/matching/queue/model/MatchSessionStatus.java
+++ b/src/main/java/com/back/domain/matching/queue/model/MatchSessionStatus.java
@@ -11,8 +11,24 @@ package com.back.domain.matching.queue.model;
  *
  * 이후 롤 매칭 단계로 확장할 때
  * ACCEPT_PENDING, DECLINED, EXPIRED 같은 상태를 여기에 추가할 수 있다.
+ *
+ * 현재 v2 ready-check 1차 구현에서는 아래 상태를 함께 사용한다.
+ * - ACCEPT_PENDING: 4명 매칭 성사 후 수락/거절을 기다리는 상태
+ * - ROOM_READY: 전원 수락과 방 생성까지 끝난 상태
+ * - EXPIRED: 수락 시간이 만료된 상태
+ * - CANCELLED: 누군가 거절했거나 방 생성이 실패해 종료된 상태
  */
 public enum MatchSessionStatus {
+    // v1 즉시매칭에서 사용하던 기존 완료 상태
     MATCHED,
+    // v2 ready-check가 시작됐지만 아직 전원 수락 전인 상태
+    ACCEPT_PENDING,
+    // 전원 수락이 끝나 roomId까지 연결된 상태
+    ROOM_READY,
+    // 제한 시간이 지나 ready-check가 무효가 된 상태
+    EXPIRED,
+    // 누군가 거절했거나 room 생성 실패로 세션이 종료된 상태
+    CANCELLED,
+    // 모든 참조가 정리되어 더 이상 조회 대상이 아닌 상태
     CLOSED
 }

--- a/src/main/java/com/back/domain/matching/queue/model/ReadyDecision.java
+++ b/src/main/java/com/back/domain/matching/queue/model/ReadyDecision.java
@@ -1,0 +1,13 @@
+package com.back.domain.matching.queue.model;
+
+/**
+ * ready-check에서 각 참가자가 현재 어떤 응답 상태인지 나타낸다.
+ *
+ * 이 값이 ready-check의 단일 원본이다.
+ * acceptedCount, acceptedByMe 같은 값은 이 enum들의 집합에서 계산한다.
+ */
+public enum ReadyDecision {
+    PENDING,
+    ACCEPTED,
+    DECLINED
+}

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -84,6 +84,7 @@ public class MatchingQueueService {
     // 4인 매칭 + 방 생성
     private CreateRoomResponse tryMatchAndCreateRoom(QueueKey queueKey) {
 
+        // 큐에서 4명 빼기
         List<WaitingUser> matchedUsers = matchStateStore.pollMatchCandidates(queueKey, 4);
 
         if (matchedUsers == null) {

--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
@@ -1,0 +1,247 @@
+package com.back.domain.matching.queue.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.springframework.stereotype.Service;
+
+import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
+import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
+import com.back.domain.battle.battleroom.service.BattleRoomService;
+import com.back.domain.matching.queue.adapter.QueueProblemPicker;
+import com.back.domain.matching.queue.dto.MatchStateV2Response;
+import com.back.domain.matching.queue.dto.MatchStatus;
+import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
+import com.back.domain.matching.queue.dto.QueueStatusResponse;
+import com.back.domain.matching.queue.dto.ReadyCheckSnapshot;
+import com.back.domain.matching.queue.dto.ReadyParticipantSnapshot;
+import com.back.domain.matching.queue.dto.RoomSnapshot;
+import com.back.domain.matching.queue.model.MatchSession;
+import com.back.domain.matching.queue.model.MatchSessionStatus;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.domain.matching.queue.store.MatchStateStore;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+/**
+ * v2 ready-check 흐름 전담 서비스
+ *
+ * 이 서비스는 "큐에 참가해 4명을 모으는 것" 자체보다
+ * "4명이 모인 뒤 수락/거절을 거쳐 ROOM_READY로 가는 상태 전이"를 책임진다.
+ *
+ * 그래서 기존 MatchingQueueService와 달리
+ * ACCEPT_PENDING, ROOM_READY, EXPIRED, CANCELLED 같은
+ * ready-check 전용 상태를 읽고 바꾸는 역할에 집중한다.
+ */
+public class ReadyCheckService {
+
+    private static final int REQUIRED_MATCH_SIZE = 4;
+    private static final long READY_CHECK_TIMEOUT_SECONDS = 15L;
+
+    private final BattleRoomService battleRoomService;
+    private final QueueProblemPicker queueProblemPicker;
+    private final MatchStateStore matchStateStore;
+    private final MemberRepository memberRepository;
+
+    /**
+     * v2 큐 참가
+     *
+     * 4명이 되기 전까지는 기존과 같은 SEARCHING 의미지만,
+     * 4명이 되는 순간에는 즉시 room을 만들지 않고 ready-check 세션만 생성한다.
+     */
+    public QueueStatusResponse joinQueueV2(Long userId, QueueJoinRequest request) {
+        QueueKey queueKey = new QueueKey(request.getCategory(), request.getDifficulty());
+        // 1L -> {array + hard}
+        // array + hard = {user1,} 에들어감
+        // 반환값은 큐 사이즈
+        int currentSize = matchStateStore.enqueue(userId, queueKey);
+
+        if (currentSize < REQUIRED_MATCH_SIZE) {
+            // 아직 4명이 안 찼다면 기존 SEARCHING 단계로 머문다.
+            return new QueueStatusResponse(
+                    "매칭 대기열에 참가했습니다.",
+                    queueKey.category(),
+                    queueKey.difficulty().name(),
+                    currentSize);
+        }
+
+        // 4명이 찬 시점에만 SEARCHING -> ACCEPT_PENDING 전환을 시도한다.
+        tryCreateReadyCheckSession(queueKey);
+
+        return new QueueStatusResponse(
+                "매칭이 성사되어 수락 대기 상태로 전환되었습니다.",
+                queueKey.category(),
+                queueKey.difficulty().name(),
+                0);
+    }
+
+    public QueueStatusResponse cancelQueueV2(Long userId) {
+        // cancel은 아직 queue에 남아 있는 SEARCHING 사용자만 대상으로 한다.
+        MatchStateStore.CancelResult cancelResult = matchStateStore.cancel(userId);
+        QueueKey queueKey = cancelResult.queueKey();
+
+        return new QueueStatusResponse(
+                "매칭 대기열에서 취소했습니다.", queueKey.category(), queueKey.difficulty().name(), cancelResult.waitingCount());
+    }
+
+    public QueueStateV2Response getMyQueueStateV2(Long userId) {
+        // queue/me는 SEARCHING UI 전용이므로 store snapshot을 그대로 내려준다.
+        return matchStateStore.getQueueStateV2(userId);
+    }
+
+    /**
+     * v2 matches/me 조회
+     *
+     * store가 들고 있는 세션 원본을 바탕으로
+     * 화면에 필요한 DTO 형태로 다시 조립한다.
+     */
+    public MatchStateV2Response getMyMatchStateV2(Long userId) {
+        // matches/me는 ready-check 전용 snapshot이다.
+        // queue 상태는 별도 endpoint로 분리하고, 여기서는 매치 세션이 있을 때만 상태를 조립한다.
+        MatchSession matchSession = matchStateStore.findMatchSessionByUserId(userId);
+
+        if (matchSession == null) {
+            // 활성 ready-check 세션이 없으면 프론트는 IDLE로 해석한다.
+            return new MatchStateV2Response(MatchStatus.IDLE, null, null, null);
+        }
+
+        return toMatchStateV2Response(userId, matchSession);
+    }
+
+    public MatchStateV2Response acceptMatch(Long userId, Long matchId) {
+        MatchSession matchSession = matchStateStore.accept(matchId, userId);
+
+        if (matchSession.status() == MatchSessionStatus.ACCEPT_PENDING && matchSession.isAllAccepted()) {
+            // 방 생성 시점을 마지막 accept로 미루는 이유는,
+            // 수락하지 않은 매치에 불필요한 방이 만들어지지 않도록 하기 위해서다.
+            try {
+                // 문제 선택과 방 생성은 전원 수락이 끝난 뒤에만 수행한다.
+                Long problemId = queueProblemPicker.pick(matchSession.queueKey(), matchSession.participantIds());
+                CreateRoomResponse response = battleRoomService.createRoom(
+                        new CreateRoomRequest(problemId, matchSession.participantIds(), REQUIRED_MATCH_SIZE));
+                matchSession = matchStateStore.markRoomReady(matchId, response.roomId());
+            } catch (RuntimeException e) {
+                // 이번 단계에서는 room 생성 실패를 별도 재시도하지 않고 매치를 취소한다.
+                matchSession = matchStateStore.cancelMatch(matchId);
+            }
+        }
+
+        return toMatchStateV2Response(userId, matchSession);
+    }
+
+    public MatchStateV2Response declineMatch(Long userId, Long matchId) {
+        // 한 명이 거절하면 ready-check 세션 전체가 CANCELLED로 종료된다.
+        MatchSession matchSession = matchStateStore.decline(matchId, userId);
+        return toMatchStateV2Response(userId, matchSession);
+    }
+
+    /**
+     * 4명 충족 시 ACCEPT_PENDING 세션을 만든다.
+     *
+     * 이 시점에는 아직 problem pick이나 room 생성이 일어나지 않는다.
+     * ready-check가 실패할 수 있기 때문에, 방 생성은 마지막 accept까지 미룬다.
+     */
+    private void tryCreateReadyCheckSession(QueueKey queueKey) {
+        List<WaitingUser> matchedUsers = matchStateStore.pollMatchCandidates(queueKey, REQUIRED_MATCH_SIZE);
+
+        if (matchedUsers == null) {
+            return;
+        }
+
+        LocalDateTime deadline = LocalDateTime.now().plusSeconds(READY_CHECK_TIMEOUT_SECONDS);
+
+        try {
+            // 이 시점에 userQueueMap에서 빠지고 userMatchMap / matchSessionMap으로 이동한다.
+            matchStateStore.markAcceptPending(queueKey, matchedUsers, deadline);
+        } catch (RuntimeException e) {
+            // 세션 생성 도중 실패하면 poll했던 유저들을 다시 queue 앞쪽으로 복구한다.
+            matchStateStore.rollbackPolledUsers(queueKey, matchedUsers);
+            throw e;
+        }
+    }
+
+    /**
+     * 내부 MatchSession을 프론트가 바로 쓸 수 있는 v2 응답 DTO로 변환한다.
+     *
+     * 상태 enum은 내부 세션 상태와 1:1로 같아 보이지만,
+     * 실제 화면에서 보여줄 메시지와 room 블록 포함 여부까지 여기서 함께 정한다.
+     */
+    // 사용 위치 /me, 수락, 거절
+    private MatchStateV2Response toMatchStateV2Response(Long userId, MatchSession matchSession) {
+        MatchStatus status = toMatchStatus(matchSession.status());
+
+        if (status == MatchStatus.IDLE) {
+            return new MatchStateV2Response(MatchStatus.IDLE, null, null, null);
+        }
+
+        // readyCheck / room / message를 나눠 담아두면 프론트가 상태별 UI를 단순하게 분기할 수 있다.
+        // TODO : 내가 생각했을땐 이거 닉네임 그냥 jwt에서 받아 쓰면 이거 필요없을거같음
+        ReadyCheckSnapshot readyCheckSnapshot = buildReadyCheckSnapshot(userId, matchSession);
+        RoomSnapshot roomSnapshot = matchSession.roomId() == null ? null : new RoomSnapshot(matchSession.roomId());
+        String message = resolveMessage(matchSession);
+
+        return new MatchStateV2Response(status, readyCheckSnapshot, roomSnapshot, message);
+    }
+
+    private MatchStatus toMatchStatus(MatchSessionStatus status) {
+        return switch (status) {
+            // v1 MATCHED와 v2 ROOM_READY는 프론트 관점에선 모두 "방 입장 가능"으로 묶는다.
+            case MATCHED, ROOM_READY -> MatchStatus.ROOM_READY;
+            case ACCEPT_PENDING -> MatchStatus.ACCEPT_PENDING;
+            case EXPIRED -> MatchStatus.EXPIRED;
+            case CANCELLED -> MatchStatus.CANCELLED;
+            case CLOSED -> MatchStatus.IDLE;
+        };
+    }
+
+    /**
+     * participant decision은 store가 들고 있고,
+     * nickname처럼 화면에 필요한 부가 정보만 서비스에서 합쳐 최종 응답을 만든다.
+     */
+    private ReadyCheckSnapshot buildReadyCheckSnapshot(Long userId, MatchSession matchSession) {
+        // nickname은 store가 아니라 서비스에서 회원 정보를 합쳐 만든다.
+        Map<Long, String> nicknameByUserId = StreamSupport.stream(
+                        memberRepository
+                                .findAllById(matchSession.participantIds())
+                                .spliterator(),
+                        false)
+                .collect(Collectors.toMap(Member::getId, Member::getNickname, (left, right) -> left));
+
+        List<ReadyParticipantSnapshot> participants = matchSession.participantIds().stream()
+                // 참가자 원본 순서를 기준으로 snapshot을 만들면 프론트가 슬롯 UI를 안정적으로 그릴 수 있다.
+                .map(participantId -> new ReadyParticipantSnapshot(
+                        participantId,
+                        nicknameByUserId.getOrDefault(participantId, String.valueOf(participantId)),
+                        matchSession.decisionOf(participantId)))
+                .toList();
+
+        return new ReadyCheckSnapshot(
+                matchSession.matchId(),
+                matchSession.acceptedCount(),
+                matchSession.participantIds().size(),
+                matchSession.isAcceptedBy(userId),
+                matchSession.deadline(),
+                participants);
+    }
+
+    /**
+     * 종료 상태에서는 프론트가 즉시 이유를 보여줄 수 있도록
+     * 사람이 읽는 메시지도 함께 내려준다.
+     */
+    private String resolveMessage(MatchSession matchSession) {
+        return switch (matchSession.status()) {
+            case EXPIRED -> "수락 시간이 만료되었습니다.";
+            case CANCELLED -> matchSession.hasDeclinedParticipant() ? "다른 참가자가 매칭을 거절했습니다." : "방 생성에 실패해 매칭이 취소되었습니다.";
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
@@ -1,5 +1,6 @@
 package com.back.domain.matching.queue.store;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
@@ -12,9 +13,11 @@ import org.springframework.stereotype.Component;
 
 import com.back.domain.matching.queue.dto.MatchStateResponse;
 import com.back.domain.matching.queue.dto.QueueStateResponse;
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
 import com.back.domain.matching.queue.model.MatchSession;
 import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.ReadyDecision;
 import com.back.domain.matching.queue.model.WaitingUser;
 
 /**
@@ -36,9 +39,14 @@ import com.back.domain.matching.queue.model.WaitingUser;
  * 지금은 인메모리 기반이지만,
  * 이후 Redis 등 외부 저장소로 바꾸더라도 서비스 로직 변경을 최소화하기 위해
  * 저장 경계를 먼저 분리한 구조다.
+ *
+ * 이번 단계에서는 같은 저장소 안에 v2 ready-check 상태도 함께 저장한다.
+ * 다만 v1과 v2가 같은 상태를 어떻게 해석할지는 서비스/DTO 계층에서 분리한다.
  */
 @Component
 public class InMemoryMatchStateStore implements MatchStateStore {
+
+    private static final int REQUIRED_MATCH_SIZE = 4;
 
     /**
      * 카테고리 + 난이도별 실제 대기열
@@ -84,6 +92,8 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      * 지금 단계에서는 MATCHED 상태와 roomId만 담지만,
      * 이후 ready-check 단계로 가면 acceptedUsers, deadline 같은 상태를
      * 여기에 확장해서 넣을 수 있다.
+     *
+     * 현재 v2에서는 participantDecisions와 deadline도 이 본문 안에 같이 저장한다.
      */
     private final Map<Long, MatchSession> matchSessionMap = new ConcurrentHashMap<>();
 
@@ -285,7 +295,7 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         List<Long> participantIds =
                 matchedUsers.stream().map(WaitingUser::getUserId).toList();
 
-        MatchSession matchSession = MatchSession.matched(matchId, participantIds, roomId);
+        MatchSession matchSession = MatchSession.matched(matchId, queueKey, participantIds, roomId);
 
         // 세션 본문을 먼저 저장해두면, 이후 userMatchMap 연결 시점에
         // /matches/me 조회가 들어와도 matchId -> session 조회가 가능하다.
@@ -296,17 +306,157 @@ public class InMemoryMatchStateStore implements MatchStateStore {
             userMatchMap.put(user.getUserId(), matchId);
         });
 
-        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+        cleanupEmptyQueue(queueKey);
+    }
 
-        if (queue == null) {
-            return;
+    /**
+     * v2 ready-check 시작 시 유저들을 SEARCHING -> ACCEPT_PENDING 상태로 전환한다.
+     *
+     * 여기서는 roomId를 만들지 않고 세션만 만든다.
+     * 왜냐하면 ready-check에서는 "4명이 모였다"와 "전원 수락해 방이 준비됐다"를
+     * 다른 상태로 분리해야 하기 때문이다.
+     */
+    @Override
+    public MatchSession markAcceptPending(QueueKey queueKey, List<WaitingUser> matchedUsers, LocalDateTime deadline) {
+        Long matchId = matchSequence.getAndIncrement();
+        // WaitingUser는 queue에 묶인 임시 객체이고,
+        // 세션 본문에는 결국 userId 목록만 남기면 되므로 여기서 변환한다.
+        List<Long> participantIds =
+                matchedUsers.stream().map(WaitingUser::getUserId).toList();
+
+        MatchSession matchSession = MatchSession.acceptPending(matchId, queueKey, participantIds, deadline);
+
+        // v1의 markMatched와 마찬가지로 세션 본문을 먼저 저장한 뒤
+        // user -> match 연결을 만든다.
+        matchSessionMap.put(matchId, matchSession);
+
+        matchedUsers.forEach(user -> {
+            // ready-check로 넘어간 사용자는 더 이상 SEARCHING queue 참가자가 아니다.
+            // 큐 맵에서 지워서 false로 되면 폴링중단
+            userQueueMap.remove(user.getUserId());
+            userMatchMap.put(user.getUserId(), matchId);
+        });
+
+        cleanupEmptyQueue(queueKey);
+        return matchSession;
+    }
+
+    /**
+     * 특정 참가자의 decision을 ACCEPTED로 바꾼다.
+     *
+     * 왜 여기서는 decision만 바꾸나?
+     * -> 전원 수락 여부 판단과 room 생성은 저장소 책임이 아니라
+     *    ReadyCheckService의 흐름 제어 책임으로 두기 위해서다.
+     */
+    @Override
+    public MatchSession accept(Long matchId, Long userId) {
+        MatchSession matchSession = requireMatchSession(matchId);
+
+        if (!matchSession.hasParticipant(userId)) {
+            throw new IllegalStateException("매치 참가자가 아닌 사용자는 수락할 수 없습니다.");
         }
 
-        synchronized (queue) {
-            if (queue.isEmpty()) {
-                waitingQueues.remove(queueKey, queue);
-            }
+        if (matchSession.isExpiredAt(LocalDateTime.now())) {
+            // 스케줄러 대신 lazy expire를 사용하므로,
+            // 읽기/액션 시점에 deadline을 넘겼으면 여기서 바로 EXPIRED로 바꾼다.
+            return expire(matchId);
         }
+
+        if (matchSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+            // 이미 ROOM_READY, CANCELLED, EXPIRED 같은 최종 상태면 더 바꾸지 않는다.
+            return matchSession;
+        }
+
+        if (matchSession.decisionOf(userId) == ReadyDecision.ACCEPTED) {
+            // 같은 사용자의 중복 accept는 현재 상태를 그대로 돌려준다.
+            return matchSession;
+        }
+
+        MatchSession updatedSession = matchSession.withDecision(userId, ReadyDecision.ACCEPTED);
+        matchSessionMap.put(matchId, updatedSession);
+        return updatedSession;
+    }
+
+    /**
+     * 특정 참가자의 decision을 DECLINED로 바꾸고 세션 전체를 취소 상태로 전환한다.
+     *
+     * ready-check에서 한 명이라도 거절하면 더 이상 같은 세션을 유지할 의미가 없으므로
+     * 세션 전체를 CANCELLED로 처리한다.
+     */
+    @Override
+    public MatchSession decline(Long matchId, Long userId) {
+        MatchSession matchSession = requireMatchSession(matchId);
+
+        if (!matchSession.hasParticipant(userId)) {
+            throw new IllegalStateException("매치 참가자가 아닌 사용자는 거절할 수 없습니다.");
+        }
+
+        if (matchSession.isExpiredAt(LocalDateTime.now())) {
+            // 거절을 누른 시점에 이미 deadline이 지났다면 거절보다 만료를 우선 반영한다.
+            return expire(matchId);
+        }
+
+        if (matchSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+            return matchSession;
+        }
+
+        // 이번 단계 정책에서는 한 명이 DECLINED가 되면 세션 전체를 종료한다.
+        MatchSession updatedSession =
+                matchSession.withDecision(userId, ReadyDecision.DECLINED).cancelled();
+        matchSessionMap.put(matchId, updatedSession);
+        return updatedSession;
+    }
+
+    /**
+     * 전원 수락이 끝난 뒤 roomId를 세션에 연결한다.
+     *
+     * 이 메서드를 별도로 둔 이유는
+     * ACCEPT_PENDING과 ROOM_READY를 명확히 나누기 위해서다.
+     */
+    @Override
+    public MatchSession markRoomReady(Long matchId, Long roomId) {
+        MatchSession matchSession = requireMatchSession(matchId);
+        // roomId가 세션에 연결되는 순간부터 프론트는 실제 입장 가능한 상태가 된다.
+        MatchSession updatedSession = matchSession.roomReady(roomId);
+        matchSessionMap.put(matchId, updatedSession);
+        return updatedSession;
+    }
+
+    /**
+     * deadline이 지난 ACCEPT_PENDING 세션을 EXPIRED로 바꾼다.
+     *
+     * 이미 최종 상태로 넘어간 세션은 그대로 두고,
+     * 수락 대기 중인 세션에만 만료를 적용한다.
+     */
+    @Override
+    public MatchSession expire(Long matchId) {
+        MatchSession matchSession = requireMatchSession(matchId);
+
+        if (matchSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+            // 이미 최종 상태로 바뀐 세션은 중복 만료 처리하지 않는다.
+            return matchSession;
+        }
+
+        MatchSession updatedSession = matchSession.expired();
+        matchSessionMap.put(matchId, updatedSession);
+        return updatedSession;
+    }
+
+    /**
+     * 거절 또는 방 생성 실패 같은 이유로 세션 전체를 취소 상태로 바꾼다.
+     */
+    @Override
+    public MatchSession cancelMatch(Long matchId) {
+        MatchSession matchSession = requireMatchSession(matchId);
+
+        if (matchSession.status() == MatchSessionStatus.CANCELLED) {
+            return matchSession;
+        }
+
+        // room 생성 실패 같은 시스템 사유도 ready-check 거절과 동일하게 취소 상태로 묶는다.
+        MatchSession updatedSession = matchSession.cancelled();
+        matchSessionMap.put(matchId, updatedSession);
+        return updatedSession;
     }
 
     /**
@@ -380,6 +530,9 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      * - MATCHED   : 방이 잡혔고 roomId가 있음
      * - SEARCHING : 아직 큐에서 매칭 대기 중
      * - IDLE      : 대기 중도 아니고 매칭 완료 상태도 아님
+     *
+     * v2 세션이 이미 ROOM_READY로 넘어가더라도,
+     * v1 프론트는 "방이 준비되었는가"만 알면 되므로 MATCHED로 해석해 호환성을 유지한다.
      */
     @Override
     public MatchStateResponse getMatchState(Long userId) {
@@ -388,13 +541,12 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         if (matchId != null) {
             MatchSession matchSession = matchSessionMap.get(matchId);
 
-            if (matchSession != null && matchSession.status() == MatchSessionStatus.MATCHED) {
+            if (matchSession == null) {
+                cleanupStaleUserMatch(userId, matchId);
+            } else if (matchSession.status() == MatchSessionStatus.MATCHED
+                    || matchSession.status() == MatchSessionStatus.ROOM_READY) {
                 return new MatchStateResponse("MATCHED", matchSession.roomId());
             }
-
-            // userMatchMap에는 연결이 남아 있는데 실제 세션이 없으면
-            // 더 이상 유효한 매칭 상태가 아니므로 조회 시점에 정리한다.
-            cleanupStaleUserMatch(userId, matchId);
         }
 
         if (userQueueMap.containsKey(userId)) {
@@ -402,6 +554,72 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         }
 
         return new MatchStateResponse("IDLE", null);
+    }
+
+    /**
+     * /queue/me 응답용 상태 조회
+     *
+     * v2에서는 queue/me를 SEARCHING UI 전용으로 유지하므로,
+     * waitingCount와 함께 requiredCount도 내려준다.
+     */
+    @Override
+    public QueueStateV2Response getQueueStateV2(Long userId) {
+        QueueKey queueKey = userQueueMap.get(userId);
+
+        if (queueKey == null) {
+            // userQueueMap에 연결이 없다는 뜻은 이미 queue 단계가 끝났다는 뜻이다.
+            return new QueueStateV2Response(false, null, null, 0, REQUIRED_MATCH_SIZE);
+        }
+
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        if (queue == null) {
+            userQueueMap.remove(userId, queueKey);
+            return new QueueStateV2Response(false, null, null, 0, REQUIRED_MATCH_SIZE);
+        }
+
+        synchronized (queue) {
+            // requiredCount를 함께 내려 프론트가 1/4, 2/4 UI를 바로 만들 수 있게 한다.
+            return new QueueStateV2Response(
+                    true, queueKey.category(), queueKey.difficulty().name(), queue.size(), REQUIRED_MATCH_SIZE);
+        }
+    }
+
+    /**
+     * v2 matches/me 응답 조립을 위한 세션 원본 조회
+     *
+     * 왜 DTO를 여기서 바로 만들지 않나?
+     * -> participant nickname 같은 화면용 정보는 store 책임이 아니라
+     *    서비스 계층에서 회원 정보를 합쳐 만드는 쪽이 더 자연스럽기 때문이다.
+     */
+    @Override
+    public MatchSession findMatchSessionByUserId(Long userId) {
+        Long matchId = userMatchMap.get(userId);
+
+        if (matchId == null) {
+            // queue에서도 빠졌고 match 연결도 없다면 ready-check 대상이 아니다.
+            return null;
+        }
+
+        MatchSession matchSession = matchSessionMap.get(matchId);
+
+        if (matchSession == null) {
+            // user -> match 연결은 남아 있는데 본문이 사라진 경우 조회 시점에 정리한다.
+            cleanupStaleUserMatch(userId, matchId);
+            return null;
+        }
+
+        if (matchSession.isExpiredAt(LocalDateTime.now())) {
+            // 별도 스케줄러 없이 조회 시점에 만료를 반영한다.
+            return expire(matchId);
+        }
+
+        if (matchSession.status() == MatchSessionStatus.CLOSED) {
+            cleanupStaleUserMatch(userId, matchId);
+            return null;
+        }
+
+        return matchSession;
     }
 
     /**
@@ -433,10 +651,13 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         }
 
         if (!roomId.equals(matchSession.roomId())) {
+            // 잘못된 roomId 요청으로 다른 세션 연결이 지워지지 않게 방어한다.
             return;
         }
 
+        // 입장에 성공한 사용자만 세션 참조에서 제거한다.
         userMatchMap.remove(userId, matchId);
+        // 유저 매치맵이 다 삭제되면 그 후에 매칭방삭제
         removeMatchSessionIfUnreferenced(matchId);
     }
 
@@ -451,11 +672,37 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         return waitingQueues.containsKey(queueKey);
     }
 
+    private MatchSession requireMatchSession(Long matchId) {
+        MatchSession matchSession = matchSessionMap.get(matchId);
+
+        if (matchSession == null) {
+            throw new IllegalStateException("존재하지 않는 매치 세션입니다.");
+        }
+
+        return matchSession;
+    }
+
+    private void cleanupEmptyQueue(QueueKey queueKey) {
+        Deque<WaitingUser> queue = waitingQueues.get(queueKey);
+
+        if (queue == null) {
+            return;
+        }
+
+        synchronized (queue) {
+            if (queue.isEmpty()) {
+                // 비어 있는 queue 객체를 제거해 queue/me 조회와 테스트 상태를 깔끔하게 유지한다.
+                waitingQueues.remove(queueKey, queue);
+            }
+        }
+    }
+
     /**
      * userMatchMap에는 연결이 남아 있지만 실제 MatchSession이 없을 때
      * 조회 시점에 해당 사용자의 stale 연결을 정리한다.
      */
     private void cleanupStaleUserMatch(Long userId, Long matchId) {
+        // 본문이 사라진 matchId를 계속 들고 있으면 이후 조회가 꼬이므로 즉시 정리한다.
         userMatchMap.remove(userId, matchId);
         removeMatchSessionIfUnreferenced(matchId);
     }
@@ -470,6 +717,7 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      */
     private void removeMatchSessionIfUnreferenced(Long matchId) {
         if (!userMatchMap.containsValue(matchId)) {
+            // 더 이상 이 matchId를 참조하는 사용자가 없을 때만 세션 본문을 제거한다.
             matchSessionMap.remove(matchId);
         }
     }

--- a/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
@@ -1,9 +1,12 @@
 package com.back.domain.matching.queue.store;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.back.domain.matching.queue.dto.MatchStateResponse;
 import com.back.domain.matching.queue.dto.QueueStateResponse;
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
+import com.back.domain.matching.queue.model.MatchSession;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
 
@@ -12,6 +15,10 @@ import com.back.domain.matching.queue.model.WaitingUser;
  *
  * 지금은 인메모리 구현체를 사용하지만,
  * 이후 Redis 등으로 교체할 수 있도록 저장 경계를 먼저 만든다.
+ *
+ * 이번 단계에서는 v1 즉시매칭과 v2 ready-check가 같은 저장소를 공유하되,
+ * 외부 계약은 컨트롤러/DTO에서 분리할 수 있도록
+ * store 레벨에서는 상태 조작 메서드만 확장한다.
  */
 public interface MatchStateStore {
 
@@ -48,6 +55,38 @@ public interface MatchStateStore {
     void markMatched(QueueKey queueKey, List<WaitingUser> matchedUsers, Long roomId);
 
     /**
+     * v2에서는 4명 매칭 직후 room을 만들지 않고,
+     * 먼저 ACCEPT_PENDING 세션을 생성해 ready-check를 시작한다.
+     */
+    MatchSession markAcceptPending(QueueKey queueKey, List<WaitingUser> matchedUsers, LocalDateTime deadline);
+
+    /**
+     * 특정 참가자의 decision을 ACCEPTED로 바꾼다.
+     */
+    // 전원 수락 판단과 room 생성은 서비스 책임이라서 여기서는 상태 변경만 한다.
+    MatchSession accept(Long matchId, Long userId);
+
+    /**
+     * 특정 참가자의 decision을 DECLINED로 바꾸고 세션 종료 흐름을 시작한다.
+     */
+    MatchSession decline(Long matchId, Long userId);
+
+    /**
+     * 전원 수락 후 roomId를 세션에 연결하고 ROOM_READY 상태로 전환한다.
+     */
+    MatchSession markRoomReady(Long matchId, Long roomId);
+
+    /**
+     * deadline이 지난 ready-check 세션을 EXPIRED 상태로 전환한다.
+     */
+    MatchSession expire(Long matchId);
+
+    /**
+     * 거절 또는 방 생성 실패 등으로 세션을 CANCELLED 상태로 전환한다.
+     */
+    MatchSession cancelMatch(Long matchId);
+
+    /**
      * 현재 해당 큐의 대기 인원 수를 반환한다.
      */
     int getWaitingCount(QueueKey queueKey);
@@ -61,6 +100,19 @@ public interface MatchStateStore {
      * matches/me 응답용 상태 조회
      */
     MatchStateResponse getMatchState(Long userId);
+
+    /**
+     * v2 queue/me는 SEARCHING UI 전용이므로 requiredCount까지 함께 내려준다.
+     */
+    QueueStateV2Response getQueueStateV2(Long userId);
+
+    /**
+     * v2 matches/me는 서비스 계층에서 닉네임 같은 부가 정보를 조합해야 하므로,
+     * 저장소는 세션 원본만 찾아서 돌려준다.
+     */
+    // store는 세션 원본 조회까지만 담당하고,
+    // 닉네임 같은 화면용 정보 조립은 서비스가 맡는다.
+    MatchSession findMatchSessionByUserId(Long userId);
 
     /**
      * 방 입장 성공 후 matched 상태를 정리한다.

--- a/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
@@ -1,0 +1,210 @@
+package com.back.domain.matching.queue.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
+import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
+import com.back.domain.battle.battleroom.service.BattleRoomService;
+import com.back.domain.matching.queue.adapter.QueueProblemPicker;
+import com.back.domain.matching.queue.dto.MatchStateV2Response;
+import com.back.domain.matching.queue.dto.MatchStatus;
+import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
+import com.back.domain.matching.queue.dto.QueueStatusResponse;
+import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
+import com.back.domain.matching.queue.store.MatchStateStore;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+
+class ReadyCheckServiceTest {
+
+    private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
+    private final QueueProblemPicker queueProblemPicker = mock(QueueProblemPicker.class);
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final MatchStateStore matchStateStore = new InMemoryMatchStateStore();
+
+    private final MatchingQueueService matchingQueueService =
+            new MatchingQueueService(battleRoomService, queueProblemPicker, matchStateStore);
+
+    private final ReadyCheckService readyCheckService =
+            new ReadyCheckService(battleRoomService, queueProblemPicker, matchStateStore, memberRepository);
+
+    @BeforeEach
+    void setUp() {
+        when(queueProblemPicker.pick(any(QueueKey.class), anyList())).thenReturn(1L);
+        when(memberRepository.findAllById(anyList())).thenAnswer(invocation -> {
+            List<Long> ids = invocation.getArgument(0);
+            return ids.stream()
+                    .map(id -> Member.of(id, "user" + id + "@test.com", "user" + id))
+                    .toList();
+        });
+    }
+
+    @Test
+    @DisplayName("v2 queue/me는 SEARCHING 동안 waitingCount와 requiredCount를 반환한다")
+    void getMyQueueStateV2_returnsSearchingInfo() {
+        QueueStatusResponse response = readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+
+        QueueStateV2Response queueState = readyCheckService.getMyQueueStateV2(1L);
+
+        assertThat(response.getWaitingCount()).isEqualTo(1);
+        assertThat(queueState.inQueue()).isTrue();
+        assertThat(queueState.category()).isEqualTo("ARRAY");
+        assertThat(queueState.difficulty()).isEqualTo("EASY");
+        assertThat(queueState.waitingCount()).isEqualTo(1);
+        assertThat(queueState.requiredCount()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("4명이 모이면 v2 matches/me는 ACCEPT_PENDING을 반환한다")
+    void getMyMatchStateV2_returnsAcceptPending_whenFourthUserJoins() {
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        QueueStatusResponse fourthResponse = readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        MatchStateV2Response response = readyCheckService.getMyMatchStateV2(1L);
+
+        assertThat(fourthResponse.getWaitingCount()).isEqualTo(0);
+        assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isFalse();
+        assertThat(response.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+        assertThat(response.room()).isNull();
+        assertThat(response.readyCheck()).isNotNull();
+        assertThat(response.readyCheck().acceptedCount()).isEqualTo(0);
+        assertThat(response.readyCheck().requiredCount()).isEqualTo(4);
+        assertThat(response.readyCheck().acceptedByMe()).isFalse();
+        assertThat(response.readyCheck().participants()).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("전원 수락이 완료되면 ROOM_READY와 roomId를 반환한다")
+    void acceptMatch_returnsRoomReady_whenAllUsersAccepted() {
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        readyCheckService.acceptMatch(1L, matchId);
+        readyCheckService.acceptMatch(2L, matchId);
+        readyCheckService.acceptMatch(3L, matchId);
+        MatchStateV2Response response = readyCheckService.acceptMatch(4L, matchId);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.ROOM_READY);
+        assertThat(response.room()).isNotNull();
+        assertThat(response.room().roomId()).isEqualTo(100L);
+        assertThat(response.readyCheck().acceptedCount()).isEqualTo(4);
+        verify(battleRoomService, times(1)).createRoom(any(CreateRoomRequest.class));
+    }
+
+    @Test
+    @DisplayName("한 명이라도 거절하면 세션 전체가 CANCELLED로 종료된다")
+    void declineMatch_returnsCancelled() {
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        MatchStateV2Response response = readyCheckService.declineMatch(2L, matchId);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.CANCELLED);
+        assertThat(response.message()).isEqualTo("다른 참가자가 매칭을 거절했습니다.");
+        assertThat(response.readyCheck().participants()).anySatisfy(participant -> {
+            if (participant.userId().equals(2L)) {
+                assertThat(participant.decision().name()).isEqualTo("DECLINED");
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("deadline이 지난 ready-check 세션은 EXPIRED로 조회된다")
+    void getMyMatchStateV2_returnsExpired_whenDeadlinePassed() {
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+        List<WaitingUser> users = List.of(
+                new WaitingUser(1L, queueKey),
+                new WaitingUser(2L, queueKey),
+                new WaitingUser(3L, queueKey),
+                new WaitingUser(4L, queueKey));
+
+        matchStateStore.markAcceptPending(queueKey, users, LocalDateTime.now().minusSeconds(1));
+
+        MatchStateV2Response response = readyCheckService.getMyMatchStateV2(1L);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.EXPIRED);
+        assertThat(response.message()).isEqualTo("수락 시간이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("방 생성이 실패하면 CANCELLED 상태와 실패 메시지를 반환한다")
+    void acceptMatch_returnsCancelled_whenCreateRoomFails() {
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenThrow(new RuntimeException("room create failed"));
+
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        readyCheckService.acceptMatch(1L, matchId);
+        readyCheckService.acceptMatch(2L, matchId);
+        readyCheckService.acceptMatch(3L, matchId);
+        MatchStateV2Response response = readyCheckService.acceptMatch(4L, matchId);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.CANCELLED);
+        assertThat(response.message()).isEqualTo("방 생성에 실패해 매칭이 취소되었습니다.");
+    }
+
+    @Test
+    @DisplayName("ROOM_READY 이후 한 명만 입장하면 그 사용자만 IDLE로 빠지고 나머지는 유지된다")
+    void clearMatchedRoom_removesOnlyEnteredUser_inV2Flow() {
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        readyCheckService.acceptMatch(1L, matchId);
+        readyCheckService.acceptMatch(2L, matchId);
+        readyCheckService.acceptMatch(3L, matchId);
+        readyCheckService.acceptMatch(4L, matchId);
+
+        matchingQueueService.clearMatchedRoom(1L, 100L);
+
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        assertThat(readyCheckService.getMyMatchStateV2(2L).status()).isEqualTo(MatchStatus.ROOM_READY);
+        assertThat(readyCheckService.getMyMatchStateV2(3L).status()).isEqualTo(MatchStatus.ROOM_READY);
+        assertThat(readyCheckService.getMyMatchStateV2(4L).status()).isEqualTo(MatchStatus.ROOM_READY);
+    }
+
+    private QueueJoinRequest createRequest(String category, Difficulty difficulty) {
+        return new QueueJoinRequest(category, difficulty);
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #85 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #85 

---

<html>
<body>
<h1>[feat] api/v2 기반 ready-check 매칭 흐름 추가</h1>

<h3>개요</h3>
<p>이번 PR은 기존의 “4명이 모이면 즉시 방 생성” 방식 대신, <strong>4인 매칭 성사 후 전원 수락을 거쳐 방을 생성하는 ready-check 기반 v2 매칭 흐름</strong>을 추가한 작업입니다.</p>
<p>즉, <code>SEARCHING</code> 단계와 <code>ACCEPT_PENDING / ROOM_READY / EXPIRED / CANCELLED</code> 단계를 분리하고, 프론트가 각 단계를 별도 UI로 그릴 수 있도록 <code>/api/v2/queue/*</code>, <code>/api/v2/matches/*</code> API를 새로 구성했습니다.</p>
<p>기존 v1 매칭 API는 유지하고, 이번 변경은 v2 흐름을 별도 컨트롤러/DTO/서비스 계층으로 확장하는 방식으로 구현했습니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) v2 queue API 추가</h3>
<p>검색 중인 상태만 담당하는 <code>/api/v2/queue</code> 계열 API를 추가했습니다.</p>

<ul>
<li><code>GET /api/v2/queue/me</code> : 현재 SEARCHING 상태의 큐 정보 조회</li>
<li><code>POST /api/v2/queue/join</code> : v2 ready-check 기반 매칭 참가</li>
<li><code>DELETE /api/v2/queue/cancel</code> : 아직 SEARCHING 상태인 사용자만 취소</li>
</ul>

<p>이 API는 “지금 몇 명이 모였는지”를 보여주는 SEARCHING UI 전용입니다. 즉, ready-check 진행 중인지, 방이 준비됐는지 같은 상태는 여기서 다루지 않고 별도 <code>/api/v2/matches</code> API로 분리했습니다.</p>

<pre><code class="language-java">@RestController
@RequestMapping("/api/v2/queue")
public class MatchingQueueV2Controller {
    @GetMapping("/me")
    public QueueStateV2Response getMyQueueState() { ... }

    @PostMapping("/join")
    public QueueStatusResponse joinQueue(...) { ... }

    @DeleteMapping("/cancel")
    public QueueStatusResponse cancelQueue() { ... }
}
</code></pre>

<h3>2) v2 matches API 추가</h3>
<p>ready-check 및 방 준비 상태를 담당하는 <code>/api/v2/matches</code> 계열 API를 추가했습니다.</p>

<ul>
<li><code>GET /api/v2/matches/me</code> : 현재 사용자의 ready-check / room 상태 조회</li>
<li><code>POST /api/v2/matches/{matchId}/accept</code> : 해당 매칭 수락</li>
<li><code>POST /api/v2/matches/{matchId}/decline</code> : 해당 매칭 거절</li>
</ul>

<p>즉, queue API는 SEARCHING만, matches API는 ready-check 이후 상태만 담당하도록 역할을 분리했습니다.</p>

<h3>3) 4인 성사 후 즉시 방 생성하지 않고 ACCEPT_PENDING 세션 생성</h3>
<p><code>ReadyCheckService.joinQueueV2()</code>에서는 기존처럼 유저를 대기열에 넣되, 4명이 모였다고 바로 방을 만들지 않습니다.</p>
<p>대신 4명이 모인 시점에 <strong>15초 제한시간의 ready-check 세션</strong>을 생성하고, 모든 참여자가 수락해야만 실제 문제 선택 및 방 생성으로 넘어가도록 변경했습니다.</p>

<pre><code class="language-java">private static final int REQUIRED_MATCH_SIZE = 4;
private static final long READY_CHECK_TIMEOUT_SECONDS = 15L;
</code></pre>

<p>흐름은 아래와 같습니다.</p>

<pre><code class="language-java">1. joinQueueV2()로 큐 참가
2. 대기 인원이 4명 미만이면 SEARCHING 유지
3. 4명 충족 시 pollMatchCandidates()로 4명 추출
4. markAcceptPending()으로 ACCEPT_PENDING 세션 생성
5. deadline = now + 15초 저장
6. 이후 각 사용자는 matches/{matchId}/accept 또는 decline 호출
</code></pre>

<h3>4) 전원 수락 시에만 문제 선택 + 방 생성 + ROOM_READY 전환</h3>
<p><code>acceptMatch()</code>는 단순히 “내 decision을 ACCEPTED로 바꾸는 것”에서 끝나지 않고, 마지막 수락으로 전원 수락이 완료되면 그때 비로소 실제 방 생성 흐름을 수행합니다.</p>

<pre><code class="language-java">if (matchSession.status() == MatchSessionStatus.ACCEPT_PENDING && matchSession.isAllAccepted()) {
    Long problemId = queueProblemPicker.pick(matchSession.queueKey(), matchSession.participantIds());
    CreateRoomResponse response = battleRoomService.createRoom(
            new CreateRoomRequest(problemId, matchSession.participantIds(), REQUIRED_MATCH_SIZE));
    matchSession = matchStateStore.markRoomReady(matchId, response.roomId());
}
</code></pre>

<p>즉, <strong>문제 선택과 방 생성은 “전원 수락 완료 후”에만 실행</strong>됩니다. 이 구조 덕분에 한 명이라도 거절하는 세션에 대해 불필요한 방 생성이 일어나지 않습니다.</p>

<h3>5) 거절/실패/만료 상태를 별도 세션 상태로 관리</h3>
<p>이번 PR에서는 매칭 그룹 단위 상태를 표현하기 위해 <code>MatchSession</code>, <code>MatchSessionStatus</code>, <code>ReadyDecision</code>를 도입했습니다.</p>

<ul>
<li><code>ACCEPT_PENDING</code> : 4명은 모였지만 아직 전원 수락 전</li>
<li><code>ROOM_READY</code> : 전원 수락 후 roomId까지 준비된 상태</li>
<li><code>EXPIRED</code> : ready-check 제한시간 초과</li>
<li><code>CANCELLED</code> : 누군가 거절했거나, 방 생성에 실패한 상태</li>
<li><code>MATCHED</code> : 기존 v1 호환용 완료 상태</li>
<li><code>PENDING / ACCEPTED / DECLINED</code> : 참여자별 ready-check 응답 상태</li>
</ul>

<p><code>MatchSession</code>에는 아래 정보들을 담습니다.</p>

<ul>
<li><code>matchId</code></li>
<li><code>queueKey</code></li>
<li><code>participantIds</code></li>
<li><code>participantDecisions</code></li>
<li><code>status</code></li>
<li><code>roomId</code></li>
<li><code>deadline</code></li>
<li><code>createdAt</code></li>
</ul>

<h3>6) 한 명이라도 거절하면 세션 전체를 CANCELLED 처리</h3>
<p><code>declineMatch()</code>에서는 특정 사용자만 거절 상태로 두는 것이 아니라, ready-check의 성격상 한 명이라도 거절하면 세션 전체를 <code>CANCELLED</code>로 전환합니다.</p>

<pre><code class="language-java">MatchSession updatedSession =
        matchSession.withDecision(userId, ReadyDecision.DECLINED).cancelled();
</code></pre>

<p>즉, 4명 중 1명이라도 거절하면 해당 매칭은 더 이상 유효하지 않은 세션으로 종료됩니다.</p>

<h3>7) 방 생성 실패도 별도 에러 재시도 없이 CANCELLED로 종료</h3>
<p>전원 수락 이후 방 생성 단계에서 예외가 발생하면, 이번 단계에서는 별도 재시도 로직을 두지 않고 세션 자체를 <code>CANCELLED</code>로 종료하도록 처리했습니다.</p>

<pre><code class="language-java">catch (RuntimeException e) {
    matchSession = matchStateStore.cancelMatch(matchId);
}
</code></pre>

<p>즉, ready-check는 성공했지만 방 생성이 실패한 경우도 프론트에는 취소된 매칭으로 응답되며, 사용자는 다시 매칭을 시작하는 흐름으로 돌아가게 됩니다.</p>

<h3>8) 만료는 별도 스케줄러 없이 lazy expire 방식으로 처리</h3>
<p>이번 1차 구현에서는 ready-check 만료를 별도 스케줄러로 미리 쓸어내지 않고, 조회/수락/거절 시점에 deadline을 넘겼는지 확인한 뒤 <code>EXPIRED</code>로 전환하는 lazy expire 방식을 사용했습니다.</p>

<pre><code class="language-java">if (matchSession.isExpiredAt(LocalDateTime.now())) {
    return expire(matchId);
}
</code></pre>

<p>즉, 프론트가 <code>matches/me</code>를 조회하거나 accept/decline 요청을 보내는 시점에 세션 만료가 반영됩니다.</p>

<h3>9) In-memory store를 v2 ready-check까지 확장</h3>
<p><code>InMemoryMatchStateStore</code>는 기존 큐 상태 관리에서 한 단계 확장되어 아래 상태를 함께 관리합니다.</p>

<ul>
<li><code>waitingQueues</code> : 실제 SEARCHING 대기열</li>
<li><code>userQueueMap</code> : userId -&gt; QueueKey</li>
<li><code>userMatchMap</code> : userId -&gt; matchId</li>
<li><code>matchSessionMap</code> : matchId -&gt; MatchSession</li>
<li><code>matchSequence</code> : 인메모리 matchId 발급</li>
</ul>

<p>또한 큐 추출/롤백/세션 상태 전환 책임을 서비스 밖의 저장소 계층으로 분리해 두었습니다. 이 구조 덕분에 이후 Redis 등 외부 저장소로 바꿀 때도 서비스 로직 변경을 최소화할 수 있게 했습니다.</p>

<h3>10) FIFO 추출 및 롤백 순서 보장</h3>
<p>4명 추출은 <code>pollFirst()</code> 기반으로 FIFO를 유지하고, ready-check 세션 생성에 실패하면 추출했던 유저들을 역순 <code>addFirst()</code>로 복구해 원래 대기 순서를 최대한 보존합니다.</p>

<pre><code class="language-java">for (int i = users.size() - 1; i >= 0; i--) {
    queue.addFirst(users.get(i));
}
</code></pre>

<p>즉, 4명 추출 단계에서 실패하더라도 대기열 순서를 최대한 유지하도록 설계했습니다.</p>

<h3>11) 프론트 UI에 맞는 v2 응답 DTO 추가</h3>
<p>v2 응답은 SEARCHING UI와 ready-check UI를 분리해서 그릴 수 있도록 DTO를 나눴습니다.</p>

<ul>
<li><code>QueueStateV2Response</code> : <code>inQueue, category, difficulty, waitingCount, requiredCount</code></li>
<li><code>MatchStateV2Response</code> : <code>status, readyCheck, room, message</code></li>
<li><code>ReadyCheckSnapshot</code> : <code>matchId, acceptedCount, requiredCount, acceptedByMe, deadline, participants</code></li>
<li><code>ReadyParticipantSnapshot</code> : <code>userId, nickname, decision</code></li>
<li><code>RoomSnapshot</code> : <code>roomId</code></li>
</ul>

<p>즉, 프론트는</p>
<ul>
<li><code>/api/v2/queue/me</code>로 SEARCHING UI</li>
<li><code>/api/v2/matches/me</code>로 ACCEPT_PENDING / ROOM_READY / CANCELLED / EXPIRED UI</li>
</ul>
<p>를 각각 분리해서 구성할 수 있습니다.</p>

<h3>12) 닉네임 조합은 서비스 계층에서 처리</h3>
<p>store는 세션 상태만 저장하고, ready-check 참여자 목록에 필요한 닉네임은 <code>ReadyCheckService</code>가 <code>MemberRepository</code>를 조회해 응답 직전에 조합합니다.</p>
<p>즉, 저장소는 상태 저장, 서비스는 응답 조합이라는 역할 분리를 유지했습니다.</p>

<h3>13) 테스트 코드 추가</h3>
<p><code>ReadyCheckServiceTest</code>를 추가해 v2 핵심 시나리오를 검증했습니다.</p>

<ul>
<li>SEARCHING 상태에서 <code>queue/me</code>가 waitingCount / requiredCount를 반환하는지</li>
<li>4번째 유저 진입 시 <code>ACCEPT_PENDING</code> 세션이 생성되는지</li>
<li>전원 수락 시 <code>ROOM_READY + roomId</code>가 반환되는지</li>
<li>누군가 거절하면 <code>CANCELLED</code>가 되는지</li>
<li>deadline 초과 시 <code>EXPIRED</code>로 보이는지</li>
<li>방 생성 실패 시 <code>CANCELLED</code>와 실패 메시지가 반환되는지</li>
<li>ROOM_READY 이후 한 명만 방 입장했을 때 그 사용자만 <code>IDLE</code>로 정리되는지</li>
</ul>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-java">[SEARCHING]
POST /api/v2/queue/join
      ↓
대기열 인원 1/4, 2/4, 3/4
      ↓
4번째 유저 진입
      ↓
즉시 room 생성하지 않고 ACCEPT_PENDING 세션 생성
deadline = now + 15s
      ↓
GET /api/v2/matches/me
  status = ACCEPT_PENDING
  readyCheck.participants = 4명
  acceptedCount = 0
      ↓
각 사용자 accept / decline
  ┌─ 한 명이라도 decline
  │    → CANCELLED
  ├─ deadline 초과
  │    → EXPIRED
  └─ 전원 accept
       → 문제 선택
       → battleRoom 생성
       → ROOM_READY + roomId 반환
      ↓
프론트가 roomId로 방 입장
      ↓
입장 성공한 사용자부터 matched state 정리
</code></pre>

<h2>확인 포인트</h2>
<ol>
<li><code>/api/v2/queue/me</code>는 SEARCHING 상태 전용으로만 동작하는지 확인</li>
<li>4명이 모여도 즉시 room을 만들지 않고 먼저 <code>ACCEPT_PENDING</code> 세션을 만드는지 확인</li>
<li>전원 수락 시에만 문제 선택과 room 생성이 일어나는지 확인</li>
<li>거절 / 만료 / room 생성 실패가 각각 <code>CANCELLED</code>, <code>EXPIRED</code>로 구분되어 응답되는지 확인</li>
<li><code>/api/v2/matches/me</code> 응답만으로 ready-check UI와 room 이동 UI를 구성할 수 있는지 확인</li>
<li>방 입장 성공 후에는 해당 사용자만 매칭 상태가 정리되고, 나머지 사용자는 그대로 유지되는지 확인</li>
</ol>
</body>
</html>

