### PR TITLE
feat: 태그 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/back/domain/tag/tag/controller/TagController.java
+++ b/src/main/java/com/back/domain/tag/tag/controller/TagController.java
@@ -1,0 +1,25 @@
+package com.back.domain.tag.tag.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.tag.tag.dto.TagResponse;
+import com.back.domain.tag.tag.service.TagService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/tags")
+@RequiredArgsConstructor
+public class TagController {
+
+    private final TagService tagService;
+
+    @GetMapping
+    public List<TagResponse> getTags() {
+        return tagService.getTags();
+    }
+}

--- a/src/main/java/com/back/domain/tag/tag/dto/TagResponse.java
+++ b/src/main/java/com/back/domain/tag/tag/dto/TagResponse.java
@@ -1,0 +1,3 @@
+package com.back.domain.tag.tag.dto;
+
+public record TagResponse(String code, String label) {}

--- a/src/main/java/com/back/domain/tag/tag/repository/TagRepository.java
+++ b/src/main/java/com/back/domain/tag/tag/repository/TagRepository.java
@@ -1,0 +1,11 @@
+package com.back.domain.tag.tag.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.tag.tag.entity.Tag;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    List<Tag> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/back/domain/tag/tag/service/TagService.java
+++ b/src/main/java/com/back/domain/tag/tag/service/TagService.java
@@ -1,0 +1,28 @@
+package com.back.domain.tag.tag.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.tag.tag.dto.TagResponse;
+import com.back.domain.tag.tag.repository.TagRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public List<TagResponse> getTags() {
+        return tagRepository.findAllByOrderByNameAsc().stream()
+                .map(tag -> tag.getName() == null ? null : tag.getName().trim())
+                .filter(name -> name != null && !name.isBlank())
+                .distinct()
+                .map(name -> new TagResponse(name, name))
+                .toList();
+    }
+}

--- a/src/test/java/com/back/domain/tag/tag/controller/TagControllerTest.java
+++ b/src/test/java/com/back/domain/tag/tag/controller/TagControllerTest.java
@@ -1,0 +1,33 @@
+package com.back.domain.tag.tag.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.tag.tag.dto.TagResponse;
+import com.back.domain.tag.tag.service.TagService;
+
+class TagControllerTest {
+
+    private final TagService tagService = mock(TagService.class);
+    private final TagController tagController = new TagController(tagService);
+
+    @Test
+    @DisplayName("태그 컨트롤러는 서비스 결과를 그대로 반환한다")
+    void getTags_returnsServiceResult() {
+        List<TagResponse> response = List.of(new TagResponse("array", "array"), new TagResponse("graph", "graph"));
+
+        when(tagService.getTags()).thenReturn(response);
+
+        List<TagResponse> actual = tagController.getTags();
+
+        assertThat(actual).isEqualTo(response);
+        verify(tagService).getTags();
+    }
+}

--- a/src/test/java/com/back/domain/tag/tag/service/TagServiceTest.java
+++ b/src/test/java/com/back/domain/tag/tag/service/TagServiceTest.java
@@ -1,0 +1,38 @@
+package com.back.domain.tag.tag.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.tag.tag.dto.TagResponse;
+import com.back.domain.tag.tag.entity.Tag;
+import com.back.domain.tag.tag.repository.TagRepository;
+
+class TagServiceTest {
+
+    private final TagRepository tagRepository = mock(TagRepository.class);
+    private final TagService tagService = new TagService(tagRepository);
+
+    @Test
+    @DisplayName("태그 목록 조회 시 code/label을 태그 이름으로 반환한다")
+    void getTags_returnsTagList() {
+        Tag arrayTag = mock(Tag.class);
+        Tag graphTag = mock(Tag.class);
+        Tag blankTag = mock(Tag.class);
+
+        when(arrayTag.getName()).thenReturn("array");
+        when(graphTag.getName()).thenReturn("graph");
+        when(blankTag.getName()).thenReturn("  ");
+
+        when(tagRepository.findAllByOrderByNameAsc()).thenReturn(List.of(arrayTag, graphTag, blankTag));
+
+        List<TagResponse> response = tagService.getTags();
+
+        assertThat(response).containsExactly(new TagResponse("array", "array"), new TagResponse("graph", "graph"));
+    }
+}


### PR DESCRIPTION
## 변경 배경
프론트에서 하드코딩된 큐 카테고리 대신 DB 기반 태그 목록을 동적으로 조회할 수 있도록 API를 추가했습니다.

## 주요 변경
1. `GET /api/v1/tags` 엔드포인트 추가
2. `TagService`에서 `tags` 테이블을 이름 오름차순으로 조회
3. 공백/빈 태그명 제거 후 `code/label` 형태로 반환
4. 컨트롤러/서비스 단위 테스트 추가

## 응답 예시
```json
[
  { "code": "array", "label": "array" },
  { "code": "graph", "label": "graph" }
]
```

## 변경 파일
- `src/main/java/com/back/domain/tag/tag/controller/TagController.java`
- `src/main/java/com/back/domain/tag/tag/service/TagService.java`
- `src/main/java/com/back/domain/tag/tag/repository/TagRepository.java`
- `src/main/java/com/back/domain/tag/tag/dto/TagResponse.java`
- `src/test/java/com/back/domain/tag/tag/controller/TagControllerTest.java`
- `src/test/java/com/back/domain/tag/tag/service/TagServiceTest.java`

## 영향 범위
- 프론트/BFF는 `/api/v1/tags`를 호출해 태그 목록을 동적으로 렌더링 가능
- 기존 큐 로직에는 영향 없음(조회 API만 추가)

## 테스트
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew spotlessApply`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test --tests "com.back.domain.tag.tag.service.TagServiceTest" --tests "com.back.domain.tag.tag.controller.TagControllerTest"`
