### PR TITLE
[feat] 솔로 문제풀이용 문제 상세 계약 확장 및 언어 starter 프로필 파이프라인 추가

### DIFF
--- a/docs/local-db-compose-guide.md
+++ b/docs/local-db-compose-guide.md
@@ -60,6 +60,24 @@ cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && pyth
 - 같은 구간을 다시 실행하면 기존 문제는 건너뜁니다. (`skipped_existing_problem` 증가)
 - `difficulty`는 `EASY`, `MEDIUM`, `HARD` 3단계 enum 문자열로 저장됩니다.
 
+실행 후 요약 로그는 아래 형태로 출력됩니다. (숫자는 실행마다 달라집니다)
+
+```text
+[2026-03-30T10:42:15] load summary
+- rows_fetched: 200
+- rows_loaded: 173
+- problems_inserted: 160
+- skipped_existing_problem: 13
+- sample_tests: 346
+- hidden_tests: 1180
+```
+
+빠르게 동작 확인만 할 때는 10건만 먼저 적재해도 됩니다.
+
+```bash
+cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/load_openr1_verifiable.py --truncate --limit 10 --chunk-size 10
+```
+
 전체 적재에 가깝게 넣고 싶으면 `limit`을 충분히 크게 줍니다.
 
 ```bash
@@ -75,7 +93,68 @@ cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && pyth
 cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/load_openr1_verifiable.py --truncate --limit 200 --chunk-size 50
 ```
 
-## 4) IntelliJ에서 확인
+## 4) 언어 starter 생성 (선택)
+
+문제 상세 응답에서 `supportedLanguages/defaultLanguage/starterCodes`를 쓰려면 실행합니다.
+
+```bash
+cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/generate_problem_language_profiles.py --limit 200
+```
+
+- 기본 생성 언어: `python3, java, c, cpp17, javascript`
+- 기본 선택 언어: `python3`
+- `(problem_id, language_code)` 기준 upsert
+
+실행 후 요약 로그 예시:
+
+```text
+[2026-03-30T10:45:02] generation summary
+- problems_targeted: 200
+- profiles_upserted: 1000
+- dry_run: False
+- languages: python3,java,c,cpp17,javascript
+```
+
+`load`를 `--truncate`로 다시 돌렸으면 아래도 함께 실행하세요.
+
+```bash
+cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/generate_problem_language_profiles.py --truncate --limit 200
+```
+
+문제별 커스텀 시그니처가 필요하면 override 파일을 사용합니다.
+
+```bash
+cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/generate_problem_language_profiles.py --overrides-json scripts/starter_overrides.example.json
+```
+
+override JSON 예시는 아래 구조를 따릅니다.
+
+```json
+{
+  "problem_id": {
+    "9951": {
+      "java": "class Solution {\\n    public int solve(int[] nums) {\\n        return 0;\\n    }\\n}\\n"
+    }
+  },
+  "source_problem_id": {
+    "852/A": {
+      "java": "class Solution {\\n    public int[] twoSum(int[] nums, int target) {\\n        return new int[]{};\\n    }\\n}\\n"
+    }
+  }
+}
+```
+
+- `problem_id`: DB의 `problems.id` 기준으로 starter override
+- `source_problem_id`: 원본 문제 키(예: `852/A`) 기준으로 starter override
+- 두 조건이 동시에 있으면 `problem_id` override가 우선됩니다.
+
+특정 문제만 재생성하고 싶으면:
+
+```bash
+cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/generate_problem_language_profiles.py --problem-ids 1,2,3 --languages python3,java,c,cpp17,javascript --default-language python3
+```
+
+## 5) IntelliJ/DBeaver에서 확인
 
 ### IntelliJ 접속 설정
 
@@ -90,26 +169,30 @@ cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && pyth
 
 1. `Database` 탭에서 PostgreSQL 데이터소스 추가  
    host=`localhost`, port=`5432`, db=`back`, user=`back`, password=`.env의 DB_PASSWORD`
-2. 아래 쿼리로 적재 결과 확인
+2. 아래 쿼리로 적재/생성 결과 확인
 
 ```sql
 select count(*) as problems from problems;
 select count(*) as tags from tags;
 select count(*) as problem_tag_connect from problem_tag_connect;
 select count(*) as test_cases from test_cases;
+select count(*) as language_profiles from problem_language_profiles;
 
 select id, source_problem_id, title, difficulty, difficulty_rating, input_mode, judge_type
 from problems
 order by id desc
 limit 20;
 
-select difficulty, count(*) from problems group by difficulty order by difficulty;
-
-select id, left(input_format, 80), left(output_format, 80)
-from problems
-order by id desc
-limit 20;
+select p.id, p.title, lp.language_code, lp.is_default
+from problems p
+join problem_language_profiles lp on lp.problem_id = p.id
+order by p.id desc, lp.is_default desc, lp.language_code asc
+limit 30;
 ```
+
+빠른 확인 기준:
+- `language_profiles`가 `problems * 5`에 가깝게 나오면 기본 5개 언어 starter가 정상 생성된 상태입니다.
+- `is_default = true` 행은 문제당 1개여야 합니다.
 
 ### DBeaver 접속 설정
 
@@ -118,7 +201,21 @@ limit 20;
 3. `Test Connection` 성공 후 `Finish`
 4. 좌측 `Database Navigator`에서 `Schemas > public > Tables` 확인
 
-## 5) 자주 나는 오류
+## 6) 자주 나는 오류
+
+- `SyntaxError: future feature annotations is not defined`
+  - 원인: Python 3.6 이하로 스크립트를 실행한 경우
+  - 조치: `python3 --version` 확인 후 3.9+로 실행
+  - 예시:
+    ```bash
+    pyenv local 3.10.13
+    exec "$SHELL" -l
+    python3 --version
+    ```
+
+- `FATAL: password authentication failed for user "${DB_USERNAME}"`
+  - 원인: `.env`가 export되지 않아 플레이스홀더 문자열이 그대로 들어간 경우
+  - 조치: `set -a && source .env && set +a` 후 재실행
 
 - `relation "problems" does not exist`
   - 원인: 스키마 생성 전에 로더를 먼저 실행한 경우
@@ -140,7 +237,7 @@ limit 20;
 set -a && source ../.env && set +a && python3 ../scripts/load_openr1_verifiable.py --limit 200 --chunk-size 50
 ```
 
-## 6) 마무리 체크
+## 7) 마무리 체크
 
 - 문서의 모든 명령어 블록이 닫혀 있는지 확인합니다.
 - `docker compose ps`에서 `postgres`가 `healthy` 상태인지 확인합니다.

--- a/scripts/generate_problem_language_profiles.py
+++ b/scripts/generate_problem_language_profiles.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""
+problems를 기준으로 problem_language_profiles를 생성/갱신한다.
+
+기본 동작:
+- 문제 제목 기반으로 언어별 starter 코드를 자동 생성
+- (문제ID, 언어) 유니크 키 기준 upsert
+
+확장 동작:
+- --overrides-json 파일로 특정 문제의 starter 코드를 언어별로 override 가능
+  예시 구조:
+  {
+    "problem_id": {
+      "9951": {
+        "java": "class Solution { ... }",
+        "python3": "class Solution: ..."
+      }
+    },
+    "source_problem_id": {
+      "852/A": {
+        "java": "..."
+      }
+    }
+  }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+psycopg = None
+
+DEFAULT_LANGUAGES = ["python3", "java", "c", "cpp17", "javascript"]
+
+
+def ensure_psycopg() -> None:
+    global psycopg
+    if psycopg is not None:
+        return
+    try:
+        import psycopg as _psycopg
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(
+            "psycopg is required. Install with: pip install 'psycopg[binary]'"
+        ) from exc
+    psycopg = _psycopg
+
+
+def default_dsn() -> str:
+    host = os.getenv("DB_HOST", "localhost")
+    port = os.getenv("DB_PORT", "5432")
+    name = os.getenv("DB_NAME", "back")
+    user = os.getenv("DB_USERNAME", "back")
+    password = os.getenv("DB_PASSWORD")
+    if not password:
+        raise ValueError(
+            "DB_PASSWORD is required. Set it in .env and export it, or pass --dsn/LOAD_DSN."
+        )
+    return f"postgresql://{user}:{password}@{host}:{port}/{name}"
+
+
+def resolve_id_sequence(
+    cur: psycopg.Cursor[Any], table_name: str, preferred_sequence_names: tuple[str, ...]
+) -> str | None:
+    """
+    테이블 id 자동 생성 전략을 판별한다.
+
+    - identity/default가 있으면 None 반환(일반 INSERT)
+    - 없으면 사용할 시퀀스명을 반환(예: problem_language_profile_id_seq)
+    """
+    cur.execute(
+        """
+        SELECT is_identity, column_default
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = %s
+          AND column_name = 'id'
+        """,
+        (table_name,),
+    )
+    row = cur.fetchone()
+    if row:
+        is_identity, column_default = row
+        if is_identity == "YES" or column_default:
+            return None
+
+    candidates: list[str] = []
+    for seq in preferred_sequence_names:
+        candidates.append(f"public.{seq}")
+        candidates.append(seq)
+    for candidate in candidates:
+        cur.execute("SELECT to_regclass(%s)::text", (candidate,))
+        seq_name = cur.fetchone()[0]
+        if seq_name:
+            return str(seq_name)
+
+    cur.execute("SELECT pg_get_serial_sequence(%s, 'id')", (f"public.{table_name}",))
+    serial_seq = cur.fetchone()[0]
+    if serial_seq:
+        return str(serial_seq)
+
+    raise RuntimeError(
+        f"Cannot resolve sequence/default for {table_name}.id. "
+        "Run BackApplication once to create schema or fix id generation."
+    )
+
+
+def slugify(text: str, max_len: int = 40) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
+    if not slug:
+        slug = "problem"
+    if slug[0].isdigit():
+        slug = f"p_{slug}"
+    return slug[:max_len]
+
+
+def to_camel_case(text: str, max_len: int = 50) -> str:
+    parts = re.findall(r"[A-Za-z0-9]+", text)
+    if not parts:
+        return "Problem"
+    camel = "".join(part[0].upper() + part[1:] for part in parts)
+    if camel[0].isdigit():
+        camel = f"P{camel}"
+    return camel[:max_len]
+
+
+def build_default_starter(language: str, title: str) -> str:
+    safe_title = title.replace('"', "'")
+    fn_slug = slugify(safe_title)
+    fn_camel = to_camel_case(safe_title)
+
+    templates: dict[str, str] = {
+        "python3": (
+            f"def solve_{fn_slug}():\n"
+            f"    \"\"\"Problem: {safe_title}\"\"\"\n"
+            "    # TODO: implement\n"
+            "    pass\n\n"
+            "if __name__ == \"__main__\":\n"
+            f"    solve_{fn_slug}()\n"
+        ),
+        "java": (
+            "import java.io.*;\n"
+            "import java.util.*;\n\n"
+            "public class Main {\n"
+            f"    static void solve{fn_camel}() throws Exception {{\n"
+            f"        // Problem: {safe_title}\n"
+            "        // TODO: implement\n"
+            "    }\n\n"
+            "    public static void main(String[] args) throws Exception {\n"
+            f"        solve{fn_camel}();\n"
+            "    }\n"
+            "}\n"
+        ),
+        "c": (
+            "#include <stdio.h>\n\n"
+            f"void solve_{fn_slug}(void) {{\n"
+            f"    // Problem: {safe_title}\n"
+            "    // TODO: implement\n"
+            "}\n\n"
+            "int main(void) {\n"
+            f"    solve_{fn_slug}();\n"
+            "    return 0;\n"
+            "}\n"
+        ),
+        "cpp17": (
+            "#include <bits/stdc++.h>\n"
+            "using namespace std;\n\n"
+            f"void solve_{fn_slug}() {{\n"
+            f"    // Problem: {safe_title}\n"
+            "    // TODO: implement\n"
+            "}\n\n"
+            "int main() {\n"
+            "    ios::sync_with_stdio(false);\n"
+            "    cin.tie(nullptr);\n"
+            f"    solve_{fn_slug}();\n"
+            "    return 0;\n"
+            "}\n"
+        ),
+        "javascript": (
+            "'use strict';\n\n"
+            f"function solve{fn_camel}(input) {{\n"
+            f"  // Problem: {safe_title}\n"
+            "  // TODO: implement\n"
+            "  return '';\n"
+            "}\n\n"
+            "const fs = require('fs');\n"
+            "const input = fs.readFileSync(0, 'utf8');\n"
+            f"process.stdout.write(String(solve{fn_camel}(input)));\n"
+        ),
+    }
+
+    starter = templates.get(language)
+    if starter is None:
+        raise ValueError(f"Unsupported language: {language}")
+    return starter
+
+
+def load_overrides(path: str | None) -> dict[str, dict[str, dict[str, str]]]:
+    if not path:
+        return {"problem_id": {}, "source_problem_id": {}}
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("overrides json must be an object")
+
+    by_problem_id = payload.get("problem_id") or {}
+    by_source_id = payload.get("source_problem_id") or {}
+
+    if not isinstance(by_problem_id, dict) or not isinstance(by_source_id, dict):
+        raise ValueError("problem_id/source_problem_id must be objects")
+
+    return {
+        "problem_id": by_problem_id,
+        "source_problem_id": by_source_id,
+    }
+
+
+def resolve_starter(
+    language: str,
+    title: str,
+    problem_id: int,
+    source_problem_id: str | None,
+    overrides: dict[str, dict[str, dict[str, str]]],
+) -> str:
+    by_problem_id = overrides.get("problem_id", {})
+    by_source = overrides.get("source_problem_id", {})
+
+    problem_override = by_problem_id.get(str(problem_id))
+    if isinstance(problem_override, dict):
+        starter = problem_override.get(language)
+        if isinstance(starter, str) and starter.strip():
+            return starter
+
+    if source_problem_id:
+        source_override = by_source.get(source_problem_id)
+        if isinstance(source_override, dict):
+            starter = source_override.get(language)
+            if isinstance(starter, str) and starter.strip():
+                return starter
+
+    return build_default_starter(language, title)
+
+
+def upsert_profile(
+    cur: psycopg.Cursor[Any],
+    id_sequence: str | None,
+    problem_id: int,
+    language_code: str,
+    starter_code: str,
+    is_default: bool,
+) -> None:
+    if id_sequence:
+        cur.execute(
+            f"""
+            INSERT INTO problem_language_profiles
+                (id, problem_id, language_code, starter_code, is_default)
+            VALUES
+                (nextval('{id_sequence}'), %s, %s, %s, %s)
+            ON CONFLICT (problem_id, language_code)
+            DO UPDATE SET
+                starter_code = EXCLUDED.starter_code,
+                is_default = EXCLUDED.is_default
+            """,
+            (problem_id, language_code, starter_code, is_default),
+        )
+    else:
+        cur.execute(
+            """
+            INSERT INTO problem_language_profiles
+                (problem_id, language_code, starter_code, is_default)
+            VALUES
+                (%s, %s, %s, %s)
+            ON CONFLICT (problem_id, language_code)
+            DO UPDATE SET
+                starter_code = EXCLUDED.starter_code,
+                is_default = EXCLUDED.is_default
+            """,
+            (problem_id, language_code, starter_code, is_default),
+        )
+
+
+def parse_languages(raw: str) -> list[str]:
+    languages = [token.strip() for token in raw.split(",") if token.strip()]
+    if not languages:
+        raise ValueError("--languages must include at least one language")
+    return languages
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate starter codes into problem_language_profiles")
+    parser.add_argument("--dsn", default=os.getenv("LOAD_DSN"), help="PostgreSQL DSN")
+    parser.add_argument(
+        "--languages",
+        default=",".join(DEFAULT_LANGUAGES),
+        help="Comma-separated language codes (default: python3,java,c,cpp17,javascript)",
+    )
+    parser.add_argument(
+        "--default-language",
+        default="python3",
+        help="Language code used as default starter (default: python3)",
+    )
+    parser.add_argument(
+        "--problem-ids",
+        default="",
+        help="Comma-separated problem ids to generate. Empty means all problems.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Generate only latest N problems (0 means no limit)",
+    )
+    parser.add_argument(
+        "--truncate",
+        action="store_true",
+        help="TRUNCATE problem_language_profiles before generation",
+    )
+    parser.add_argument(
+        "--overrides-json",
+        default="",
+        help="Optional JSON file path for per-problem overrides",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def build_problem_query(problem_ids: list[int], limit: int) -> tuple[str, tuple[Any, ...]]:
+    if problem_ids:
+        placeholders = ",".join(["%s"] * len(problem_ids))
+        return (
+            f"""
+            SELECT id, source_problem_id, title
+            FROM problems
+            WHERE id IN ({placeholders})
+            ORDER BY id ASC
+            """,
+            tuple(problem_ids),
+        )
+
+    if limit > 0:
+        return (
+            """
+            SELECT id, source_problem_id, title
+            FROM problems
+            ORDER BY id DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+
+    return (
+        """
+        SELECT id, source_problem_id, title
+        FROM problems
+        ORDER BY id ASC
+        """,
+        tuple(),
+    )
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.dsn:
+        try:
+            args.dsn = default_dsn()
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+
+    try:
+        languages = parse_languages(args.languages)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if args.default_language not in languages:
+        print("--default-language must be included in --languages", file=sys.stderr)
+        return 2
+
+    problem_ids: list[int] = []
+    if args.problem_ids.strip():
+        try:
+            problem_ids = [int(token.strip()) for token in args.problem_ids.split(",") if token.strip()]
+        except ValueError:
+            print("--problem-ids must be comma-separated integers", file=sys.stderr)
+            return 2
+
+    try:
+        overrides = load_overrides(args.overrides_json)
+    except Exception as exc:
+        print(f"failed to read overrides: {exc}", file=sys.stderr)
+        return 2
+
+    ensure_psycopg()
+    conn = psycopg.connect(args.dsn)
+    conn.autocommit = False
+
+    stats = {
+        "problems_targeted": 0,
+        "profiles_upserted": 0,
+    }
+
+    try:
+        with conn.cursor() as cur:
+            profile_id_seq = resolve_id_sequence(
+                cur,
+                "problem_language_profiles",
+                ("problem_language_profile_id_seq",),
+            )
+
+            query, params = build_problem_query(problem_ids, args.limit)
+            cur.execute(query, params)
+            rows = cur.fetchall()
+            if args.limit > 0 and not problem_ids:
+                rows = sorted(rows, key=lambda r: r[0])
+
+            stats["problems_targeted"] = len(rows)
+
+            if args.truncate and not args.dry_run:
+                cur.execute("TRUNCATE TABLE problem_language_profiles RESTART IDENTITY")
+
+            for problem_id, source_problem_id, title in rows:
+                for language in languages:
+                    starter = resolve_starter(
+                        language=language,
+                        title=title,
+                        problem_id=int(problem_id),
+                        source_problem_id=source_problem_id,
+                        overrides=overrides,
+                    )
+
+                    if args.dry_run:
+                        stats["profiles_upserted"] += 1
+                        continue
+
+                    upsert_profile(
+                        cur,
+                        id_sequence=profile_id_seq,
+                        problem_id=int(problem_id),
+                        language_code=language,
+                        starter_code=starter,
+                        is_default=(language == args.default_language),
+                    )
+                    stats["profiles_upserted"] += 1
+
+        if args.dry_run:
+            conn.rollback()
+        else:
+            conn.commit()
+
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    now = datetime.now().isoformat(timespec="seconds")
+    print(f"[{now}] generation summary")
+    for key, value in stats.items():
+        print(f"- {key}: {value}")
+    print(f"- dry_run: {args.dry_run}")
+    print(f"- languages: {','.join(languages)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/starter_overrides.example.json
+++ b/scripts/starter_overrides.example.json
@@ -1,0 +1,13 @@
+{
+  "problem_id": {
+    "9951": {
+      "java": "class Solution {\n    public int solve(int[] nums) {\n        // TODO\n        return 0;\n    }\n}\n",
+      "python3": "class Solution:\n    def solve(self, nums: list[int]) -> int:\n        # TODO\n        return 0\n"
+    }
+  },
+  "source_problem_id": {
+    "852/A": {
+      "java": "class Solution {\n    public int[] twoSum(int[] nums, int target) {\n        return new int[]{};\n    }\n}\n"
+    }
+  }
+}

--- a/src/main/java/com/back/domain/problem/languageprofile/entity/ProblemLanguageProfile.java
+++ b/src/main/java/com/back/domain/problem/languageprofile/entity/ProblemLanguageProfile.java
@@ -1,0 +1,42 @@
+package com.back.domain.problem.languageprofile.entity;
+
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.global.jpa.entity.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "problem_language_profiles",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_problem_language_profiles_problem_language",
+                    columnNames = {"problem_id", "language_code"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemLanguageProfile extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "problem_language_profile_seq_gen")
+    @SequenceGenerator(
+            name = "problem_language_profile_seq_gen",
+            sequenceName = "problem_language_profile_id_seq",
+            allocationSize = 50)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    @Column(name = "language_code", nullable = false, length = 30)
+    private String languageCode;
+
+    @Column(name = "starter_code", columnDefinition = "TEXT", nullable = false)
+    private String starterCode;
+
+    @Column(name = "is_default", nullable = false)
+    private Boolean isDefault;
+}

--- a/src/main/java/com/back/domain/problem/languageprofile/entity/ProblemLanguageProfile.java
+++ b/src/main/java/com/back/domain/problem/languageprofile/entity/ProblemLanguageProfile.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "problem_language_profiles",
         uniqueConstraints = {
+            // 문제 1개당 동일 언어 profile이 중복 생성되지 않도록 강제
             @UniqueConstraint(
                     name = "uk_problem_language_profiles_problem_language",
                     columnNames = {"problem_id", "language_code"})
@@ -29,14 +30,18 @@ public class ProblemLanguageProfile extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_id", nullable = false)
+    // 어떤 문제의 언어 profile인지 식별
     private Problem problem;
 
     @Column(name = "language_code", nullable = false, length = 30)
+    // 예: python3, java, c, cpp17, javascript
     private String languageCode;
 
     @Column(name = "starter_code", columnDefinition = "TEXT", nullable = false)
+    // 해당 언어 선택 시 에디터 초기 코드
     private String starterCode;
 
     @Column(name = "is_default", nullable = false)
+    // 상세 화면 기본 선택 언어 여부
     private Boolean isDefault;
 }

--- a/src/main/java/com/back/domain/problem/languageprofile/repository/ProblemLanguageProfileRepository.java
+++ b/src/main/java/com/back/domain/problem/languageprofile/repository/ProblemLanguageProfileRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.back.domain.problem.languageprofile.entity.ProblemLanguageProfile;
 
 public interface ProblemLanguageProfileRepository extends JpaRepository<ProblemLanguageProfile, Long> {
+    // 상세 응답 구성 시 문제별 언어 profile 전체를 안정적인 순서(id 오름차순)로 조회
     List<ProblemLanguageProfile> findByProblemIdOrderByIdAsc(Long problemId);
 }

--- a/src/main/java/com/back/domain/problem/languageprofile/repository/ProblemLanguageProfileRepository.java
+++ b/src/main/java/com/back/domain/problem/languageprofile/repository/ProblemLanguageProfileRepository.java
@@ -1,0 +1,11 @@
+package com.back.domain.problem.languageprofile.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.problem.languageprofile.entity.ProblemLanguageProfile;
+
+public interface ProblemLanguageProfileRepository extends JpaRepository<ProblemLanguageProfile, Long> {
+    List<ProblemLanguageProfile> findByProblemIdOrderByIdAsc(Long problemId);
+}

--- a/src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java
@@ -1,5 +1,7 @@
 package com.back.domain.problem.problem.dto;
 
+import java.util.List;
+
 import com.back.domain.problem.problem.entity.Problem;
 
 public record ProblemDetailResponse(
@@ -10,9 +12,22 @@ public record ProblemDetailResponse(
         String inputFormat,
         String outputFormat,
         Long timeLimitMs,
-        Long memoryLimitMb) {
+        Long memoryLimitMb,
+        List<String> supportedLanguages,
+        String defaultLanguage,
+        List<StarterCode> starterCodes,
+        List<SampleCase> sampleCases) {
 
-    public static ProblemDetailResponse from(Problem problem) {
+    public record StarterCode(String language, String code) {}
+
+    public record SampleCase(String input, String output) {}
+
+    public static ProblemDetailResponse from(
+            Problem problem,
+            List<String> supportedLanguages,
+            String defaultLanguage,
+            List<StarterCode> starterCodes,
+            List<SampleCase> sampleCases) {
         return new ProblemDetailResponse(
                 problem.getId(),
                 problem.getTitle(),
@@ -21,6 +36,10 @@ public record ProblemDetailResponse(
                 problem.getInputFormat(),
                 problem.getOutputFormat(),
                 problem.getTimeLimitMs(),
-                problem.getMemoryLimitMb());
+                problem.getMemoryLimitMb(),
+                supportedLanguages,
+                defaultLanguage,
+                starterCodes,
+                sampleCases);
     }
 }

--- a/src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java
@@ -13,13 +13,19 @@ public record ProblemDetailResponse(
         String outputFormat,
         Long timeLimitMs,
         Long memoryLimitMb,
+        // 문제 화면에서 언어 선택 드롭다운을 구성하기 위한 지원 언어 목록
         List<String> supportedLanguages,
+        // 언어 선택 초기값(없으면 프론트에서 첫 번째 언어를 fallback으로 사용)
         String defaultLanguage,
+        // 언어별 시작 코드. 에디터 초기값 세팅에 사용
         List<StarterCode> starterCodes,
+        // 공개 가능한 샘플 테스트 케이스만 전달
         List<SampleCase> sampleCases) {
 
+    // 특정 언어의 기본 코드 템플릿
     public record StarterCode(String language, String code) {}
 
+    // 문제 상세 화면 하단 예제 입/출력 영역 데이터
     public record SampleCase(String input, String output) {}
 
     public static ProblemDetailResponse from(

--- a/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
+++ b/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
@@ -55,11 +55,13 @@ public class ProblemService {
         List<ProblemLanguageProfile> languageProfiles =
                 problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(problemId);
 
+        // 언어 프로필을 기반으로 상세 화면의 언어 목록을 구성한다.
         List<String> supportedLanguages = languageProfiles.stream()
                 .map(ProblemLanguageProfile::getLanguageCode)
                 .distinct()
                 .toList();
 
+        // isDefault=true를 우선 사용하고, 없으면 첫 번째 언어를 기본값으로 선택한다.
         String defaultLanguage = languageProfiles.stream()
                 .filter(profile -> Boolean.TRUE.equals(profile.getIsDefault()))
                 .findFirst()
@@ -67,11 +69,13 @@ public class ProblemService {
                 .or(() -> languageProfiles.stream().findFirst().map(ProblemLanguageProfile::getLanguageCode))
                 .orElse(null);
 
+        // 프론트 에디터에서 언어 전환 시 바로 반영할 starter code 목록
         List<ProblemDetailResponse.StarterCode> starterCodes = languageProfiles.stream()
                 .map(profile ->
                         new ProblemDetailResponse.StarterCode(profile.getLanguageCode(), profile.getStarterCode()))
                 .toList();
 
+        // 채점용 hidden 케이스는 제외하고, sample 케이스만 노출한다.
         List<ProblemDetailResponse.SampleCase> sampleCases = problem.getTestCases().stream()
                 .filter(tc -> Boolean.TRUE.equals(tc.getIsSample()))
                 .map(this::toSampleCase)

--- a/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
+++ b/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
@@ -1,15 +1,20 @@
 package com.back.domain.problem.problem.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.back.domain.problem.languageprofile.entity.ProblemLanguageProfile;
+import com.back.domain.problem.languageprofile.repository.ProblemLanguageProfileRepository;
 import com.back.domain.problem.problem.dto.ProblemDetailResponse;
 import com.back.domain.problem.problem.dto.ProblemListResponse;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
@@ -22,6 +27,7 @@ public class ProblemService {
     private static final int MAX_PAGE_SIZE = 100;
 
     private final ProblemRepository problemRepository;
+    private final ProblemLanguageProfileRepository problemLanguageProfileRepository;
 
     public ProblemListResponse getProblems(int page, int size) {
         if (page < 0) {
@@ -46,6 +52,35 @@ public class ProblemService {
                 .findById(problemId)
                 .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 문제입니다."));
 
-        return ProblemDetailResponse.from(problem);
+        List<ProblemLanguageProfile> languageProfiles =
+                problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(problemId);
+
+        List<String> supportedLanguages = languageProfiles.stream()
+                .map(ProblemLanguageProfile::getLanguageCode)
+                .distinct()
+                .toList();
+
+        String defaultLanguage = languageProfiles.stream()
+                .filter(profile -> Boolean.TRUE.equals(profile.getIsDefault()))
+                .findFirst()
+                .map(ProblemLanguageProfile::getLanguageCode)
+                .or(() -> languageProfiles.stream().findFirst().map(ProblemLanguageProfile::getLanguageCode))
+                .orElse(null);
+
+        List<ProblemDetailResponse.StarterCode> starterCodes = languageProfiles.stream()
+                .map(profile ->
+                        new ProblemDetailResponse.StarterCode(profile.getLanguageCode(), profile.getStarterCode()))
+                .toList();
+
+        List<ProblemDetailResponse.SampleCase> sampleCases = problem.getTestCases().stream()
+                .filter(tc -> Boolean.TRUE.equals(tc.getIsSample()))
+                .map(this::toSampleCase)
+                .toList();
+
+        return ProblemDetailResponse.from(problem, supportedLanguages, defaultLanguage, starterCodes, sampleCases);
+    }
+
+    private ProblemDetailResponse.SampleCase toSampleCase(TestCase testCase) {
+        return new ProblemDetailResponse.SampleCase(testCase.getInput(), testCase.getExpectedOutput());
     }
 }

--- a/src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java
@@ -42,7 +42,20 @@ class ProblemControllerTest {
     void getProblem_returnsServiceResult() {
         // given
         ProblemDetailResponse response = new ProblemDetailResponse(
-                1L, "A + B", "EASY", "두 정수 A, B를 입력받아 합을 출력하시오.", "첫 줄에 A, B가 공백으로 주어진다.", "A+B를 출력한다.", 1000L, 256L);
+                1L,
+                "A + B",
+                "EASY",
+                "두 정수 A, B를 입력받아 합을 출력하시오.",
+                "첫 줄에 A, B가 공백으로 주어진다.",
+                "A+B를 출력한다.",
+                1000L,
+                256L,
+                List.of("python3", "java"),
+                "python3",
+                List.of(
+                        new ProblemDetailResponse.StarterCode("python3", "print('hello')"),
+                        new ProblemDetailResponse.StarterCode("java", "class Main {}")),
+                List.of(new ProblemDetailResponse.SampleCase("1 2", "3")));
         when(problemService.getProblem(1L)).thenReturn(response);
 
         // when

--- a/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
@@ -16,17 +16,23 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import com.back.domain.problem.languageprofile.entity.ProblemLanguageProfile;
+import com.back.domain.problem.languageprofile.repository.ProblemLanguageProfileRepository;
 import com.back.domain.problem.problem.dto.ProblemDetailResponse;
 import com.back.domain.problem.problem.dto.ProblemListResponse;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.global.exception.ServiceException;
 
 class ProblemServiceTest {
 
     private final ProblemRepository problemRepository = mock(ProblemRepository.class);
-    private final ProblemService problemService = new ProblemService(problemRepository);
+    private final ProblemLanguageProfileRepository problemLanguageProfileRepository =
+            mock(ProblemLanguageProfileRepository.class);
+    private final ProblemService problemService =
+            new ProblemService(problemRepository, problemLanguageProfileRepository);
 
     @Test
     @DisplayName("문제 목록 조회 시 페이지 정보와 요약 목록을 반환한다")
@@ -85,6 +91,11 @@ class ProblemServiceTest {
     void getProblem_returnsProblemDetail() {
         // given
         Problem problem = mock(Problem.class);
+        TestCase sampleCase = mock(TestCase.class);
+        TestCase hiddenCase = mock(TestCase.class);
+        ProblemLanguageProfile pythonProfile = mock(ProblemLanguageProfile.class);
+        ProblemLanguageProfile javaProfile = mock(ProblemLanguageProfile.class);
+
         when(problem.getId()).thenReturn(1L);
         when(problem.getTitle()).thenReturn("A + B");
         when(problem.getDifficulty()).thenReturn(DifficultyLevel.EASY);
@@ -93,8 +104,24 @@ class ProblemServiceTest {
         when(problem.getOutputFormat()).thenReturn("A+B를 출력한다.");
         when(problem.getTimeLimitMs()).thenReturn(1000L);
         when(problem.getMemoryLimitMb()).thenReturn(256L);
+        when(problem.getTestCases()).thenReturn(List.of(sampleCase, hiddenCase));
+
+        when(sampleCase.getIsSample()).thenReturn(true);
+        when(sampleCase.getInput()).thenReturn("1 2");
+        when(sampleCase.getExpectedOutput()).thenReturn("3");
+
+        when(hiddenCase.getIsSample()).thenReturn(false);
+
+        when(pythonProfile.getLanguageCode()).thenReturn("python3");
+        when(pythonProfile.getStarterCode()).thenReturn("print('hello')");
+        when(pythonProfile.getIsDefault()).thenReturn(true);
+        when(javaProfile.getLanguageCode()).thenReturn("java");
+        when(javaProfile.getStarterCode()).thenReturn("class Main {}");
+        when(javaProfile.getIsDefault()).thenReturn(false);
 
         when(problemRepository.findById(1L)).thenReturn(Optional.of(problem));
+        when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L))
+                .thenReturn(List.of(pythonProfile, javaProfile));
 
         // when
         ProblemDetailResponse response = problemService.getProblem(1L);
@@ -108,6 +135,13 @@ class ProblemServiceTest {
         assertThat(response.outputFormat()).isEqualTo("A+B를 출력한다.");
         assertThat(response.timeLimitMs()).isEqualTo(1000L);
         assertThat(response.memoryLimitMb()).isEqualTo(256L);
+        assertThat(response.supportedLanguages()).containsExactly("python3", "java");
+        assertThat(response.defaultLanguage()).isEqualTo("python3");
+        assertThat(response.starterCodes())
+                .containsExactly(
+                        new ProblemDetailResponse.StarterCode("python3", "print('hello')"),
+                        new ProblemDetailResponse.StarterCode("java", "class Main {}"));
+        assertThat(response.sampleCases()).containsExactly(new ProblemDetailResponse.SampleCase("1 2", "3"));
     }
 
     @Test


### PR DESCRIPTION
## 변경 배경
솔로 문제풀이 화면에서 언어 선택/초기 코드/샘플 케이스를 바로 사용할 수 있도록 문제 상세 응답 계약을 확장하고, 데이터 적재 파이프라인을 보강했습니다.

## 주요 변경
1. 문제 상세 응답 확장
- `supportedLanguages`, `defaultLanguage`, `starterCodes`, `sampleCases` 추가
- 샘플 케이스(`isSample=true`)만 노출하도록 분리

2. 문제-언어 starter 프로필 파이프라인 추가
- `problem_language_profiles` 생성/갱신 스크립트 추가
- 기본 5개 언어(py/java/c/cpp17/js) starter 자동 생성
- 문제별 override JSON 지원 (`problem_id`, `source_problem_id` 기준)

3. 로컬 DB 가이드 강화
- load/generate 단계별 실행 예시 추가
- 요약 로그 예시 및 검증 SQL 추가
- python/env 관련 자주 나는 오류 가이드 보강

4. 코드 가독성 보강
- 엔티티/DTO/서비스에 의도 주석 추가
- repository 조회 의도 명시

## 왜 이렇게 했는가
- 프론트는 문제 상세 응답 하나로 언어 드롭다운 + 코드 에디터 초기값 + 예제 케이스를 즉시 구성해야 함
- 문제 적재(load)와 starter 생성(generate)을 분리해 운영 유연성 확보
  - 문제만 재적재하거나
  - starter만 재생성/override 가능
- 채점용 hidden 케이스는 상세 응답에서 제외해 보안/공정성 유지

## 변경 파일
- `docs/local-db-compose-guide.md`
- `scripts/generate_problem_language_profiles.py`
- `scripts/starter_overrides.example.json`
- `src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java`
- `src/main/java/com/back/domain/problem/problem/service/ProblemService.java`
- `src/main/java/com/back/domain/problem/languageprofile/entity/ProblemLanguageProfile.java`
- `src/main/java/com/back/domain/problem/languageprofile/repository/ProblemLanguageProfileRepository.java`
- `src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java`
- `src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java`

## 영향 범위
- API: `GET /api/v1/problems/{id}` 응답 필드 확장
- DB: `problem_language_profiles` 사용 전제
- 문서: 로컬 데이터 적재/검증 절차 업데이트

## 테스트
- ProblemServiceTest
- ProblemControllerTest
