### PR TITLE
fix: WebSocket STOMP 인증 및 연결 안정성 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.batch:spring-batch-test")
     testImplementation("org.springframework.security:spring-security-test")
+    implementation("org.springframework.security:spring-security-messaging")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Auth

--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -67,5 +67,5 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
                       and p.status = com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.PLAYING
                       and r.status = com.back.domain.battle.battleroom.entity.BattleRoomStatus.PLAYING
                     """)
-    Optional<BattleParticipant> findPlayingParticipantByMemberId(@Param("memberId") Long memberId);
+    List<BattleParticipant> findPlayingParticipantByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -39,16 +39,18 @@ public class BattleDisconnectHandler {
             return;
         }
 
-        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).stream().findFirst().ifPresent(participant -> {
-            Long roomId = participant.getBattleRoom().getId();
+        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).stream()
+                .findFirst()
+                .ifPresent(participant -> {
+                    Long roomId = participant.getBattleRoom().getId();
 
-            participant.abandon();
-            battleParticipantRepository.save(participant);
+                    participant.abandon();
+                    battleParticipantRepository.save(participant);
 
-            log.info("배틀 이탈 처리 - memberId={}, roomId={}", memberId, roomId);
+                    log.info("배틀 이탈 처리 - memberId={}, roomId={}", memberId, roomId);
 
-            messagingTemplate.convertAndSend(
-                    "/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
-        });
+                    messagingTemplate.convertAndSend(
+                            "/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
+                });
     }
 }

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -39,7 +39,7 @@ public class BattleDisconnectHandler {
             return;
         }
 
-        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).ifPresent(participant -> {
+        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).stream().findFirst().ifPresent(participant -> {
             Long roomId = participant.getBattleRoom().getId();
 
             participant.abandon();

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -39,9 +39,7 @@ public class BattleDisconnectHandler {
             return;
         }
 
-        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).stream()
-                .findFirst()
-                .ifPresent(participant -> {
+        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).stream().findFirst().ifPresent(participant -> {
                     Long roomId = participant.getBattleRoom().getId();
 
                     participant.abandon();

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -39,7 +39,9 @@ public class BattleDisconnectHandler {
             return;
         }
 
-        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).stream().findFirst().ifPresent(participant -> {
+        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).stream()
+                .findFirst()
+                .ifPresent(participant -> {
                     Long roomId = participant.getBattleRoom().getId();
 
                     participant.abandon();

--- a/src/main/java/com/back/global/websocket/WebSocketSecurityConfig.java
+++ b/src/main/java/com/back/global/websocket/WebSocketSecurityConfig.java
@@ -1,0 +1,18 @@
+package com.back.global.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
+
+@Configuration
+public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBrokerConfigurer {
+
+    /**
+     * spring-security-messaging이 클래스패스에 있으면 WebSocket CSRF가 자동으로 활성화됨.
+     * REST API에서 HTTP CSRF는 이미 비활성화되어 있으므로, WebSocket도 동일하게 처리.
+     * true를 반환하면 SockJS/STOMP 연결 시 CSRF 토큰 없이도 접속 가능.
+     */
+    @Override
+    protected boolean sameOriginDisabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/back/global/websocket/WebSocketSecurityConfig.java
+++ b/src/main/java/com/back/global/websocket/WebSocketSecurityConfig.java
@@ -7,12 +7,20 @@ import org.springframework.security.config.annotation.web.socket.AbstractSecurit
 public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBrokerConfigurer {
 
     /**
-     * spring-security-messaging이 클래스패스에 있으면 WebSocket CSRF가 자동으로 활성화됨.
-     * REST API에서 HTTP CSRF는 이미 비활성화되어 있으므로, WebSocket도 동일하게 처리.
-     * true를 반환하면 SockJS/STOMP 연결 시 CSRF 토큰 없이도 접속 가능.
+     * spring-security-messaging이 클래스패스에 있으면 WebSocket CSRF(동일 출처 검사)가 자동으로 활성화됨.
+     * 현재는 SockJS/STOMP 연결을 허용하기 위해 CSRF 검사를 비활성화한 상태.
+     *
+     * [보안 주의]
+     * 현재 WebSocket 인증이 쿠키(accessToken) 기반이므로, sameOriginDisabled() = true는
+     * 악의적인 사이트가 사용자 쿠키를 이용해 cross-origin WebSocket 연결을 시도할 수 있는 위험이 있음.
+     *
+     * TODO: 쿠키 기반 인증을 STOMP CONNECT 헤더(Authorization: Bearer {token}) 방식으로 전환하여
+     *       CSRF 위험을 근본적으로 제거하고, sameOriginDisabled()를 false로 되돌릴 것.
+     *       - 프론트: Client({ connectHeaders: { Authorization: `Bearer ${token}` } })
+     *       - 백엔드: JwtHandshakeInterceptor에서 쿠키 대신 헤더에서 JWT 파싱
      */
     @Override
     protected boolean sameOriginDisabled() {
-        return true;
+        return true; // TODO: 헤더 기반 JWT 인증 전환 후 false로 변경
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #99 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #99 

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
관전기능에서 방 참여자의 코드 정보가 정상 전송되지 않는 문제 수정

- spring-security-messaging 추가에 따른 WebSocket CSRF 비활성화 (CloseStatus 1002 해결)                                            
- findPlayingParticipantByMemberId 반환 타입을 List로 변경해 중복 결과 예외 해결  

---

## ✅ 주요 변경 사항
  - BattleParticipantRepository - 반환 타입 Optional → List                                                                          
  - BattleDisconnectHandler - stream().findFirst() 패턴으로 변경                                                                     
  - WebSocketSecurityConfig 신규 추가 - WebSocket CSRF 비활성화

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->


---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
