### PR TITLE
[fix] active match session 재참가 차단 및 terminal session 재join cleanup

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
@@ -17,6 +17,7 @@ import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.ReadyDecision;
 import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.global.exception.ServiceException;
 
 /**
  * 현재 MVP용 인메모리 매칭 상태 저장소
@@ -118,8 +119,13 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      */
     @Override
     public int enqueue(Long userId, QueueKey queueKey) {
+        // join 시에는 queue 중복 여부만 볼 게 아니라, 기존 match session 연결도 먼저 확인해야 한다.
+        // active session이면 재join을 막고, terminal/stale session이면 현재 사용자 링크만 정리한 뒤 진행한다.
+        // TODO : 근데 이걸 join 쪽에서 들고 있는게 맞는건지에 대한 의문
+        ensureJoinEligibility(userId);
+
         if (userQueueMap.putIfAbsent(userId, queueKey) != null) {
-            throw new IllegalStateException("이미 매칭 대기열에 참가 중인 사용자입니다.");
+            throw new ServiceException("409-1", "이미 매칭 대기열에 참가 중인 사용자입니다.");
         }
 
         Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
@@ -569,6 +575,38 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         return matchSession;
     }
 
+    /**
+     * queue 재진입 전 현재 사용자의 기존 match session 연결을 먼저 확인한다.
+     *
+     * active session은 보호해야 하므로 재join을 차단하고,
+     * terminal/stale session만 현재 사용자 기준으로 정리한 뒤 새 queue 참가를 허용한다.
+     */
+    private void ensureJoinEligibility(Long userId) {
+        Long matchId = userMatchMap.get(userId);
+
+        if (matchId == null) {
+            return;
+        }
+
+        MatchSession matchSession = matchSessionMap.get(matchId);
+
+        if (matchSession == null) {
+            // userMatchMap에는 연결이 남아 있지만 세션 본문이 이미 없는 경우다.
+            // 이건 "종료 상태를 보여줄 세션"조차 없어진 stale link라서 현재 사용자 연결만 바로 정리한다.
+            cleanupStaleUserMatch(userId, matchId);
+            return;
+        }
+
+        switch (matchSession.status()) {
+            case ACCEPT_PENDING, ROOM_READY -> throw new ServiceException("409-1", "이미 진행 중인 매칭이 있습니다.");
+            case CANCELLED, EXPIRED, CLOSED -> {
+                // terminal session은 본문이 아직 남아 있으므로 다른 참가자는 계속 matches/me로 종료 상태를 볼 수 있다.
+                // 따라서 세션 전체를 지우지 않고, 다시 join을 누른 현재 사용자 링크만 정리한 뒤 재참가를 허용한다.
+                cleanupTerminalUserMatch(userId, matchId);
+            }
+        }
+    }
+
     private void cleanupEmptyQueue(QueueKey queueKey) {
         Deque<WaitingUser> queue = waitingQueues.get(queueKey);
 
@@ -590,6 +628,19 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      */
     private void cleanupStaleUserMatch(Long userId, Long matchId) {
         // 본문이 사라진 matchId를 계속 들고 있으면 이후 조회가 꼬이므로 즉시 정리한다.
+        // 여기서는 이미 세션 본문이 없기 때문에 "누구에게 종료 상태를 보여줄지"를 고려할 필요가 없다.
+        userMatchMap.remove(userId, matchId);
+        removeMatchSessionIfUnreferenced(matchId);
+    }
+
+    /**
+     * terminal session은 matches/me에서 계속 보여줘야 하므로 세션 전체를 즉시 지우지 않는다.
+     * 다시 join을 시도한 현재 사용자만 기존 match 연결에서 분리하고,
+     * 마지막 참조자까지 빠졌을 때만 세션 본문이 제거되게 한다.
+     */
+    private void cleanupTerminalUserMatch(Long userId, Long matchId) {
+        // terminal session은 본문이 살아 있으므로 종료 모달 용도로 아직 의미가 있다.
+        // 그래서 join을 다시 누른 현재 사용자만 old match에서 분리하고, 다른 참가자 링크는 그대로 둔다.
         userMatchMap.remove(userId, matchId);
         removeMatchSessionIfUnreferenced(matchId);
     }
@@ -603,6 +654,10 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      * 이후 Redis 단계에서는 더 적합한 카운트/집합 구조로 바꿀 수 있다.
      */
     private void removeMatchSessionIfUnreferenced(Long matchId) {
+        // matchmap 에
+        // 1 -> 10
+        // 2 -> 10
+        // 가르키고 있으면 삭제하지말아라
         if (!userMatchMap.containsValue(matchId)) {
             // 더 이상 이 matchId를 참조하는 사용자가 없을 때만 세션 본문을 제거한다.
             matchSessionMap.remove(matchId);

--- a/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
@@ -1,6 +1,7 @@
 package com.back.domain.matching.queue.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -8,8 +9,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +34,7 @@ import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
 import com.back.domain.matching.queue.store.MatchStateStore;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
+import com.back.global.exception.ServiceException;
 
 class ReadyCheckServiceTest {
 
@@ -69,6 +73,18 @@ class ReadyCheckServiceTest {
     }
 
     @Test
+    @DisplayName("SEARCHING 중 같은 사용자가 다시 join하면 409 conflict를 반환한다")
+    void joinQueueV2_throwsConflict_whenUserAlreadySearching() {
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+
+        assertThatThrownBy(() -> readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY)))
+                .isInstanceOfSatisfying(ServiceException.class, ex -> {
+                    assertThat(ex.getResultCode()).isEqualTo("409-1");
+                    assertThat(ex.getMsg()).isEqualTo("이미 매칭 대기열에 참가 중인 사용자입니다.");
+                });
+    }
+
+    @Test
     @DisplayName("4명이 모이면 v2 matches/me는 ACCEPT_PENDING을 반환한다")
     void getMyMatchStateV2_returnsAcceptPending_whenFourthUserJoins() {
         readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
@@ -87,6 +103,21 @@ class ReadyCheckServiceTest {
         assertThat(response.readyCheck().requiredCount()).isEqualTo(4);
         assertThat(response.readyCheck().acceptedByMe()).isFalse();
         assertThat(response.readyCheck().participants()).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("ACCEPT_PENDING 상태 사용자가 다시 join하면 409 conflict를 반환한다")
+    void joinQueueV2_throwsConflict_whenUserAlreadyInAcceptPending() {
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        assertThatThrownBy(() -> readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY)))
+                .isInstanceOfSatisfying(ServiceException.class, ex -> {
+                    assertThat(ex.getResultCode()).isEqualTo("409-1");
+                    assertThat(ex.getMsg()).isEqualTo("이미 진행 중인 매칭이 있습니다.");
+                });
     }
 
     @Test
@@ -115,6 +146,31 @@ class ReadyCheckServiceTest {
     }
 
     @Test
+    @DisplayName("ROOM_READY 상태 사용자가 다시 join하면 409 conflict를 반환한다")
+    void joinQueueV2_throwsConflict_whenUserAlreadyInRoomReady() {
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        readyCheckService.acceptMatch(1L, matchId);
+        readyCheckService.acceptMatch(2L, matchId);
+        readyCheckService.acceptMatch(3L, matchId);
+        readyCheckService.acceptMatch(4L, matchId);
+
+        assertThatThrownBy(() -> readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY)))
+                .isInstanceOfSatisfying(ServiceException.class, ex -> {
+                    assertThat(ex.getResultCode()).isEqualTo("409-1");
+                    assertThat(ex.getMsg()).isEqualTo("이미 진행 중인 매칭이 있습니다.");
+                });
+    }
+
+    @Test
     @DisplayName("한 명이라도 거절하면 세션 전체가 CANCELLED로 종료된다")
     void declineMatch_returnsCancelled() {
         readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
@@ -136,7 +192,28 @@ class ReadyCheckServiceTest {
     }
 
     @Test
-    @DisplayName("deadline이 지난 ready-check 세션은 EXPIRED로 조회된다")
+    @DisplayName("CANCELLED 상태에서 한 사용자만 다시 join하면 그 사용자만 새 queue에 들어가고 나머지는 terminal 상태를 유지한다")
+    void joinQueueV2_allowsRejoinForOnlyCurrentUser_whenSessionCancelled() {
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+        readyCheckService.declineMatch(2L, matchId);
+
+        QueueStatusResponse rejoinResponse = readyCheckService.joinQueueV2(1L, createRequest("Graph", Difficulty.EASY));
+
+        assertThat(rejoinResponse.getWaitingCount()).isEqualTo(1);
+        assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isTrue();
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        assertThat(readyCheckService.getMyMatchStateV2(2L).status()).isEqualTo(MatchStatus.CANCELLED);
+        assertThat(readyCheckService.getMyMatchStateV2(3L).status()).isEqualTo(MatchStatus.CANCELLED);
+        assertThat(readyCheckService.getMyMatchStateV2(4L).status()).isEqualTo(MatchStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("deadline이 지나면 ready-check 세션은 EXPIRED로 조회된다")
     void getMyMatchStateV2_returnsExpired_whenDeadlinePassed() {
         QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
         List<WaitingUser> users = List.of(
@@ -154,7 +231,31 @@ class ReadyCheckServiceTest {
     }
 
     @Test
-    @DisplayName("방 생성이 실패하면 CANCELLED 상태와 실패 메시지를 반환한다")
+    @DisplayName("EXPIRED 상태에서도 현재 사용자만 cleanup 후 다시 join할 수 있다")
+    void joinQueueV2_allowsRejoinForOnlyCurrentUser_whenSessionExpired() {
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+        List<WaitingUser> users = List.of(
+                new WaitingUser(1L, queueKey),
+                new WaitingUser(2L, queueKey),
+                new WaitingUser(3L, queueKey),
+                new WaitingUser(4L, queueKey));
+
+        matchStateStore.markAcceptPending(queueKey, users, LocalDateTime.now().minusSeconds(1));
+
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.EXPIRED);
+
+        QueueStatusResponse rejoinResponse = readyCheckService.joinQueueV2(1L, createRequest("Graph", Difficulty.EASY));
+
+        assertThat(rejoinResponse.getWaitingCount()).isEqualTo(1);
+        assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isTrue();
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        assertThat(readyCheckService.getMyMatchStateV2(2L).status()).isEqualTo(MatchStatus.EXPIRED);
+        assertThat(readyCheckService.getMyMatchStateV2(3L).status()).isEqualTo(MatchStatus.EXPIRED);
+        assertThat(readyCheckService.getMyMatchStateV2(4L).status()).isEqualTo(MatchStatus.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("방 생성에 실패하면 CANCELLED 상태와 실패 메시지를 반환한다")
     void acceptMatch_returnsCancelled_whenCreateRoomFails() {
         when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
                 .thenThrow(new RuntimeException("room create failed"));
@@ -201,7 +302,58 @@ class ReadyCheckServiceTest {
         assertThat(readyCheckService.getMyMatchStateV2(4L).status()).isEqualTo(MatchStatus.ROOM_READY);
     }
 
+    @Test
+    @DisplayName("stale session은 재join 시 cleanup 후 정상 참가된다")
+    void joinQueueV2_cleansUpStaleSession_whenOnlyUserMatchLinkRemains() throws Exception {
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+        matchSessionMap().remove(matchId);
+
+        QueueStatusResponse response = readyCheckService.joinQueueV2(1L, createRequest("Graph", Difficulty.EASY));
+
+        assertThat(response.getWaitingCount()).isEqualTo(1);
+        assertThat(userMatchMap().containsKey(1L)).isFalse();
+        assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isTrue();
+    }
+
+    @Test
+    @DisplayName("terminal session의 마지막 참조자까지 재join하면 세션 본문이 제거된다")
+    void joinQueueV2_removesTerminalSession_whenLastReferenceIsCleaned() throws Exception {
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+        readyCheckService.declineMatch(2L, matchId);
+
+        readyCheckService.joinQueueV2(1L, createRequest("Graph", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("DP", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Greedy", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Tree", Difficulty.EASY));
+
+        assertThat(matchSessionMap().containsKey(matchId)).isFalse();
+    }
+
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {
         return new QueueJoinRequest(category, difficulty);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<Long, Long> userMatchMap() throws Exception {
+        Field field = InMemoryMatchStateStore.class.getDeclaredField("userMatchMap");
+        field.setAccessible(true);
+        return (Map<Long, Long>) field.get(matchStateStore);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<Long, ?> matchSessionMap() throws Exception {
+        Field field = InMemoryMatchStateStore.class.getDeclaredField("matchSessionMap");
+        field.setAccessible(true);
+        return (Map<Long, ?>) field.get(matchStateStore);
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #98 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #98 

---
<html>
<body>
<h1>[fix] active match session 재참가 차단 및 terminal session 정리</h1>

<h3>개요</h3>
<p>이번 PR은 v2 ready-check 매칭 흐름에서 <strong>이미 진행 중인 매칭 세션에 연결된 사용자가 다시 queue에 참가할 수 있던 문제</strong>를 막고, <strong>이미 종료된 match session은 현재 사용자 기준으로만 정리한 뒤 재참가를 허용</strong>하도록 보완한 작업입니다.</p>
<p>기존에는 queue 재진입 시 <code>userQueueMap</code>만 검사했기 때문에, 사용자가 이미 <code>ACCEPT_PENDING</code> 또는 <code>ROOM_READY</code> 상태의 match session에 연결돼 있어도 다시 <code>join</code>을 시도할 수 있었습니다. 반대로 <code>CANCELLED</code>, <code>EXPIRED</code>, <code>CLOSED</code> 같은 종료 세션은 재참가를 막아야 할 active session은 아니지만, 이전 연결이 남아 있어서 새 queue 참가 전에 정리 로직이 필요했습니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) queue 재진입 전 active match session 여부를 먼저 검사하도록 변경</h3>
<p><code>InMemoryMatchStateStore.enqueue()</code> 진입 시 가장 먼저 <code>ensureJoinEligibility(userId)</code>를 호출하도록 변경했습니다.</p>

<pre><code class="language-java">@Override
public int enqueue(Long userId, QueueKey queueKey) {
    ensureJoinEligibility(userId);

    if (userQueueMap.putIfAbsent(userId, queueKey) != null) {
        throw new ServiceException("409-1", "이미 매칭 대기열에 참가 중인 사용자입니다.");
    }

    ...
}
</code></pre>

<p>즉, 이제 join 가능 여부는 단순히 <code>현재 queue에 들어 있는가</code>만 보는 것이 아니라, <strong>기존 match session 연결까지 포함해서</strong> 판단합니다.</p>

<h3>2) active session은 재join을 차단하도록 보완</h3>
<p><code>ensureJoinEligibility()</code>에서는 현재 사용자의 <code>userMatchMap</code> 연결을 먼저 조회한 뒤, 연결된 세션이 살아 있고 상태가 active면 바로 재참가를 막습니다.</p>

<pre><code class="language-java">switch (matchSession.status()) {
    case ACCEPT_PENDING, ROOM_READY ->
            throw new ServiceException("409-1", "이미 진행 중인 매칭이 있습니다.");
    case CANCELLED, EXPIRED, CLOSED -> {
        cleanupTerminalUserMatch(userId, matchId);
    }
}
</code></pre>

<p>즉, 아래 상태에서는 다시 queue에 참가할 수 없습니다.</p>
<ul>
<li><code>ACCEPT_PENDING</code> : 이미 ready-check 수락 대기 중</li>
<li><code>ROOM_READY</code> : 이미 방이 준비된 상태</li>
</ul>

<p>이 변경으로 <strong>수락 대기 중인 사용자</strong>나 <strong>이미 roomId가 배정된 사용자</strong>가 다시 queue에 들어가 매칭 상태를 꼬이게 만드는 문제를 차단합니다.</p>

<h3>3) terminal session은 현재 사용자만 정리하고 재참가 허용</h3>
<p>종료된 세션은 active session과 다르게 재join을 막을 이유는 없지만, 그렇다고 세션 전체를 즉시 지우면 다른 참가자들이 <code>/matches/me</code>에서 종료 상태를 확인하지 못할 수 있습니다.</p>
<p>그래서 이번 PR에서는 terminal session에 대해 <strong>현재 사용자의 링크만 분리</strong>하고, 세션 본문은 다른 참조자가 남아 있는 동안 유지하도록 정리했습니다.</p>

<pre><code class="language-java">private void cleanupTerminalUserMatch(Long userId, Long matchId) {
    userMatchMap.remove(userId, matchId);
    removeMatchSessionIfUnreferenced(matchId);
}
</code></pre>

<p>대상 terminal 상태는 아래와 같습니다.</p>
<ul>
<li><code>CANCELLED</code></li>
<li><code>EXPIRED</code></li>
<li><code>CLOSED</code></li>
</ul>

<p>즉, 예를 들어 4명 중 1명만 다시 join을 누르면:</p>
<ul>
<li>그 사용자만 기존 terminal session 연결에서 빠짐</li>
<li>나머지 3명은 기존 <code>CANCELLED</code> / <code>EXPIRED</code> 상태를 계속 조회 가능</li>
<li>세션을 참조하는 마지막 사용자까지 빠졌을 때만 세션 본문이 제거됨</li>
</ul>

<h3>4) stale session 링크도 join 시점에 자동 정리</h3>
<p><code>userMatchMap</code>에는 matchId 연결이 남아 있지만, 실제 <code>matchSessionMap</code>에는 세션 본문이 이미 없는 경우도 고려했습니다.</p>
<p>이 경우는 더 이상 보여줄 종료 상태조차 없는 stale link이므로, join 시점에 현재 사용자의 링크를 즉시 정리한 뒤 새 queue 참가를 허용합니다.</p>

<pre><code class="language-java">if (matchSession == null) {
    cleanupStaleUserMatch(userId, matchId);
    return;
}
</code></pre>

<p>즉, stale 상태 때문에 사용자가 영구적으로 재참가하지 못하는 문제를 방지했습니다.</p>

<h3>5) duplicate join 예외를 ServiceException(409)로 통일</h3>
<p>기존에는 이미 queue에 참가 중인 사용자가 다시 join할 경우 <code>IllegalStateException</code>을 던지고 있었습니다. 이번 PR에서는 active session 재참가 차단과 같은 계열의 오류로 보기 때문에, 응답 성격을 맞추기 위해 <code>ServiceException("409-1", ...)</code>로 통일했습니다.</p>

<pre><code class="language-java">throw new ServiceException("409-1", "이미 매칭 대기열에 참가 중인 사용자입니다.");
</code></pre>

<p>즉, 중복 join 또는 진행 중 매칭 상태와 충돌하는 join 요청은 모두 conflict 계열로 일관되게 처리됩니다.</p>

<h3>6) session 본문 제거 조건을 마지막 참조자 기준으로 유지</h3>
<p>terminal session을 일부 사용자만 정리할 수 있게 되면서, 세션 본문 제거 시점이 더 중요해졌습니다. 이번 PR에서는 기존 <code>removeMatchSessionIfUnreferenced(matchId)</code> 동작을 유지해, <strong>아무도 해당 matchId를 참조하지 않을 때만</strong> 세션 본문을 제거하도록 했습니다.</p>

<pre><code class="language-java">private void removeMatchSessionIfUnreferenced(Long matchId) {
    if (!userMatchMap.containsValue(matchId)) {
        matchSessionMap.remove(matchId);
    }
}
</code></pre>

<p>즉, 세션 상태를 봐야 하는 다른 참가자가 남아 있는 동안에는 terminal session 본문이 유지됩니다.</p>

<hr>

<h2>테스트 추가</h2>

<p><code>ReadyCheckServiceTest</code>에 아래 시나리오를 추가해 이번 보완 케이스를 검증했습니다.</p>

<ol>
<li><code>SEARCHING</code> 중 같은 사용자가 다시 join하면 <code>409-1</code> conflict를 반환하는지 확인</li>
<li><code>ACCEPT_PENDING</code> 상태 사용자가 다시 join하면 <code>409-1</code> conflict를 반환하는지 확인</li>
<li><code>ROOM_READY</code> 상태 사용자가 다시 join하면 <code>409-1</code> conflict를 반환하는지 확인</li>
<li><code>CANCELLED</code> 상태에서 한 사용자만 다시 join하면 그 사용자만 새 queue에 들어가고, 나머지는 기존 terminal 상태를 유지하는지 확인</li>
<li><code>EXPIRED</code> 상태에서도 현재 사용자만 cleanup 후 재join 가능한지 확인</li>
<li><code>stale session</code> 링크만 남아 있는 경우 join 시 자동 cleanup 후 정상 참가되는지 확인</li>
<li>terminal session의 마지막 참조자까지 재join하면 세션 본문이 최종 제거되는지 확인</li>
</ol>

<h3>예시 시나리오 1) active session 재참가 차단</h3>
<pre><code class="language-java">assertThatThrownBy(() -> readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY)))
        .isInstanceOfSatisfying(ServiceException.class, ex -> {
            assertThat(ex.getResultCode()).isEqualTo("409-1");
            assertThat(ex.getMsg()).isEqualTo("이미 진행 중인 매칭이 있습니다.");
        });
</code></pre>

<h3>예시 시나리오 2) CANCELLED 상태에서 현재 사용자만 재참가 허용</h3>
<pre><code class="language-java">QueueStatusResponse rejoinResponse = readyCheckService.joinQueueV2(1L, createRequest("Graph", Difficulty.EASY));

assertThat(rejoinResponse.getWaitingCount()).isEqualTo(1);
assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isTrue();
assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
assertThat(readyCheckService.getMyMatchStateV2(2L).status()).isEqualTo(MatchStatus.CANCELLED);
</code></pre>

<h3>예시 시나리오 3) 마지막 참조자 cleanup 시 세션 본문 제거</h3>
<pre><code class="language-java">readyCheckService.joinQueueV2(1L, createRequest("Graph", Difficulty.EASY));
readyCheckService.joinQueueV2(2L, createRequest("DP", Difficulty.EASY));
readyCheckService.joinQueueV2(3L, createRequest("Greedy", Difficulty.EASY));
readyCheckService.joinQueueV2(4L, createRequest("Tree", Difficulty.EASY));

assertThat(matchSessionMap().containsKey(matchId)).isFalse();
</code></pre>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">join 요청
  ↓
ensureJoinEligibility(userId)
  ↓
1. userMatchMap 연결 없음
   → 바로 queue 참가 허용

2. matchSession 있음 + ACCEPT_PENDING / ROOM_READY
   → 409 conflict
   → 재join 차단

3. matchSession 있음 + CANCELLED / EXPIRED / CLOSED
   → 현재 사용자만 기존 match 연결 정리
   → 새 queue 참가 허용
   → 다른 참가자는 terminal 상태 유지

4. userMatchMap만 남고 matchSession 본문 없음
   → stale link cleanup
   → 새 queue 참가 허용
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>ready-check 진행 중인 사용자의 중복 join을 서버 단에서 확실히 차단합니다.</li>
<li>terminal session은 전체 삭제가 아니라 사용자 단위 cleanup으로 정리해, 다른 참가자들의 종료 상태 조회를 보존합니다.</li>
<li>stale link 때문에 재참가가 막히는 예외 케이스를 자동으로 회복할 수 있습니다.</li>
<li>duplicate join / active session 충돌 응답을 <code>409-1</code> 기준으로 일관되게 맞춥니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li><code>SEARCHING</code>, <code>ACCEPT_PENDING</code>, <code>ROOM_READY</code> 각각에서 중복 join이 서버에서 차단되는지 확인</li>
<li><code>CANCELLED</code>, <code>EXPIRED</code>, <code>CLOSED</code> 상태에서는 현재 사용자만 cleanup 후 재join 가능한지 확인</li>
<li>terminal session을 아직 참조하는 다른 사용자는 <code>/matches/me</code>에서 종료 상태를 계속 볼 수 있는지 확인</li>
<li>마지막 참조자까지 cleanup 된 뒤에는 세션 본문이 실제로 제거되는지 확인</li>
</ol>
</body>
</html>

