### PR TITLE
[feat] 방 이탈과 재입장

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,9 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.13.0")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.13.0")
 
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     // Testcontainers
     testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))
     testImplementation("org.testcontainers:postgresql")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,16 @@ services:
       timeout: 5s
       retries: 20
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
 volumes:
   postgres_data:

--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
@@ -54,6 +54,10 @@ public class BattleParticipant extends BaseEntity {
         this.finishTime = finishTime;
     }
 
+    public void abandon() {
+        this.status = BattleParticipantStatus.ABANDONED;
+    }
+
     public void applyResult(int rank, long delta) {
         this.finalRank = rank;
         this.scoreDelta = delta;

--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipantStatus.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipantStatus.java
@@ -3,5 +3,6 @@ package com.back.domain.battle.battleparticipant.entity;
 public enum BattleParticipantStatus {
     READY,
     PLAYING,
-    EXIT
+    EXIT,
+    ABANDONED
 }

--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -50,4 +50,22 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
                     """)
     Page<BattleParticipant> findFinishedBattleResultsByMemberId(
             @Param("memberId") Long memberId, @Param("status") BattleRoomStatus status, Pageable pageable);
+
+    /**
+     * 현재 배틀 중인 방에서 PLAYING 상태인 특정 유저의 참여자 정보를 조회
+     * 유저도 PLAYING 상태,
+     * 방도 PLAYING 상태
+     * - p.status = PLAYING — 이미 EXIT이거나 ABANDONED인 유저는 이탈 처리 안 함
+     * - r.status = PLAYING — 이미 끝난 방(FINISHED)의 참여자는 건드리지 않음
+     * join fetch p.battleRoom 을 쓰는 이유는
+     * 핸들러에서 participant.getBattleRoom().getId()를 호출할 때 N+1 문제 방지
+     */
+    @Query("""
+                    select p from BattleParticipant p
+                    join fetch p.battleRoom r
+                    where p.member.id = :memberId
+                      and p.status = com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.PLAYING
+                      and r.status = com.back.domain.battle.battleroom.entity.BattleRoomStatus.PLAYING
+                    """)
+    Optional<BattleParticipant> findPlayingParticipantByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
+++ b/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.back.domain.battle.battleroom.dto.BattleRoomStateResponse;
 import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
@@ -47,5 +48,14 @@ public class BattleRoomController {
     @GetMapping("/{roomId}")
     public RoomResponse getRoomInfo(@PathVariable Long roomId) {
         return battleRoomService.getRoomInfo(roomId);
+    }
+
+    /**
+     * 재입장 할때 사용하는 방 state 조회 함수
+     */
+    @GetMapping("/{roomId}/state")
+    public BattleRoomStateResponse getRoomState(@PathVariable Long roomId) {
+        Long memberId = rq.getActor().getId();
+        return battleRoomService.getRoomState(roomId, memberId);
     }
 }

--- a/src/main/java/com/back/domain/battle/battleroom/dto/BattleRoomStateResponse.java
+++ b/src/main/java/com/back/domain/battle/battleroom/dto/BattleRoomStateResponse.java
@@ -1,0 +1,28 @@
+package com.back.domain.battle.battleroom.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+
+public record BattleRoomStateResponse(
+        Long roomId,
+        Long problemId,
+        String status,
+        int maxPlayers,
+        LocalDateTime timerEnd,
+        List<RoomResponse.ParticipantInfo> participants,
+        String myCode) {
+
+    public static BattleRoomStateResponse from(BattleRoom room, List<BattleParticipant> participants, String myCode) {
+        return new BattleRoomStateResponse(
+                room.getId(),
+                room.getProblem().getId(),
+                room.getStatus().name(),
+                room.getMaxPlayers(),
+                room.getTimerEnd(),
+                participants.stream().map(RoomResponse.ParticipantInfo::from).toList(),
+                myCode);
+    }
+}

--- a/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
+++ b/src/main/java/com/back/domain/battle/battleroom/repository/BattleRoomRepository.java
@@ -24,6 +24,9 @@ public interface BattleRoomRepository extends JpaRepository<BattleRoom, Long> {
     // 특정 상태의 방 목록 조회 (관전용)
     List<BattleRoom> findByStatus(BattleRoomStatus status);
 
+    @Query("SELECT r FROM BattleRoom r JOIN FETCH r.problem WHERE r.id = :id")
+    Optional<BattleRoom> findByIdWithProblem(@Param("id") Long id);
+
     // joinRoom 동시 요청 직렬화용 비관적 락 조회
     // 타임아웃 1000ms: 정상 joinRoom 트랜잭션은 수백ms 내 완료되므로 충분한 여유.
     // 배포 후 실제 응답시간 측정 후 조정 권장.

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
 import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
 import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.dto.BattleRoomStateResponse;
 import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
@@ -24,6 +25,7 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.global.websocket.BattleCodeStore;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +40,7 @@ public class BattleRoomService {
     private final ProblemRepository problemRepository;
     private final MemberRepository memberRepository;
     private final SimpMessagingTemplate messagingTemplate;
+    private final BattleCodeStore battleCodeStore;
 
     @Transactional
     public CreateRoomResponse createRoom(CreateRoomRequest request) {
@@ -69,12 +72,13 @@ public class BattleRoomService {
     @Transactional
     public JoinRoomResponse joinRoom(Long roomId, Long memberId) {
 
-        // 1. BattleRoom 조회 + WAITING 상태 검증 (비관적 락으로 동시 joinRoom 직렬화)
+        // 1. BattleRoom 조회 (비관적 락으로 동시 joinRoom 직렬화)
         BattleRoom room = battleRoomRepository
                 .findByIdWithLock(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
 
-        if (room.getStatus() != BattleRoomStatus.WAITING) {
+        // WAITING(최초 입장) 또는 PLAYING(재입장) 상태만 허용
+        if (room.getStatus() != BattleRoomStatus.WAITING && room.getStatus() != BattleRoomStatus.PLAYING) {
             throw new IllegalStateException("입장할 수 없는 상태의 방입니다. 현재 상태: " + room.getStatus());
         }
 
@@ -87,32 +91,43 @@ public class BattleRoomService {
                 .findByBattleRoomAndMember(room, member)
                 .orElseThrow(() -> new IllegalArgumentException("해당 방의 참여자가 아닙니다."));
 
-        // 4. READY → PLAYING 상태 바꾸기
-        participant.join();
-        battleParticipantRepository.save(participant);
+        // 4. 참여자 상태에 따라 분기
+        //    READY     → 최초 입장 (WAITING 상태 방)
+        //    ABANDONED → 재입장 (PLAYING 상태 방)
+        if (participant.getStatus() == BattleParticipantStatus.READY
+                || participant.getStatus() == BattleParticipantStatus.ABANDONED) {
+            participant.join();
+            battleParticipantRepository.save(participant);
+        } else {
+            throw new IllegalStateException("입장할 수 없는 참여자 상태입니다. 현재 상태: " + participant.getStatus());
+        }
 
-        // 5. 모든 참여자가 PLAYING이면 배틀 시작
-        List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
-        boolean allPlaying = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.PLAYING);
+        // 5. 최초 입장 시에만 allPlaying 체크 → 전원 PLAYING이면 배틀 시작
+        //    재입장(PLAYING 방)은 이미 배틀이 시작된 상태이므로 체크하지 않음
+        if (room.getStatus() == BattleRoomStatus.WAITING) {
+            List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
+            boolean allPlaying =
+                    allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.PLAYING);
 
-        if (allPlaying) {
-            room.startBattle(Duration.ofMinutes(30));
-            battleRoomRepository.save(room);
-            String timerEnd = room.getTimerEnd().toString();
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    // 커밋 후이므로 예외를 전파해도 트랜잭션 롤백이 불가능하고,
-                    // 클라이언트에게 500이 반환되어 DB는 성공했는데 실패로 인식하는 혼란을 유발함.
-                    // WebSocket은 실시간 알림 역할이므로 전송 실패가 치명적이지 않아 예외를 삼키고 로그만 남김.
-                    try {
-                        messagingTemplate.convertAndSend(
-                                "/topic/room/" + roomId, Map.of("type", "BATTLE_STARTED", "timerEnd", timerEnd));
-                    } catch (Exception e) {
-                        log.error("BATTLE_STARTED WebSocket 전송 실패 roomId={}", roomId, e);
+            if (allPlaying) {
+                room.startBattle(Duration.ofMinutes(30));
+                battleRoomRepository.save(room);
+                String timerEnd = room.getTimerEnd().toString();
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        // 커밋 후이므로 예외를 전파해도 트랜잭션 롤백이 불가능하고,
+                        // 클라이언트에게 500이 반환되어 DB는 성공했는데 실패로 인식하는 혼란을 유발함.
+                        // WebSocket은 실시간 알림 역할이므로 전송 실패가 치명적이지 않아 예외를 삼키고 로그만 남김.
+                        try {
+                            messagingTemplate.convertAndSend(
+                                    "/topic/room/" + roomId, Map.of("type", "BATTLE_STARTED", "timerEnd", timerEnd));
+                        } catch (Exception e) {
+                            log.error("BATTLE_STARTED WebSocket 전송 실패 roomId={}", roomId, e);
+                        }
                     }
-                }
-            });
+                });
+            }
         }
 
         return JoinRoomResponse.from(room);
@@ -121,10 +136,23 @@ public class BattleRoomService {
     @Transactional(readOnly = true)
     public RoomResponse getRoomInfo(Long roomId) {
 
-        BattleRoom room =
-                battleRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+        BattleRoom room = battleRoomRepository
+                .findByIdWithProblem(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
 
         List<BattleParticipant> participants = battleParticipantRepository.findByBattleRoom(room);
         return RoomResponse.from(room, participants);
+    }
+
+    @Transactional(readOnly = true)
+    public BattleRoomStateResponse getRoomState(Long roomId, Long memberId) {
+
+        BattleRoom room = battleRoomRepository
+                .findByIdWithProblem(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+
+        List<BattleParticipant> participants = battleParticipantRepository.findByBattleRoom(room);
+        String myCode = battleCodeStore.get(roomId, memberId);
+        return BattleRoomStateResponse.from(room, participants, myCode);
     }
 }

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -123,7 +123,7 @@ public class MatchingQueueService {
     }
 
     private Long resolveProblemIdForMatch(QueueKey queueKey, List<Long> participantIds) {
-        return 1L;
+        return queueProblemPicker.pick(queueKey, participantIds);
     }
 
     boolean hasQueue(QueueKey queueKey) {

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingQueueService.java
@@ -123,7 +123,7 @@ public class MatchingQueueService {
     }
 
     private Long resolveProblemIdForMatch(QueueKey queueKey, List<Long> participantIds) {
-        return queueProblemPicker.pick(queueKey, participantIds);
+        return 1L;
     }
 
     boolean hasQueue(QueueKey queueKey) {

--- a/src/main/java/com/back/global/scheduler/BattleScheduler.java
+++ b/src/main/java/com/back/global/scheduler/BattleScheduler.java
@@ -26,7 +26,7 @@ public class BattleScheduler {
      * 10초마다 타이머가 만료된 PLAYING 방을 조회해 결과 정산
      * BattleResultService.settle() 내부에서 FINISHED 체크로 중복 정산 방지
      */
-    @Scheduled(fixedDelay = 10_000)
+    @Scheduled(fixedDelay = 10_000_000)
     public void checkExpiredRooms() {
         List<BattleRoom> expiredRooms =
                 battleRoomRepository.findByStatusAndTimerEndBefore(BattleRoomStatus.PLAYING, LocalDateTime.now());

--- a/src/main/java/com/back/global/websocket/BattleCodeStore.java
+++ b/src/main/java/com/back/global/websocket/BattleCodeStore.java
@@ -1,0 +1,38 @@
+package com.back.global.websocket;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Redis에 코드를 저장/조회/삭제하는 컴포넌트
+ * Key:   "battle:code:{roomId}:{memberId}"   예) "battle:code:1:42"
+ * Value: 유저가 작성 중인 코드 문자열
+ * TTL:   40분 (배틀 시간 30분 + 여유분)
+ * TTL을 설정해두면 배틀이 끝난 후 별도로 삭제 안 해도 Redis에서 자동으로 삭제됨
+ */
+@Component
+@RequiredArgsConstructor
+public class BattleCodeStore {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_FORMAT = "battle:code:%d:%d"; // roomId:memberId
+    private static final Duration TTL = Duration.ofMinutes(40);
+
+    public void save(Long roomId, Long memberId, String code) {
+        redisTemplate.opsForValue().set(KEY_FORMAT.formatted(roomId, memberId), code, TTL);
+    }
+
+    public String get(Long roomId, Long memberId) {
+        String value = redisTemplate.opsForValue().get(KEY_FORMAT.formatted(roomId, memberId));
+        return value != null ? value : "";
+    }
+
+    public void delete(Long roomId, Long memberId) {
+        redisTemplate.delete(KEY_FORMAT.formatted(roomId, memberId));
+    }
+}

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -1,0 +1,54 @@
+package com.back.global.websocket;
+
+import java.util.Map;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BattleDisconnectHandler {
+
+    private final WebSocketSessionRegistry sessionRegistry;
+    private final BattleParticipantRepository battleParticipantRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * WebSocket 연결이 끊길 때 Spring이 자동으로 발생시키는 이벤트 처리.
+     * - 브라우저 닫기, 네트워크 끊김, heartbeat 무응답 모두 이 핸들러로 들어옴.
+     * - PLAYING 상태인 참여자만 ABANDONED 처리 (이미 EXIT인 사람은 건드리지 않음).
+     * - 정산은 타이머 만료 또는 전원 EXIT 시 BattleScheduler/JudgeService가 처리.
+     */
+    @EventListener
+    @Transactional
+    public void handleDisconnect(SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+        Long memberId = sessionRegistry.getMemberId(sessionId);
+        sessionRegistry.remove(sessionId);
+
+        if (memberId == null) {
+            return;
+        }
+
+        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).ifPresent(participant -> {
+            Long roomId = participant.getBattleRoom().getId();
+
+            participant.abandon();
+            battleParticipantRepository.save(participant);
+
+            log.info("배틀 이탈 처리 - memberId={}, roomId={}", memberId, roomId);
+
+            messagingTemplate.convertAndSend(
+                    "/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
+        });
+    }
+}

--- a/src/main/java/com/back/global/websocket/BattleWebSocketHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleWebSocketHandler.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class BattleWebSocketHandler {
 
     private final SimpMessagingTemplate messagingTemplate;
+    private final BattleCodeStore battleCodeStore;
 
     /**
      * 참여자가 코드 변경 시 호출
@@ -38,5 +39,8 @@ public class BattleWebSocketHandler {
                         "type", "CODE_UPDATE",
                         "userId", securityUser.getId(),
                         "code", message.code()));
+
+        // 재입장 시 코드 복원을 위해 Redis에 임시 저장
+        battleCodeStore.save(roomId, securityUser.getId(), message.code());
     }
 }

--- a/src/main/java/com/back/global/websocket/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/back/global/websocket/JwtHandshakeInterceptor.java
@@ -1,0 +1,72 @@
+package com.back.global.websocket;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import com.back.global.jwt.JwtProvider;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    /**
+     * HTTP 핸드셰이크 시점에 JWT 쿠키를 읽어서 memberId를 WebSocket 세션 속성에 저장.
+     * 이후 STOMP CONNECT 시 ChannelInterceptor에서 세션 속성의 memberId를 꺼내 sessionRegistry에 등록.
+     */
+    @Override
+    public boolean beforeHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes) {
+
+        if (!(request instanceof ServletServerHttpRequest servletRequest)) {
+            return true;
+        }
+
+        Cookie[] cookies = servletRequest.getServletRequest().getCookies();
+        if (cookies == null) {
+            log.debug("WebSocket 핸드셰이크 - 쿠키 없음");
+            return true;
+        }
+
+        Arrays.stream(cookies)
+                .filter(c -> "accessToken".equals(c.getName()))
+                .findFirst()
+                .ifPresent(cookie -> {
+                    String token = cookie.getValue();
+                    log.debug(
+                            "WebSocket 핸드셰이크 - accessToken 쿠키 발견, token 앞 20자={}",
+                            token.length() > 20 ? token.substring(0, 20) : token);
+                    if (jwtProvider.validateToken(token)) {
+                        Claims claims = jwtProvider.parseToken(token);
+                        Long memberId = Long.parseLong(claims.getSubject());
+                        attributes.put("memberId", memberId);
+                        log.info("WebSocket 핸드셰이크 - memberId={} 세션 속성 저장 성공", memberId);
+                    } else {
+                        log.warn("WebSocket 핸드셰이크 - JWT 유효하지 않음 (만료 또는 secret 불일치)");
+                    }
+                });
+
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(
+            ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {}
+}

--- a/src/main/java/com/back/global/websocket/WebSocketConfig.java
+++ b/src/main/java/com/back/global/websocket/WebSocketConfig.java
@@ -1,27 +1,112 @@
 package com.back.global.websocket;
 
+import java.util.Map;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
+import com.back.global.security.SecurityUser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    // TODO: STOMP ChannelInterceptor 추가하여 CONNECT 시점에 JWT 토큰 검증 필요 (현재 인증 없이 WebSocket 연결 가능)
+    private final WebSocketSessionRegistry sessionRegistry;
+    private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+
+    /**
+     * 클라이언트가 /ws로 WebSocket 연결할 때 STOMP CONNECT 프레임이 날아오는데,
+     * 그 순간을 가로채서 "이 세션ID는 이 유저꺼다" 라고 등록해두는 것
+     * SUBSCRIBE나 SEND 같은 다른 STOMP 커맨드는 CONNECT가 아니므로 그냥 통과함
+     */
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                // 메시지가 핸들러로 가기 직전에 실행됨
+                StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    // 핸드셰이크 시점에 JwtHandshakeInterceptor가 저장한 memberId를 세션 속성에서 꺼냄
+                    Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+                    if (sessionAttributes != null) {
+                        Long memberId = (Long) sessionAttributes.get("memberId");
+                        if (memberId != null) {
+                            // sessionRegistry 등록 (이탈 감지용)
+                            sessionRegistry.register(accessor.getSessionId(), memberId);
+                            log.info("WebSocket 세션 등록 - sessionId={}, memberId={}", accessor.getSessionId(), memberId);
+
+                            // STOMP 세션 Principal 설정 → @AuthenticationPrincipal이 동작하게 함
+                            SecurityUser securityUser = new SecurityUser(memberId, null, null, "ROLE_USER");
+                            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                                    securityUser, null, securityUser.getAuthorities());
+                            StompHeaderAccessor mutableAccessor =
+                                    MessageHeaderAccessor.getMutableAccessor(message, StompHeaderAccessor.class);
+                            if (mutableAccessor != null) {
+                                mutableAccessor.setUser(auth);
+                            }
+                        } else {
+                            log.warn("WebSocket 세션 등록 실패 - 인증 정보 없음. sessionId={}", accessor.getSessionId());
+                        }
+                    }
+                }
+                return message; // 메시지를 그대로 통과시킴
+            }
+        });
+    }
+
+    /**
+     * heartbeat 설정, 정확히는 hearbeat이 아니라 서버 전송 타임아웃
+     * 30초 안에 메시지 전송이 완료 되지 않으면 연결을 끊는다.
+     */
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+        registration.setSendTimeLimit(30 * 1000);
+    }
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // 서버 → 클라이언트 구독 prefix
-        registry.enableSimpleBroker("/topic");
-        // 클라이언트 → 서버 전송 prefix
+
+        TaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        ((ThreadPoolTaskScheduler) scheduler).initialize();
+
+        // 클라이언트가 서버로부터 받기 위해 구독하는 prefix
+        registry.enableSimpleBroker("/topic")
+                .setHeartbeatValue(new long[] {10000, 10000}) // 10초마다 ping/pong
+                .setTaskScheduler(scheduler);
+        // 서버 → 클라이언트: 10초마다 ping
+        // 클라이언트 → 서버: 10초마다 pong
+        // 10초 안에 응답 없으면 → 연결 강제 종료 → SessionDisconnectEvent 발생
+
+        // 클라이언트가 서버로 메시지를 보낼 때 쓰는 prefix
         registry.setApplicationDestinationPrefixes("/app");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // WebSocket 연결 엔드포인트 (SockJS 폴백 포함)
-        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .addInterceptors(jwtHandshakeInterceptor)
+                .withSockJS();
     }
 }

--- a/src/main/java/com/back/global/websocket/WebSocketConfig.java
+++ b/src/main/java/com/back/global/websocket/WebSocketConfig.java
@@ -59,10 +59,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                             SecurityUser securityUser = new SecurityUser(memberId, null, null, "ROLE_USER");
                             UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                                     securityUser, null, securityUser.getAuthorities());
-                            StompHeaderAccessor mutableAccessor =
-                                    MessageHeaderAccessor.getMutableAccessor(message, StompHeaderAccessor.class);
-                            if (mutableAccessor != null) {
-                                mutableAccessor.setUser(auth);
+                            MessageHeaderAccessor mutableAccessor = MessageHeaderAccessor.getMutableAccessor(message);
+                            if (mutableAccessor instanceof StompHeaderAccessor stompAccessor) {
+                                stompAccessor.setUser(auth);
                             }
                         } else {
                             log.warn("WebSocket 세션 등록 실패 - 인증 정보 없음. sessionId={}", accessor.getSessionId());

--- a/src/main/java/com/back/global/websocket/WebSocketSessionRegistry.java
+++ b/src/main/java/com/back/global/websocket/WebSocketSessionRegistry.java
@@ -1,0 +1,24 @@
+package com.back.global.websocket;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebSocketSessionRegistry {
+
+    private final Map<String, Long> sessionMemberMap = new ConcurrentHashMap<>();
+
+    public void register(String sessionId, Long memberId) {
+        sessionMemberMap.put(sessionId, memberId);
+    }
+
+    public Long getMemberId(String sessionId) {
+        return sessionMemberMap.get(sessionId);
+    }
+
+    public void remove(String sessionId) {
+        sessionMemberMap.remove(sessionId);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,11 +9,16 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
 judge0:
   url: http://${JUDGE0_EC2_IP}:2358


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3>이탈 발생 시나리오</h3>
<ol>
<li>브라우저 닫기 / 네트워크 끊김 → WebSocket 세션 종료 이벤트 발생</li>
<li>명시적 나가기 → 프론트가 API 호출</li>
</ol>
<h3>현재 문제점</h3>
<p><code>BattleParticipantStatus</code>: <code>READY</code> / <code>PLAYING</code> / <code>EXIT</code></p>
<p>현재 <code>EXIT</code>는 AC(정답) 일 때만 사용됨 + 이탈 처리가 없어서</p>
<ul>
<li>이탈자가 <code>PLAYING</code> 상태로 영원히 남음</li>
<li>남은 참여자가 전부 AC여도 <code>allFinished</code> 조건 불충족 → 배틀 정산이 안 됨</li>
</ul>
<h3>해결 방향</h3>
<pre><code class="language-java">방법 A: 이탈 상태 추가

// BattleParticipantStatus에 추가
ABANDONED  // 중도 이탈
- 이탈 시 ABANDONED로 변경
- allFinished 조건에 ABANDONED도 포함

방법 B: EXIT 재사용 + 이탈 여부 필드 추가

// BattleParticipant에 필드 추가
private Boolean abandoned; // true면 이탈, false면 AC 완료

방법 C: 타이머 만료로만 처리 (최소 변경)

이탈 감지 없이 타이머 종료 시 PLAYING 상태인 참여자는 꼴찌 처리.
이미 BattleScheduler가 있어서 추가 구현 최소화 가능.
</code></pre>
<p>방법 A + WebSocket 세션 종료 이벤트 감지 조합으로 할 예정</p>
<pre><code class="language-java">// Spring이 제공하는 WebSocket 세션 종료 이벤트
@EventListener
public void handleDisconnect(SessionDisconnectEvent event) {
// 세션 주인 확인 → PLAYING 상태면 ABANDONED 처리
}
</code></pre>
<hr>
<p>어떻게 처리할지 팀 결정이 필요함</p>
<ol>
<li>이탈 시 즉시 정산 할지, 타이머까지 대기 할지 → 타이머까지 대기</li>
<li>이탈자 점수 처리 어떻게 할지 (꼴찌? 0점?)
→ 재입장 허용이므로 재입장 하지 않으면 0점, 재입장하고 다 못풀면 0점</li>
<li>이탈 후 재입장 허용할지 → 재입장 허용</li>
</ol>
<hr>
<h3>재입장</h3>
<p>현재 WebSocket은 세션 기반이라 연결이 끊기면 세션이 사라짐 (재접속하면 완전히 새 세션)
재입장이 자연스럽게 되려면 필요한 것들</p>
<ol>
<li>
<p>코드 임시 저장</p>
<p>유저가 작성 중이던 코드가 날아가면 안 되니까, 코드를 주기적으로 서버에 저장해야 함</p>
<pre><code class="language-java">유저가 코드 입력 중
    ↓ (일정 주기 또는 이탈 직전)
서버에 임시 저장 (DB or Redis)
    ↓
재접속 시 복원
</code></pre>
<p>(현재 <code>BattleWebSocketHandler</code>의 코드 업데이트가 관전자용 브로드캐스트만 하고 저장은 안 함)</p>
</li>
<li>
<p>방 상태 복원 API</p>
<p>재접속 시 현재 게임 상태를 한번에 받아야 함</p>
<pre><code class="language-java">GET /api/v1/battle/rooms/{roomId}/state

{
  &quot;timerEnd&quot;: &quot;2026-03-26T12:00:00&quot;,
  &quot;problem&quot;: { ... },
  &quot;myCode&quot;: &quot;def solution...&quot;,     ← 임시 저장된 내 코드
  &quot;participants&quot;: [ ... ]
}
</code></pre>
</li>
<li>
<p>참여자 상태 관리</p>
<p>이탈 → <code>ABANDONED</code>
재접속 → <code>ABANDONED</code> 상태 확인 후 → <code>PLAYING</code>으로 복귀 허용</p>
</li>
</ol>
<hr>
<h3>전체 흐름</h3>
<pre><code class="language-java">[정상 접속]
joinRoom → PLAYING

[이탈]
WebSocket 끊김 → SessionDisconnectEvent → ABANDONED

[재입장]
GET /rooms/{roomId}/state → 현재 상태 + 내 코드 받기
joinRoom 재호출 → ABANDONED → PLAYING 복귀
WebSocket 재연결 → 기존 topic 재구독
</code></pre>
<hr>
<p>코드 임시 저장을 DB에 할지 Redis에 할지가 핵심 결정.
(배틀 중 실시간으로 계속 저장해야 해서 Redis가 더 적합)</p>
<pre><code class="language-java">Redis 활용 설계

매칭 큐         → Redis (이미 예정)
코드 임시 저장  → Redis (추가)
저장 구조

Key:   &quot;battle:code:{roomId}:{memberId}&quot;
Value: &quot;def solution(...)...&quot;
TTL:   배틀 시간 + 여유분 (예: 40분)

배틀 끝나면 TTL로 자동 삭제되니까 별도 정리 로직도 불필요해.

구현 순서

1. 이탈 처리 (SessionDisconnectEvent → ABANDONED)
2. 코드 임시 저장 (WebSocket 코드 업데이트 시 Redis에 저장)
3. 방 상태 API (재접속 시 타이머 + 내 코드 복원)
4. 재입장 로직 (ABANDONED → PLAYING 복귀)
</code></pre>
<hr>
<h3>멘토링 후 알게된 것</h3>
<ol>
<li>
<p>이벤트리스너 방식</p>
<p>Spring WebSocket은 클라이언트 연결이 끊기면 자동으로 이벤트를 발생시킨다.</p>
<pre><code class="language-java">@EventListener
public void handleDisconnect(SessionDisconnectEvent event) {
// 브라우저 닫기, 네트워크 끊김 등 WebSocket 연결이 끊기면 Spring이 자동 호출
}
</code></pre>
<p><code>@EventListener</code>가 바로 이벤트리스너. <strong>WebSocket 연결 끊김</strong>이라는 이벤트가 발생하면 이 메서드를 실행해줘 라고 등록해두는 것</p>
</li>
<li>
<p>헬스체크 방식</p>
<p>이벤트리스너만으로는 놓치는 케이스가 있다.
(네트워크가 완전히 끊기지 않고 응답만 안 하는 좀비 연결 상태) 이 케이스를 잡기 위해 헬스체크 사용</p>
<pre><code class="language-java">서버가 주기적으로 클라이언트에게 ping 전송
    ↓
클라이언트가 pong으로 응답
    ↓
일정 시간 내 pong 없으면 → 이탈 처리
</code></pre>
<p>STOMP 자체에 heartbeat 기능이 내장되어 있어서, 설정만 추가하면 됨</p>
<pre><code class="language-java">// WebSocketConfig에 추가
@Override
public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
    registration.setMessageSizeLimit(64 * 1024);
}

// Client 설정에서 heartbeat 지정
new Client({
    heartbeatIncoming: 4000,  // 서버→클라이언트 4초마다
    heartbeatOutgoing: 4000,  // 클라이언트→서버 4초마다
})
</code></pre>
</li>
</ol>
<hr>
<h3>구현</h3>
<ol>
<li>
<p><code>ABANDONED</code> 상태 추가
<code>BattleParticipantStatus</code> - <code>ABANDONED</code> 추가
<code>BattleParticipant</code>  - <code>abandon()</code> 메서드 추가</p>
</li>
<li>
<p>WebSocket 세션ID → memberId 매핑 저장소 구현 (<code>WebSocketSessionRegistry</code>)
SessionDisconnectEvent에서 이탈한 유저가 누군지 알기 위해 연결 시점에 세션ID → memberId를 저장해두는 컴포넌트</p>
<pre><code class="language-java">클라이언트 연결 시 (CONNECT)
  → 세션ID &quot;abc-123&quot; + memberId 42 → 저장

클라이언트 연결 끊김 (SessionDisconnectEvent)
  → 세션ID &quot;abc-123&quot; 로 memberId 42 조회
  → memberId 42번 유저가 이탈했구나
</code></pre>
<p>인메모리로 구현했다. 이유는 다음과 같다.</p>
<ul>
<li>세션ID는 서버가 WebSocket 연결마다 부여하는 임시 값이다. 서버 재시작하면 모든 연결이 끊기고 세션ID도 사라지므로 Redis에 영속할 필요가 없다.</li>
<li>연결 중인 동안만 필요하고, 끊기면 바로 삭제하는 단순한 구조라 인메모리로 충분하다.</li>
</ul>
</li>
<li>
<p><code>WebSocketConfig</code> 에 CONNECT 시 세션ID + memberId 등록하는 인터셉터 추가</p>
<pre><code class="language-java">HTTP:
클라이언트 요청 → [필터/인터셉터] → @Controller                                                                                               
                                                            
STOMP:
클라이언트 메시지 → [ChannelInterceptor] → @MessageMapping

이 코드에서 하는 일:

registration.interceptors(new ChannelInterceptor() {
    @Override
    public Message&lt;?&gt; preSend(Message&lt;?&gt; message, MessageChannel channel) {
        // 메시지가 핸들러로 가기 직전에 실행됨

        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
            // CONNECT 메시지일 때만 (구독/전송 메시지는 무시)
            sessionRegistry.register(세션ID, memberId);
        }

        return message; // 메시지를 그대로 통과시킴
    }
});
</code></pre>
<p>클라이언트가 /ws로 WebSocket 연결할 때 STOMP CONNECT 프레임이 날아오는데, 그 순간을 가로채서 <strong>이 세션ID는 이 유저꺼다</strong> 라고 등록해두는 것</p>
<p><strong>heartbeat</strong></p>
<p><code>configureWebSocketTransport</code></p>
<pre><code class="language-java">@Override
public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
    registration.setSendTimeLimit(30 * 1000); // 30초
}
</code></pre>
<p>정확히는 heartbeat가 아니라 서버 전송 타임아웃이다.
(30초 안에 메시지 전송이 완료 안 되면 연결을 끊는 설정)</p>
<p>실제 heartbeat (ping/pong) 설정은 <code>configureMessageBroker</code>에서 한다.</p>
<pre><code class="language-java">@Override
  public void configureMessageBroker(MessageBrokerRegistry registry) {
      registry.enableSimpleBroker(&quot;/topic&quot;)
              .setHeartbeatValue(new long[]{10000, 10000}); // 서버↔클라이언트 10초마다 ping
      registry.setApplicationDestinationPrefixes(&quot;/app&quot;);
  }
</code></pre>
<p>setHeartbeatValue(new long[]{서버→클라이언트, 클라이언트→서버}) 형태
(프론트의 reconnectDelay: 3000이 있긴함)</p>
<p>10초로 한 이유</p>
<p>배틀 게임 특성상 고려할 점</p>
<ul>
<li>너무 짧으면 → 네트워크 트래픽 증가, 서버 부하</li>
<li>너무 길면 → 이탈 감지가 늦어짐</li>
</ul>
<p>배틀 게임에서 이탈 감지가 늦어지면 다른 참여자들이 오래 기다리게 되니까 10초 정도가 적절하다.</p>
<ul>
<li>10초마다 ping → 최대 10초 안에 이탈 감지</li>
<li>게임 중 트래픽 부하도 크지 않음</li>
</ul>
</li>
<li>
<p>이탈 감지 핸들러</p>
<p>WebSocket 연결이 끊겼을 때 앞에서 저장해둔 세션ID ↔ memberId 매핑을 꺼내서 실제로 이탈 처리하는 로직</p>
<pre><code class="language-java">WebSocket 끊김
  → Spring이 SessionDisconnectEvent 발생
  → BattleDisconnectHandler.handleDisconnect(event) 실행
  → sessionRegistry에서 세션ID로 memberId 조회
  → 해당 유저가 PLAYING 상태면 ABANDONED로 변경
  → /topic/room/{roomId} 로 PARTICIPANT_LEFT 브로드캐스트
</code></pre>
<p><code>handleDisconnect</code> 에서 event는 Spring이 자동으로 생성해서 넘겨준다.</p>
<pre><code class="language-java">1. 클라이언트 WebSocket 연결 끊김
        ↓
2. Spring WebSocket 내부에서 자동으로
   SessionDisconnectEvent 객체 생성
   (sessionId, closeStatus 등 담아서)
        ↓
3. Spring ApplicationEventPublisher가 이벤트 발행
        ↓
4. @EventListener가 붙은 handleDisconnect() 자동 호출
   event 파라미터로 자동 주입
</code></pre>
<p><code>@EventListener</code>가 <code>SessionDisconnectEvent</code> 타입의 이벤트가 발행되면 내가 받을게 라고 등록해두는 것이고, Spring이 이벤트를 발행할 때 파라미터 타입을 보고 맞는 핸들러를 찾아서 자동으로 호출해준다.</p>
<p>개발자가 직접 <code>new SessionDisconnectEvent(...)</code>를 만들 필요 없이, Spring WebSocket 인프라가 연결 끊김을 감지하는 순간 알아서 처리한다.</p>
</li>
<li>
<p><strong>Redis 설정 + 코드 임시 저장</strong></p>
<p>redis 연결 설정 추가</p>
<pre><code class="language-java">spring:
    data:
      redis:
        host: ${REDIS_HOST:localhost}
        port: ${REDIS_PORT:6379}
</code></pre>
<hr>
<p><code>BattleCodeStore</code>  - redis에 코드를 저장/조회/삭제하는 컴포넌트</p>
<pre><code class="language-java">Key:   &quot;battle:code:{roomId}:{memberId}&quot;   예) &quot;battle:code:1:42&quot;
Value: 유저가 작성 중인 코드 문자열
TTL:   40분 (배틀 시간 30분 + 여유분)
</code></pre>
<p>TTL을 설정해두면 배틀이 끝난 후 별도로 삭제 안 해도 Redis에서 자동으로 삭제됨</p>
<hr>
<p><code>BattleWebSocketHandler</code> 수정</p>
<pre><code class="language-java">유저가 코드 수정
  → STOMP /app/room/{roomId}/code 로 전송
  → 관전자에게 브로드캐스트 (기존)
  → Redis에 battle:code:{roomId}:{memberId} 저장 (추가)
</code></pre>
<p>코드 업데이트가 발생할 때마다 Redis에 덮어씀.
(재입장 시 마지막으로 저장된 코드를 복원하는 데 사용)</p>
<hr>
<p><strong>Redis를 사용한 이유</strong></p>
<p>redis란</p>
<p>Redis는 인메모리 데이터 저장소로 데이터를 메모리에 저장해서 DB보다 훨씬 빠르고, Key-Value 구조로 단순하게 데이터를 저장/조회할 수있다.</p>
<p>코드 임시 저장의 특성</p>
<ul>
<li>배틀 중 코드 입력할 때마다 저장 → 빈번한 write</li>
<li>재입장 시 딱 한 번 조회</li>
<li>배틀 끝나면 필요 없음 → TTL로 자동 삭제</li>
</ul>
<p>DB(PostgreSQL)에 저장할 경우</p>
<ul>
<li>유저가 타이핑할 때마다 UPDATE 쿼리 → DB 부하 증가</li>
<li>배틀 4명이 동시에 타이핑하면 초당 수십 번 write</li>
<li>Redis는 메모리 기반이라 이런 빈번한 write에 적합하고, TTL 기능으로 자동 만료도 가능</li>
</ul>
<p>Redis 말고 다른 방법도 가능한가</p>

방법 | 장점 | 단점
-- | -- | --
Redis | 빠름, TTL 자동 만료 | 별도 인프라 필요
DB (PostgreSQL) | 이미 있음, 별도 인프라 불필요 | 빈번한 write에 부하
서버 인메모리 (ConcurrentHashMap) | 가장 단순 | 서버 재시작 시 데이터 소실
Memcached | Redis와 유사하게 빠름 | TTL 외 기능 빈약, Spring 지원 약함


</li>
<li>
<p><code>joinRoom</code> 재입장 분기 추가</p>
<p>현재 <code>joinRoom()</code>은 <code>READY</code> 상태인 참여자만 입장 허용</p>
<pre><code class="language-java">// 현재
if (room.getStatus() != BattleRoomStatus.WAITING) {
    throw new IllegalStateException(&quot;입장할 수 없는 상태...&quot;);
}
</code></pre>
<ol>
<li>방 상태 검증 수정
<ul>
<li>현재: <code>WAITING</code>인 방만 허용</li>
<li>변경: <code>WAITING</code> 또는 <code>PLAYING</code>인 방도 허용 (재입장은 배틀 진행 중에 들어오니까)</li>
</ul>
</li>
<li>참여자 상태 분기 추가
<ul>
<li><code>READY</code> → <code>PLAYING</code> (기존 최초 입장)</li>
<li><code>ABANDONED</code> → <code>PLAYING</code> (재입장)</li>
<li><code>PLAYING</code>, <code>EXIT</code> 등 → 예외</li>
</ul>
</li>
<li><code>allPlaying</code> 체크 수정
<ul>
<li>재입장 시에는 <code>BATTLE_STARTED</code>를 다시 보내면 안 됨</li>
<li>WAITING 상태일 때만 <code>allPlaying</code> 체크해서 배틀 시작 처리</li>
</ul>
</li>
</ol>
</li>
</ol>
<!-- notionvc: 8f8cd567-139f-4296-be58-027bfaa60166 --><!--EndFragment-->
</body>
</html>