### PR TITLE
[fix] 마지막 accept 동시 요청 시 room 중복 생성 방지

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/model/MatchSession.java
+++ b/src/main/java/com/back/domain/matching/queue/model/MatchSession.java
@@ -118,6 +118,22 @@ public record MatchSession(
                 createdAt);
     }
 
+    /**
+     * 마지막 accept 경쟁 상황에서는 한 요청만 room 생성 권한을 가져가야 하므로
+     * ROOM_READY 직전의 내부 선점 상태를 별도로 둔다.
+     */
+    public MatchSession roomCreating() {
+        return new MatchSession(
+                matchId,
+                queueKey,
+                participantIds,
+                participantDecisions,
+                MatchSessionStatus.ROOM_CREATING,
+                roomId,
+                deadline,
+                createdAt);
+    }
+
     public MatchSession expired() {
         // 누가 어디까지 수락했는지는 프론트가 보여줘야 하므로 decision 정보는 유지한다.
         return new MatchSession(

--- a/src/main/java/com/back/domain/matching/queue/model/MatchSessionStatus.java
+++ b/src/main/java/com/back/domain/matching/queue/model/MatchSessionStatus.java
@@ -20,6 +20,8 @@ package com.back.domain.matching.queue.model;
 public enum MatchSessionStatus {
     // v2 ready-check가 시작됐지만 아직 전원 수락 전인 상태
     ACCEPT_PENDING,
+    // 전원 수락은 끝났지만 room 생성 권한을 한 요청이 선점한 내부 상태
+    ROOM_CREATING,
     // 전원 수락이 끝나 roomId까지 연결된 상태
     ROOM_READY,
     // 제한 시간이 지나 ready-check가 무효가 된 상태

--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
@@ -121,7 +121,12 @@ public class ReadyCheckService {
     public MatchStateV2Response acceptMatch(Long userId, Long matchId) {
         MatchSession matchSession = matchStateStore.accept(matchId, userId);
 
-        if (matchSession.status() == MatchSessionStatus.ACCEPT_PENDING && matchSession.isAllAccepted()) {
+        MatchStateStore.RoomCreationAttempt roomCreationAttempt = matchStateStore.tryBeginRoomCreation(matchId);
+        matchSession = roomCreationAttempt.matchSession();
+
+        if (roomCreationAttempt.acquired()) {
+            // 마지막 accept 경쟁 상황에서도 room 생성은 이 요청만 수행한다.
+            // 선점을 못 한 동시 요청은 현재 세션 상태만 그대로 응답으로 돌려준다.
             // 방 생성 시점을 마지막 accept로 미루는 이유는,
             // 수락하지 않은 매치에 불필요한 방이 만들어지지 않도록 하기 위해서다.
             try {
@@ -207,7 +212,8 @@ public class ReadyCheckService {
         return switch (status) {
             // ROOM_READY는 프론트 관점에서 바로 방 입장 가능한 상태다.
             case ROOM_READY -> MatchStatus.ROOM_READY;
-            case ACCEPT_PENDING -> MatchStatus.ACCEPT_PENDING;
+            // ROOM_CREATING은 room 생성 중인 내부 상태일 뿐이라 프론트에는 노출하지 않는다.
+            case ACCEPT_PENDING, ROOM_CREATING -> MatchStatus.ACCEPT_PENDING;
             case EXPIRED -> MatchStatus.EXPIRED;
             case CANCELLED -> MatchStatus.CANCELLED;
             case CLOSED -> MatchStatus.IDLE;

--- a/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
@@ -310,31 +310,46 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      */
     @Override
     public MatchSession accept(Long matchId, Long userId) {
-        MatchSession matchSession = requireMatchSession(matchId);
+        final LocalDateTime now = LocalDateTime.now();
+        final MatchSession[] resultHolder = new MatchSession[1];
 
-        if (!matchSession.hasParticipant(userId)) {
-            throw new IllegalStateException("매치 참가자가 아닌 사용자는 수락할 수 없습니다.");
-        }
+        matchSessionMap.compute(matchId, (id, currentSession) -> {
+            if (currentSession == null) {
+                throw new IllegalStateException("존재하지 않는 매치 세션입니다.");
+            }
 
-        if (matchSession.isExpiredAt(LocalDateTime.now())) {
-            // 스케줄러 대신 lazy expire를 사용하므로,
-            // 읽기/액션 시점에 deadline을 넘겼으면 여기서 바로 EXPIRED로 바꾼다.
-            return expire(matchId);
-        }
+            if (!currentSession.hasParticipant(userId)) {
+                throw new IllegalStateException("매치 참가자가 아닌 사용자는 수락할 수 없습니다.");
+            }
 
-        if (matchSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
-            // 이미 ROOM_READY, CANCELLED, EXPIRED 같은 최종 상태면 더 바꾸지 않는다.
-            return matchSession;
-        }
+            if (currentSession.isExpiredAt(now)) {
+                // 스케줄러 대신 lazy expire를 사용하므로,
+                // 읽기/액션 시점에 deadline을 넘겼으면 여기서 바로 EXPIRED로 바꾼다.
+                MatchSession expiredSession = currentSession.status() == MatchSessionStatus.ACCEPT_PENDING
+                        ? currentSession.expired()
+                        : currentSession;
+                resultHolder[0] = expiredSession;
+                return expiredSession;
+            }
 
-        if (matchSession.decisionOf(userId) == ReadyDecision.ACCEPTED) {
-            // 같은 사용자의 중복 accept는 현재 상태를 그대로 돌려준다.
-            return matchSession;
-        }
+            if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                // 이미 ROOM_CREATING, ROOM_READY, CANCELLED, EXPIRED 같은 상태면 더 바꾸지 않는다.
+                resultHolder[0] = currentSession;
+                return currentSession;
+            }
 
-        MatchSession updatedSession = matchSession.withDecision(userId, ReadyDecision.ACCEPTED);
-        matchSessionMap.put(matchId, updatedSession);
-        return updatedSession;
+            if (currentSession.decisionOf(userId) == ReadyDecision.ACCEPTED) {
+                // 같은 사용자의 중복 accept는 현재 상태를 그대로 돌려준다.
+                resultHolder[0] = currentSession;
+                return currentSession;
+            }
+
+            MatchSession updatedSession = currentSession.withDecision(userId, ReadyDecision.ACCEPTED);
+            resultHolder[0] = updatedSession;
+            return updatedSession;
+        });
+
+        return resultHolder[0];
     }
 
     /**
@@ -345,26 +360,71 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      */
     @Override
     public MatchSession decline(Long matchId, Long userId) {
-        MatchSession matchSession = requireMatchSession(matchId);
+        final LocalDateTime now = LocalDateTime.now();
+        final MatchSession[] resultHolder = new MatchSession[1];
 
-        if (!matchSession.hasParticipant(userId)) {
-            throw new IllegalStateException("매치 참가자가 아닌 사용자는 거절할 수 없습니다.");
-        }
+        matchSessionMap.compute(matchId, (id, currentSession) -> {
+            if (currentSession == null) {
+                throw new IllegalStateException("존재하지 않는 매치 세션입니다.");
+            }
 
-        if (matchSession.isExpiredAt(LocalDateTime.now())) {
-            // 거절을 누른 시점에 이미 deadline이 지났다면 거절보다 만료를 우선 반영한다.
-            return expire(matchId);
-        }
+            if (!currentSession.hasParticipant(userId)) {
+                throw new IllegalStateException("매치 참가자가 아닌 사용자는 거절할 수 없습니다.");
+            }
 
-        if (matchSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
-            return matchSession;
-        }
+            if (currentSession.isExpiredAt(now)) {
+                // 거절을 누른 시점에 이미 deadline이 지났다면 거절보다 만료를 우선 반영한다.
+                MatchSession expiredSession = currentSession.status() == MatchSessionStatus.ACCEPT_PENDING
+                        ? currentSession.expired()
+                        : currentSession;
+                resultHolder[0] = expiredSession;
+                return expiredSession;
+            }
 
-        // 이번 단계 정책에서는 한 명이 DECLINED가 되면 세션 전체를 종료한다.
-        MatchSession updatedSession =
-                matchSession.withDecision(userId, ReadyDecision.DECLINED).cancelled();
-        matchSessionMap.put(matchId, updatedSession);
-        return updatedSession;
+            if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                resultHolder[0] = currentSession;
+                return currentSession;
+            }
+
+            // 이번 단계 정책에서는 한 명이 DECLINED가 되면 세션 전체를 종료한다.
+            MatchSession updatedSession =
+                    currentSession.withDecision(userId, ReadyDecision.DECLINED).cancelled();
+            resultHolder[0] = updatedSession;
+            return updatedSession;
+        });
+
+        return resultHolder[0];
+    }
+
+    @Override
+    public RoomCreationAttempt tryBeginRoomCreation(Long matchId) {
+        final boolean[] acquired = new boolean[] {false};
+        final MatchSession[] resultHolder = new MatchSession[1];
+
+        matchSessionMap.compute(matchId, (id, currentSession) -> {
+            if (currentSession == null) {
+                throw new IllegalStateException("존재하지 않는 매치 세션입니다.");
+            }
+
+            if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                resultHolder[0] = currentSession;
+                return currentSession;
+            }
+
+            if (!currentSession.isAllAccepted()) {
+                resultHolder[0] = currentSession;
+                return currentSession;
+            }
+
+            // 마지막 accept 경쟁 상황에서는 한 요청만 ROOM_CREATING으로 선점해야
+            // createRoom(...)가 한 번만 호출된다.
+            MatchSession roomCreatingSession = currentSession.roomCreating();
+            acquired[0] = true;
+            resultHolder[0] = roomCreatingSession;
+            return roomCreatingSession;
+        });
+
+        return new RoomCreationAttempt(resultHolder[0], acquired[0]);
     }
 
     /**
@@ -375,11 +435,31 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      */
     @Override
     public MatchSession markRoomReady(Long matchId, Long roomId) {
-        MatchSession matchSession = requireMatchSession(matchId);
-        // roomId가 세션에 연결되는 순간부터 프론트는 실제 입장 가능한 상태가 된다.
-        MatchSession updatedSession = matchSession.roomReady(roomId);
-        matchSessionMap.put(matchId, updatedSession);
-        return updatedSession;
+        final MatchSession[] resultHolder = new MatchSession[1];
+
+        matchSessionMap.compute(matchId, (id, currentSession) -> {
+            if (currentSession == null) {
+                throw new IllegalStateException("존재하지 않는 매치 세션입니다.");
+            }
+
+            if (currentSession.status() == MatchSessionStatus.ROOM_READY) {
+                resultHolder[0] = currentSession;
+                return currentSession;
+            }
+
+            if (currentSession.status() != MatchSessionStatus.ROOM_CREATING
+                    && currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                resultHolder[0] = currentSession;
+                return currentSession;
+            }
+
+            // roomId가 세션에 연결되는 순간부터 프론트는 실제 입장 가능한 상태가 된다.
+            MatchSession updatedSession = currentSession.roomReady(roomId);
+            resultHolder[0] = updatedSession;
+            return updatedSession;
+        });
+
+        return resultHolder[0];
     }
 
     /**
@@ -407,16 +487,25 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      */
     @Override
     public MatchSession cancelMatch(Long matchId) {
-        MatchSession matchSession = requireMatchSession(matchId);
+        final MatchSession[] resultHolder = new MatchSession[1];
 
-        if (matchSession.status() == MatchSessionStatus.CANCELLED) {
-            return matchSession;
-        }
+        matchSessionMap.compute(matchId, (id, currentSession) -> {
+            if (currentSession == null) {
+                throw new IllegalStateException("존재하지 않는 매치 세션입니다.");
+            }
 
-        // room 생성 실패 같은 시스템 사유도 ready-check 거절과 동일하게 취소 상태로 묶는다.
-        MatchSession updatedSession = matchSession.cancelled();
-        matchSessionMap.put(matchId, updatedSession);
-        return updatedSession;
+            if (currentSession.status() == MatchSessionStatus.CANCELLED) {
+                resultHolder[0] = currentSession;
+                return currentSession;
+            }
+
+            // room 생성 실패 같은 시스템 사유도 ready-check 거절과 동일하게 취소 상태로 묶는다.
+            MatchSession updatedSession = currentSession.cancelled();
+            resultHolder[0] = updatedSession;
+            return updatedSession;
+        });
+
+        return resultHolder[0];
     }
 
     /**

--- a/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
@@ -26,6 +26,12 @@ public interface MatchStateStore {
     record CancelResult(QueueKey queueKey, int waitingCount) {}
 
     /**
+     * room 생성 선점 결과를 서비스 계층에서 해석할 수 있도록
+     * 현재 세션 상태와 이번 요청의 선점 성공 여부를 함께 내려준다.
+     */
+    record RoomCreationAttempt(MatchSession matchSession, boolean acquired) {}
+
+    /**
      * 유저를 큐에 넣고 현재 큐 크기를 반환한다.
      * 이미 같은 유저가 대기 중이면 예외를 던진다.
      */
@@ -63,6 +69,11 @@ public interface MatchStateStore {
      * 특정 참가자의 decision을 DECLINED로 바꾸고 세션 종료 흐름을 시작한다.
      */
     MatchSession decline(Long matchId, Long userId);
+
+    /**
+     * 전원 수락이 끝난 세션에서 room 생성 권한을 한 요청만 선점하도록 시도한다.
+     */
+    RoomCreationAttempt tryBeginRoomCreation(Long matchId);
 
     /**
      * 전원 수락 후 roomId를 세션에 연결하고 ROOM_READY 상태로 전환한다.

--- a/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
@@ -10,6 +10,12 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +31,7 @@ import com.back.domain.matching.queue.dto.QueueJoinRequest;
 import com.back.domain.matching.queue.dto.QueueStateV2Response;
 import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
 import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
@@ -37,7 +44,7 @@ class ReadyCheckServiceTest {
     private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
     private final QueueProblemPicker queueProblemPicker = mock(QueueProblemPicker.class);
     private final MemberRepository memberRepository = mock(MemberRepository.class);
-    private final MatchStateStore matchStateStore = new InMemoryMatchStateStore();
+    private final InMemoryMatchStateStore matchStateStore = new InMemoryMatchStateStore();
 
     private final ReadyCheckService readyCheckService =
             new ReadyCheckService(battleRoomService, queueProblemPicker, matchStateStore, memberRepository);
@@ -199,6 +206,109 @@ class ReadyCheckServiceTest {
         assertThat(readyCheckService.getMyMatchStateV2(2L).status()).isEqualTo(MatchStatus.ROOM_READY);
         assertThat(readyCheckService.getMyMatchStateV2(3L).status()).isEqualTo(MatchStatus.ROOM_READY);
         assertThat(readyCheckService.getMyMatchStateV2(4L).status()).isEqualTo(MatchStatus.ROOM_READY);
+    }
+
+    @Test
+    @DisplayName("마지막 accept가 동시에 들어와도 room은 한 번만 생성된다")
+    void acceptMatch_createsRoomOnlyOnce_whenLastAcceptsRace() throws Exception {
+        AtomicInteger createRoomCallCount = new AtomicInteger();
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class))).thenAnswer(invocation -> {
+            createRoomCallCount.incrementAndGet();
+            Thread.sleep(200);
+            return new CreateRoomResponse(100L, "WAITING");
+        });
+
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        readyCheckService.acceptMatch(1L, matchId);
+        readyCheckService.acceptMatch(2L, matchId);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<MatchStateV2Response> user3Future = executorService.submit(() -> {
+                startLatch.await();
+                return readyCheckService.acceptMatch(3L, matchId);
+            });
+            Future<MatchStateV2Response> user4Future = executorService.submit(() -> {
+                startLatch.await();
+                return readyCheckService.acceptMatch(4L, matchId);
+            });
+
+            startLatch.countDown();
+
+            MatchStateV2Response user3Response = user3Future.get(5, TimeUnit.SECONDS);
+            MatchStateV2Response user4Response = user4Future.get(5, TimeUnit.SECONDS);
+            MatchStateV2Response finalState = readyCheckService.getMyMatchStateV2(1L);
+
+            assertThat(createRoomCallCount.get()).isEqualTo(1);
+            assertThat(user3Response.status()).isIn(MatchStatus.ACCEPT_PENDING, MatchStatus.ROOM_READY);
+            assertThat(user4Response.status()).isIn(MatchStatus.ACCEPT_PENDING, MatchStatus.ROOM_READY);
+            assertThat(finalState.status()).isEqualTo(MatchStatus.ROOM_READY);
+            assertThat(finalState.room()).isNotNull();
+            assertThat(finalState.room().roomId()).isEqualTo(100L);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("ROOM_CREATING은 matches/me에서 ACCEPT_PENDING으로만 보인다")
+    void getMyMatchStateV2_hidesRoomCreatingState() {
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+        List<WaitingUser> users = List.of(
+                new WaitingUser(1L, queueKey),
+                new WaitingUser(2L, queueKey),
+                new WaitingUser(3L, queueKey),
+                new WaitingUser(4L, queueKey));
+
+        Long matchId = matchStateStore
+                .markAcceptPending(queueKey, users, LocalDateTime.now().plusSeconds(30))
+                .matchId();
+
+        matchStateStore.accept(matchId, 1L);
+        matchStateStore.accept(matchId, 2L);
+        matchStateStore.accept(matchId, 3L);
+        matchStateStore.accept(matchId, 4L);
+        MatchStateStore.RoomCreationAttempt roomCreationAttempt = matchStateStore.tryBeginRoomCreation(matchId);
+
+        MatchStateV2Response response = readyCheckService.getMyMatchStateV2(1L);
+
+        assertThat(roomCreationAttempt.acquired()).isTrue();
+        assertThat(roomCreationAttempt.matchSession().status()).isEqualTo(MatchSessionStatus.ROOM_CREATING);
+        assertThat(response.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+        assertThat(response.room()).isNull();
+        assertThat(response.readyCheck()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 ROOM_READY인 세션에 추가 accept가 와도 room은 다시 생성되지 않는다")
+    void acceptMatch_doesNotCreateRoomAgain_whenAlreadyRoomReady() {
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
+        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        readyCheckService.acceptMatch(1L, matchId);
+        readyCheckService.acceptMatch(2L, matchId);
+        readyCheckService.acceptMatch(3L, matchId);
+        readyCheckService.acceptMatch(4L, matchId);
+        MatchStateV2Response response = readyCheckService.acceptMatch(4L, matchId);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.ROOM_READY);
+        assertThat(response.room()).isNotNull();
+        verify(battleRoomService, times(1)).createRoom(any(CreateRoomRequest.class));
     }
 
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #104 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #104 

---
<html>
<body>
<h1>[fix] ready-check 마지막 accept 동시 요청 시 room 중복 생성 방지</h1>

<h3>개요</h3>
<p>이번 PR은 ready-check 매칭에서 <strong>마지막 accept 요청이 동시에 들어올 때 room이 중복 생성될 수 있는 경쟁 상황(race condition)</strong>을 방지하는 작업입니다.</p>
<p>기존 흐름에서는 여러 사용자의 accept 요청이 거의 동시에 들어오면, 둘 이상의 요청이 모두 "전원 수락 완료" 상태를 관측하고 각각 <code>createRoom(...)</code>을 호출할 가능성이 있었습니다. 이번 PR에서는 room 생성 직전의 내부 선점 상태를 추가하고, store 단에서 원자적으로 room 생성 권한을 하나의 요청만 가져가도록 바꿨습니다.</p>
<p>또한 이 과정에서 accept / decline / roomReady / cancel 상태 전이도 <code>compute</code> 기반으로 정리해, 동시 요청 상황에서도 세션 상태가 일관되게 유지되도록 보완했습니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) <code>ROOM_CREATING</code> 내부 상태 추가</h3>
<p>기존 세션 상태는 <code>ACCEPT_PENDING</code>, <code>ROOM_READY</code>, <code>EXPIRED</code>, <code>CANCELLED</code>, <code>CLOSED</code>만 사용하고 있었습니다.</p>
<p>이번 PR에서는 마지막 accept 경쟁 상황에서 <strong>room 생성 권한을 먼저 선점한 요청만 실제 createRoom을 호출할 수 있도록</strong> 중간 상태인 <code>ROOM_CREATING</code>을 추가했습니다.</p>

<pre><code class="language-java">public enum MatchSessionStatus {
    ACCEPT_PENDING,
    ROOM_CREATING,
    ROOM_READY,
    EXPIRED,
    CANCELLED,
    CLOSED
}
</code></pre>

<p>의미는 아래와 같습니다.</p>
<ul>
<li><code>ACCEPT_PENDING</code> : 아직 전원 수락 전이거나, 수락 완료 직후 room 생성 전 상태</li>
<li><code>ROOM_CREATING</code> : 전원 수락이 끝났고, 특정 요청이 room 생성 권한을 선점한 내부 상태</li>
<li><code>ROOM_READY</code> : roomId까지 연결이 끝나 실제 입장 가능한 상태</li>
</ul>

<h3>2) <code>MatchSession.roomCreating()</code> 추가</h3>
<p><code>MatchSession</code>에 <code>ROOM_CREATING</code> 상태로 전환하는 전용 메서드를 추가했습니다.</p>

<pre><code class="language-java">public MatchSession roomCreating() {
    return new MatchSession(
            matchId,
            queueKey,
            participantIds,
            participantDecisions,
            MatchSessionStatus.ROOM_CREATING,
            roomId,
            deadline,
            createdAt);
}
</code></pre>

<p>이 메서드는 마지막 accept 경쟁 구간에서 <strong>room 생성 직전 선점 상태</strong>를 세션에 반영할 때 사용됩니다.</p>

<h3>3) <code>accept()</code>를 원자적 상태 전이로 변경</h3>
<p>기존 <code>InMemoryMatchStateStore.accept()</code>는 세션을 읽고 조건을 검사한 뒤 <code>put()</code>으로 갱신하는 형태였습니다. 이 방식은 단일 요청 흐름에서는 동작하지만, 동시 요청이 들어오면 읽기와 쓰기 사이에 상태가 바뀌는 race에 취약합니다.</p>
<p>이번 PR에서는 <code>matchSessionMap.compute(...)</code>를 사용해 <strong>세션 조회, 유효성 검사, 상태 전이, 결과 반환을 하나의 원자적 구간</strong>으로 묶었습니다.</p>

<pre><code class="language-java">matchSessionMap.compute(matchId, (id, currentSession) -> {
    if (currentSession == null) {
        throw new IllegalStateException("존재하지 않는 매치 세션입니다.");
    }

    if (!currentSession.hasParticipant(userId)) {
        throw new IllegalStateException("매치 참가자가 아닌 사용자는 수락할 수 없습니다.");
    }

    if (currentSession.isExpiredAt(now)) {
        MatchSession expiredSession = currentSession.status() == MatchSessionStatus.ACCEPT_PENDING
                ? currentSession.expired()
                : currentSession;
        resultHolder[0] = expiredSession;
        return expiredSession;
    }

    if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
        resultHolder[0] = currentSession;
        return currentSession;
    }

    if (currentSession.decisionOf(userId) == ReadyDecision.ACCEPTED) {
        resultHolder[0] = currentSession;
        return currentSession;
    }

    MatchSession updatedSession = currentSession.withDecision(userId, ReadyDecision.ACCEPTED);
    resultHolder[0] = updatedSession;
    return updatedSession;
});
</code></pre>

<p>즉, accept는 이제 아래 조건을 동시에 안전하게 처리합니다.</p>
<ul>
<li>존재하지 않는 세션 거부</li>
<li>참가자가 아닌 사용자 거부</li>
<li>deadline 경과 시 lazy expire 우선 반영</li>
<li>이미 final/internal 상태면 그대로 반환</li>
<li>같은 사용자의 중복 accept는 idempotent하게 현재 상태 반환</li>
</ul>

<h3>4) <code>decline()</code>도 동일하게 원자적 상태 전이로 정리</h3>
<p><code>decline()</code> 역시 accept와 같은 이유로 <code>compute</code> 기반으로 바꿨습니다.</p>
<p>즉, 거절 요청도 경쟁 상황에서 아래 규칙을 일관되게 유지합니다.</p>
<ul>
<li>이미 deadline이 지났으면 거절보다 <code>EXPIRED</code>를 우선 반영</li>
<li>이미 <code>ROOM_CREATING</code>, <code>ROOM_READY</code>, <code>CANCELLED</code> 등 다른 상태면 현재 상태를 그대로 반환</li>
<li>아직 <code>ACCEPT_PENDING</code>인 경우에만 <code>DECLINED + CANCELLED</code> 처리</li>
</ul>

<p>이번 단계 정책인 "한 명이라도 거절하면 세션 전체를 종료" 규칙은 그대로 유지됩니다.</p>

<h3>5) room 생성 선점용 <code>tryBeginRoomCreation()</code> 추가</h3>
<p>이번 PR의 핵심은 <strong>전원 수락 완료 이후 실제 room 생성 권한을 한 요청만 가져가도록 보장</strong>하는 것입니다.</p>
<p>이를 위해 <code>MatchStateStore</code>에 아래 계약을 추가했습니다.</p>

<pre><code class="language-java">record RoomCreationAttempt(MatchSession matchSession, boolean acquired) {}

RoomCreationAttempt tryBeginRoomCreation(Long matchId);
</code></pre>

<p>store 구현에서는 <code>compute</code>를 사용해 아래 로직을 원자적으로 수행합니다.</p>

<pre><code class="language-java">if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
    resultHolder[0] = currentSession;
    return currentSession;
}

if (!currentSession.isAllAccepted()) {
    resultHolder[0] = currentSession;
    return currentSession;
}

MatchSession roomCreatingSession = currentSession.roomCreating();
acquired[0] = true;
resultHolder[0] = roomCreatingSession;
return roomCreatingSession;
</code></pre>

<p>즉, 아래 의미를 가집니다.</p>
<ul>
<li>아직 전원 수락이 아니면 선점 실패</li>
<li>이미 다른 요청이 <code>ROOM_CREATING</code> 또는 <code>ROOM_READY</code>로 바꿨으면 선점 실패</li>
<li>오직 한 요청만 <code>ACCEPT_PENDING -&gt; ROOM_CREATING</code> 전환에 성공</li>
</ul>

<p>이 시점부터 해당 요청만 room 생성 책임을 가지게 됩니다.</p>

<h3>6) <code>ReadyCheckService.acceptMatch()</code> 흐름 변경</h3>
<p>서비스 계층에서는 기존에 <code>accept()</code> 후 바로 <code>isAllAccepted()</code>를 검사하고 room 생성으로 넘어갔습니다. 이번 PR에서는 중간에 <code>tryBeginRoomCreation()</code>을 호출해 선점 성공 여부를 먼저 확인하도록 변경했습니다.</p>

<pre><code class="language-java">public MatchStateV2Response acceptMatch(Long userId, Long matchId) {
    MatchSession matchSession = matchStateStore.accept(matchId, userId);

    MatchStateStore.RoomCreationAttempt roomCreationAttempt = matchStateStore.tryBeginRoomCreation(matchId);
    matchSession = roomCreationAttempt.matchSession();

    if (roomCreationAttempt.acquired()) {
        try {
            Long problemId = queueProblemPicker.pick(matchSession.queueKey(), matchSession.participantIds());
            CreateRoomResponse response = battleRoomService.createRoom(
                    new CreateRoomRequest(problemId, matchSession.participantIds(), REQUIRED_MATCH_SIZE));
            matchSession = matchStateStore.markRoomReady(matchId, response.roomId());
        } catch (RuntimeException e) {
            matchSession = matchStateStore.cancelMatch(matchId);
        }
    }

    return toMatchStateV2Response(userId, matchSession);
}
</code></pre>

<p>즉, 마지막 accept 경쟁 상황에서도:</p>
<ul>
<li>선점한 요청 1개만 <code>createRoom(...)</code> 호출</li>
<li>선점하지 못한 동시 요청은 현재 세션 상태만 응답</li>
<li>결과적으로 room 생성은 정확히 1회만 발생</li>
</ul>

<h3>7) <code>markRoomReady()</code>도 idempotent하게 보완</h3>
<p>room 생성이 완료된 뒤 세션을 <code>ROOM_READY</code>로 바꾸는 <code>markRoomReady()</code>도 <code>compute</code> 기반으로 바꿨습니다.</p>
<p>이번 보완 포인트는 아래와 같습니다.</p>
<ul>
<li>이미 <code>ROOM_READY</code>인 경우 현재 세션 그대로 반환</li>
<li><code>ROOM_CREATING</code> 또는 예외적 상황의 <code>ACCEPT_PENDING</code>에서만 <code>ROOM_READY</code> 전환 허용</li>
<li>중복 호출이 들어와도 상태가 꼬이지 않도록 idempotent 처리</li>
</ul>

<h3>8) <code>cancelMatch()</code>도 compute 기반으로 정리</h3>
<p>room 생성 실패 시 세션을 <code>CANCELLED</code>로 전환하는 <code>cancelMatch()</code> 역시 <code>compute</code> 기반으로 바꿨습니다.</p>
<p>즉, 동시 실패 처리나 중복 호출이 들어와도 안전하게 현재 세션을 기준으로 취소 상태를 유지합니다.</p>

<h3>9) <code>ROOM_CREATING</code>은 프론트에 노출하지 않도록 매핑</h3>
<p><code>ROOM_CREATING</code>은 room 생성 경쟁 제어를 위한 <strong>내부 상태</strong>일 뿐, 프론트가 직접 알아야 하는 상태는 아닙니다. 그래서 <code>ReadyCheckService.toMatchStatus()</code>에서 <code>ROOM_CREATING</code>은 그대로 노출하지 않고 <code>ACCEPT_PENDING</code>으로 매핑했습니다.</p>

<pre><code class="language-java">private MatchStatus toMatchStatus(MatchSessionStatus status) {
    return switch (status) {
        case ROOM_READY -> MatchStatus.ROOM_READY;
        case ACCEPT_PENDING, ROOM_CREATING -> MatchStatus.ACCEPT_PENDING;
        case EXPIRED -> MatchStatus.EXPIRED;
        case CANCELLED -> MatchStatus.CANCELLED;
        case CLOSED -> MatchStatus.IDLE;
    };
}
</code></pre>

<p>즉, room 생성이 끝나기 전 잠깐 동안의 내부 선점 상태는 프론트에서는 그냥 기존 ACCEPT_PENDING처럼 보입니다.</p>

<h3>10) 동시성 및 idempotency 테스트 추가</h3>
<p><code>ReadyCheckServiceTest</code>에 이번 race condition을 직접 재현하는 테스트를 추가했습니다.</p>

<h4>10-1) 마지막 accept 동시 요청 시 room 생성 1회 보장</h4>
<p><code>CountDownLatch</code>와 <code>ExecutorService</code>를 사용해 마지막 accept 두 개를 동시에 보내고, <code>battleRoomService.createRoom(...)</code> 호출 횟수가 정확히 1번인지 검증했습니다.</p>

<pre><code class="language-java">assertThat(createRoomCallCount.get()).isEqualTo(1);
assertThat(finalState.status()).isEqualTo(MatchStatus.ROOM_READY);
assertThat(finalState.room().roomId()).isEqualTo(100L);
</code></pre>

<h4>10-2) <code>ROOM_CREATING</code>은 외부에 숨겨지는지 검증</h4>
<p>store에서 세션을 <code>ROOM_CREATING</code>까지 직접 전환한 뒤, <code>matches/me</code> 응답에서는 여전히 <code>ACCEPT_PENDING</code>으로 보이는지 확인했습니다.</p>

<h4>10-3) 이미 <code>ROOM_READY</code>인 세션에 추가 accept가 와도 room 재생성 안 함</h4>
<p>같은 사용자가 room ready 이후 다시 accept를 보내도 <code>createRoom(...)</code>이 다시 호출되지 않고, 상태는 그대로 <code>ROOM_READY</code>를 반환하는지 검증했습니다.</p>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">기존
마지막 accept 2개가 거의 동시에 들어옴
  ↓
각 요청이 모두 "전원 수락 완료"라고 판단
  ↓
둘 다 createRoom(...) 호출 가능
  ↓
room 중복 생성 위험

변경 후
마지막 accept 2개가 거의 동시에 들어옴
  ↓
각 요청이 accept()로 decision 반영
  ↓
tryBeginRoomCreation()에서 한 요청만 ROOM_CREATING 선점 성공
  ↓
선점 성공 요청만 createRoom(...) 호출
  ↓
markRoomReady()로 ROOM_READY 전환
  ↓
나머지 요청은 현재 세션 상태만 반환
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>마지막 accept 동시 요청 시 room이 중복 생성되는 race condition을 막습니다.</li>
<li><code>ROOM_CREATING</code> 내부 상태로 room 생성 권한을 명확하게 한 요청만 선점하게 만듭니다.</li>
<li><code>accept</code>, <code>decline</code>, <code>markRoomReady</code>, <code>cancelMatch</code>를 compute 기반으로 정리해 상태 전이 일관성을 높입니다.</li>
<li>프론트 응답 스펙은 유지하면서 내부 동시성 제어만 강화합니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li>마지막 accept 두 요청이 동시에 들어와도 <code>battleRoomService.createRoom(...)</code>이 1회만 호출되는지 확인</li>
<li><code>ROOM_CREATING</code> 상태는 외부 응답에서 노출되지 않고 <code>ACCEPT_PENDING</code>으로만 보이는지 확인</li>
<li>이미 <code>ROOM_READY</code>가 된 세션에 추가 accept가 와도 room이 다시 생성되지 않는지 확인</li>
<li>room 생성 실패 시 <code>CANCELLED</code> 전환이 동시 요청 상황에서도 안전하게 동작하는지 확인</li>
</ol>
</body>
</html>
