### PR TITLE
[fix] 한 사용자가 2개의 방에 PLAYING중일 수 있는 문제 수정

### DIFF
--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -59,13 +59,16 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
      * - r.status = PLAYING — 이미 끝난 방(FINISHED)의 참여자는 건드리지 않음
      * join fetch p.battleRoom 을 쓰는 이유는
      * 핸들러에서 participant.getBattleRoom().getId()를 호출할 때 N+1 문제 방지
+     *
+     * DB의 partial unique index(uq_one_playing_per_member)가 동시에 2개 이상의 PLAYING 참여자를
+     * 방지하므로 결과는 항상 0개 또는 1개. 2개 이상이면 IncorrectResultSizeDataAccessException 발생.
      */
     @Query("""
-                    select p from BattleParticipant p
-                    join fetch p.battleRoom r
-                    where p.member.id = :memberId
-                      and p.status = com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.PLAYING
-                      and r.status = com.back.domain.battle.battleroom.entity.BattleRoomStatus.PLAYING
-                    """)
-    List<BattleParticipant> findPlayingParticipantByMemberId(@Param("memberId") Long memberId);
+            select p from BattleParticipant p
+            join fetch p.battleRoom r
+            where p.member.id = :memberId
+              and p.status = com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.PLAYING
+              and r.status = com.back.domain.battle.battleroom.entity.BattleRoomStatus.PLAYING
+            """)
+    Optional<BattleParticipant> findPlayingParticipantByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/back/global/init/DatabaseIndexInitializer.java
+++ b/src/main/java/com/back/global/init/DatabaseIndexInitializer.java
@@ -1,0 +1,31 @@
+package com.back.global.init;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DatabaseIndexInitializer {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * ddl-auto: update 가 테이블 스키마를 먼저 반영한 뒤 실행되도록 ApplicationReadyEvent 사용.
+     * IF NOT EXISTS 로 멱등성 보장 — 서버 재시작 시 중복 실행돼도 안전.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void createIndexes() {
+        jdbcTemplate.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_one_playing_per_member
+                ON battle_participants (user_id)
+                WHERE status = 'PLAYING'
+                """);
+        log.info("DB index 확인 완료 - uq_one_playing_per_member");
+    }
+}

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -39,18 +39,16 @@ public class BattleDisconnectHandler {
             return;
         }
 
-        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).stream()
-                .findFirst()
-                .ifPresent(participant -> {
-                    Long roomId = participant.getBattleRoom().getId();
+        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).ifPresent(participant -> {
+            Long roomId = participant.getBattleRoom().getId();
 
-                    participant.abandon();
-                    battleParticipantRepository.save(participant);
+            participant.abandon();
+            battleParticipantRepository.save(participant);
 
-                    log.info("배틀 이탈 처리 - memberId={}, roomId={}", memberId, roomId);
+            log.info("배틀 이탈 처리 - memberId={}, roomId={}", memberId, roomId);
 
-                    messagingTemplate.convertAndSend(
-                            "/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
-                });
+            messagingTemplate.convertAndSend(
+                    "/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
+        });
     }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3>엣지케이스 시나리오</h3>
<ol>
<li>
<p>어떤 사용자A가 배틀룸1에서 나가서 abandoned된 상태인데 그 상태에서 재진입을 안하고 다른 방을 매칭해서 들어갔다</p>

방 | User A의 participant.status | room.status | 쿼리에서 반환?
-- | -- | -- | --
배틀룸1 | ABANDONED | PLAYING | ❌ (p.status 조건 불만족)
배틀룸2 | PLAYING | PLAYING | ✅


<p>배틀룸1에서 나갔을 때 이미 <code>participant.abandon()</code>이 호출되어 상태가 <code>ABANDONED</code>로 바뀌므로, 이후에 배틀룸2에서 disconnect가 발생해도 배틀룸1
participant는 p.status = PLAYING 필터에서 걸러짐</p>
</li>
<li>
<p>만약 어떤 이유로 같은 사용자가 두 방에 동시에 <code>PLAYING</code> 상태로 존재한다면 (findFirst()가 비결정적으로 한 쪽만 처리)
(정상적인 매칭플로우에서는 발생하지 않아야 하는 상황)</p>
<p><strong>DB 레벨 partial unique index</strong>
같은 멤버가 PLAYING 상태로 두 방에 동시에 존재하는 것 자체를 DB가 막게 한다.</p>
<pre><code class="language-sql">CREATE UNIQUE INDEX uq_participant_member_playing
ON battle_participant (member_id)
WHERE status = 'PLAYING';
</code></pre>
<p>JPA migration(Flyway/Liquibase)에 추가하거나, 엔티티에 <code>@Table(uniqueConstraints = ...)</code> 형태로도 가능하다.</p>

</li>
</ol>
<hr>
<h3>구현</h3>
<p>DB Partial Unique Index 적용</p>
<p>Flyway 없이 ddl-auto: update 환경에서 partial index를 적용하는 가장 깔끔한 방법은 ApplicationReadyEvent를 리스닝하는 Spring 컴포넌트를 추가하는 것</p>
<pre><code class="language-java">새 파일: DatabaseIndexInitializer.java
@Component
@RequiredArgsConstructor
public class DatabaseIndexInitializer {

    private final JdbcTemplate jdbcTemplate;

    @EventListener(ApplicationReadyEvent.class)
    public void createIndexes() {
        jdbcTemplate.execute(&quot;&quot;&quot;
            CREATE UNIQUE INDEX IF NOT EXISTS uq_one_playing_per_member
            ON battle_participants (user_id)
            WHERE status = 'PLAYING'
        &quot;&quot;&quot;);
    }
}
</code></pre>
<ul>
<li><code>ApplicationReadyEvent</code> 사용 이유: ddl-auto: update가 테이블을 먼저 생성/수정한 이후에 실행되도록 보장</li>
<li><code>IF NOT EXISTS</code> 덕분에 서버 재시작 시에도 멱등성 유지</li>
<li>PostgreSQL은 partial index 네이티브 지원, 비용 없음</li>
</ul>
<hr>
<h3>Entity에 uniqueConstraint 추가하는 방식으로 안하고 ApplicationReadyEvent를 리스닝하는 Spring 컴포넌트를 만든이유</h3>
<p>JPA의 <code>@UniqueConstraint</code>는 partial index를 지원하지 않기 때문이다.</p>
<pre><code class="language-java">// 이건 불가능 - JPA 표준에 WHERE 조건을 넣는 방법이 없음
@Table(uniqueConstraints = @UniqueConstraint(
    columnNames = &quot;user_id&quot;,
    // WHERE status = 'PLAYING' ← 표현할 방법 없음
))
</code></pre>
<p><code>@UniqueConstraint</code>로 user_id만 걸면 한 유저가 여러 방에 참여한 이력 자체를 저장할 수 없게 된다. (과거 ABANDONED, EXIT 기록도 모두 막힘)</p>
<p>그래서 &quot;PLAYING 상태인 행에만&quot; 유니크를 적용하는 partial index가 필요하고, 이건 raw SQL로만 가능하다.
Flyway가 없으니 <code>ApplicationReadyEvent</code>컴포넌트가 가장 깔끔한 대안이다.</p>
<!-- notionvc: 74738bb2-0558-4886-826c-5e50aa32e4db --><!--EndFragment-->
</body>
</html>