### PR TITLE
[refactor] ready-check 닉네임 snapshot 저장으로 matches/me DB 조회 제거

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueV2Controller.java
+++ b/src/main/java/com/back/domain/matching/queue/controller/MatchingQueueV2Controller.java
@@ -43,7 +43,10 @@ public class MatchingQueueV2Controller {
     public QueueStatusResponse joinQueue(@Valid @RequestBody QueueJoinRequest request) {
         // queue/join은 큐 참가만 담당하고,
         // ready-check 시작 여부 판단은 서비스에서 처리한다.
-        return readyCheckService.joinQueueV2(requireActorId(), request);
+        Member actor = requireActor();
+        // 예: user1 -> "m1" 이 queue에 들어갈 때 nickname snapshot도 함께 넘겨
+        // matches/me 에서 members 재조회 없이 ready-check 참가자 정보를 만들 수 있게 한다.
+        return readyCheckService.joinQueueV2(actor.getId(), actor.getNickname(), request);
     }
 
     @DeleteMapping("/cancel")
@@ -53,12 +56,16 @@ public class MatchingQueueV2Controller {
     }
 
     private Long requireActorId() {
+        return requireActor().getId();
+    }
+
+    private Member requireActor() {
         Member actor = rq.getActor();
 
         if (actor == null) {
             throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
         }
 
-        return actor.getId();
+        return actor;
     }
 }

--- a/src/main/java/com/back/domain/matching/queue/model/MatchSession.java
+++ b/src/main/java/com/back/domain/matching/queue/model/MatchSession.java
@@ -26,6 +26,12 @@ public record MatchSession(
         // 이 매치에 원래 묶인 참가자 원본 목록이다.
         // ready-check 진행 중에도 이 목록 자체는 바뀌지 않는다.
         List<Long> participantIds,
+        /**
+         * join 시점 nickname snapshot을 세션에 함께 저장한다.
+         * 예: participantIds = [1,2,3,4], participantNicknames = {1:"m1", 2:"m2", 3:"m3", 4:"m4"}
+         * participantIds 는 room 생성과 응답 순서를 위해 유지하고, nickname 은 이 snapshot map 에서 읽는다.
+         */
+        Map<Long, String> participantNicknames,
         // ready-check의 단일 상태 원본이다.
         // 누가 ACCEPTED / PENDING / DECLINED 인지는 여기만 보면 된다.
         Map<Long, ReadyDecision> participantDecisions,
@@ -43,12 +49,17 @@ public record MatchSession(
             throw new IllegalArgumentException("participantIds는 비어 있을 수 없습니다.");
         }
 
+        if (participantNicknames == null || participantNicknames.isEmpty()) {
+            throw new IllegalArgumentException("participantNicknames 는 비어 있을 수 없습니다.");
+        }
+
         if (participantDecisions == null || participantDecisions.isEmpty()) {
             throw new IllegalArgumentException("participantDecisions는 비어 있을 수 없습니다.");
         }
 
         // record로 받은 컬렉션이 바깥에서 수정되지 않도록 방어 복사한다.
         participantIds = List.copyOf(participantIds);
+        participantNicknames = Map.copyOf(participantNicknames);
         participantDecisions = Map.copyOf(participantDecisions);
     }
 
@@ -59,7 +70,11 @@ public record MatchSession(
      * 먼저 ACCEPT_PENDING 세션을 만든 뒤 각 참가자의 수락 여부를 기다린다.
      */
     public static MatchSession acceptPending(
-            Long matchId, QueueKey queueKey, List<Long> participantIds, LocalDateTime deadline) {
+            Long matchId,
+            QueueKey queueKey,
+            List<Long> participantIds,
+            Map<Long, String> participantNicknames,
+            LocalDateTime deadline) {
         if (deadline == null) {
             throw new IllegalArgumentException("ready-check 세션은 deadline이 필요합니다.");
         }
@@ -74,6 +89,7 @@ public record MatchSession(
                 matchId,
                 queueKey,
                 participantIds,
+                participantNicknames,
                 participantDecisions,
                 MatchSessionStatus.ACCEPT_PENDING,
                 null,
@@ -95,7 +111,15 @@ public record MatchSession(
         updatedDecisions.put(userId, decision);
 
         return new MatchSession(
-                matchId, queueKey, participantIds, updatedDecisions, status, roomId, deadline, createdAt);
+                matchId,
+                queueKey,
+                participantIds,
+                participantNicknames,
+                updatedDecisions,
+                status,
+                roomId,
+                deadline,
+                createdAt);
     }
 
     /**
@@ -111,6 +135,7 @@ public record MatchSession(
                 matchId,
                 queueKey,
                 participantIds,
+                participantNicknames,
                 participantDecisions,
                 MatchSessionStatus.ROOM_READY,
                 roomId,
@@ -124,6 +149,7 @@ public record MatchSession(
                 matchId,
                 queueKey,
                 participantIds,
+                participantNicknames,
                 participantDecisions,
                 MatchSessionStatus.EXPIRED,
                 roomId,
@@ -137,6 +163,7 @@ public record MatchSession(
                 matchId,
                 queueKey,
                 participantIds,
+                participantNicknames,
                 participantDecisions,
                 MatchSessionStatus.CANCELLED,
                 roomId,

--- a/src/main/java/com/back/domain/matching/queue/model/WaitingUser.java
+++ b/src/main/java/com/back/domain/matching/queue/model/WaitingUser.java
@@ -14,6 +14,12 @@ public class WaitingUser {
     private final Long userId;
 
     /**
+     * ready-check 응답에서 회원 정보를 다시 조회하지 않도록 join 시점 nickname snapshot을 함께 보관한다.
+     * 예: WaitingUser(1L, "m1", (DP, EASY)) 이면 이후 matches/me 에서도 "m1"을 그대로 쓸 수 있다.
+     */
+    private final String nickname;
+
+    /**
      * 사용자가 어떤 조건의 큐에 들어갔는지 나타내는 값
      * 예: (ARRAY, EASY)
      */
@@ -35,8 +41,9 @@ public class WaitingUser {
      *
      * joinedAt은 객체가 생성되는 현재 시각으로 자동 저장한다.
      */
-    public WaitingUser(Long userId, QueueKey queueKey) {
+    public WaitingUser(Long userId, String nickname, QueueKey queueKey) {
         this.userId = userId;
+        this.nickname = nickname;
         this.queueKey = queueKey;
         this.joinedAt = LocalDateTime.now();
     }
@@ -44,6 +51,10 @@ public class WaitingUser {
     // 대기 중인 사용자의 ID 반환
     public Long getUserId() {
         return userId;
+    }
+
+    public String getNickname() {
+        return nickname;
     }
 
     // 사용자가 속한 큐 정보 반환

--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
@@ -2,9 +2,6 @@ package com.back.domain.matching.queue.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.springframework.stereotype.Service;
 
@@ -25,8 +22,6 @@ import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
 import com.back.domain.matching.queue.store.MatchStateStore;
-import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -51,7 +46,6 @@ public class ReadyCheckService {
     private final BattleRoomService battleRoomService;
     private final QueueProblemPicker queueProblemPicker;
     private final MatchStateStore matchStateStore;
-    private final MemberRepository memberRepository;
 
     /**
      * v2 큐 참가
@@ -59,12 +53,14 @@ public class ReadyCheckService {
      * 4명이 되기 전까지는 기존과 같은 SEARCHING 의미지만,
      * 4명이 되는 순간에는 즉시 room을 만들지 않고 ready-check 세션만 생성한다.
      */
-    public QueueStatusResponse joinQueueV2(Long userId, QueueJoinRequest request) {
+    public QueueStatusResponse joinQueueV2(Long userId, String nickname, QueueJoinRequest request) {
         QueueKey queueKey = new QueueKey(request.getCategory(), request.getDifficulty());
         // 1L -> {array + hard}
         // array + hard = {user1,} 에들어감
         // 반환값은 큐 사이즈
-        int currentSize = matchStateStore.enqueue(userId, queueKey);
+        // 예: user1 이 "m1" 닉네임으로 queue 에 들어오면 이 snapshot 을 함께 넘긴다.
+        // 이후 matches/me 는 같은 nickname 을 재사용하고, members 재조회는 하지 않는다.
+        int currentSize = matchStateStore.enqueue(userId, nickname, queueKey);
 
         if (currentSize < REQUIRED_MATCH_SIZE) {
             // 아직 4명이 안 찼다면 기존 SEARCHING 단계로 머문다.
@@ -220,18 +216,15 @@ public class ReadyCheckService {
      */
     private ReadyCheckSnapshot buildReadyCheckSnapshot(Long userId, MatchSession matchSession) {
         // nickname은 store가 아니라 서비스에서 회원 정보를 합쳐 만든다.
-        Map<Long, String> nicknameByUserId = StreamSupport.stream(
-                        memberRepository
-                                .findAllById(matchSession.participantIds())
-                                .spliterator(),
-                        false)
-                .collect(Collectors.toMap(Member::getId, Member::getNickname, (left, right) -> left));
-
+        // 세션에 저장한 nickname snapshot 을 그대로 꺼내 쓴다.
+        // 예: participantIds = [1,2], participantNicknames = {1:"m1", 2:"m2"} 이면 participants = [(1,"m1"), (2,"m2")] 로
+        // 바로 조립된다.
+        // 그래서 matches/me 는 더 이상 members where id in (...) 조회를 다시 만들지 않는다.
         List<ReadyParticipantSnapshot> participants = matchSession.participantIds().stream()
                 // 참가자 원본 순서를 기준으로 snapshot을 만들면 프론트가 슬롯 UI를 안정적으로 그릴 수 있다.
                 .map(participantId -> new ReadyParticipantSnapshot(
                         participantId,
-                        nicknameByUserId.getOrDefault(participantId, String.valueOf(participantId)),
+                        matchSession.participantNicknames().getOrDefault(participantId, String.valueOf(participantId)),
                         matchSession.decisionOf(participantId)))
                 .toList();
 

--- a/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
@@ -3,6 +3,7 @@ package com.back.domain.matching.queue.store;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -117,7 +118,7 @@ public class InMemoryMatchStateStore implements MatchStateStore {
      *    add + size 같은 복합 로직은 한 덩어리로 묶어야 일관성이 맞기 때문이다.
      */
     @Override
-    public int enqueue(Long userId, QueueKey queueKey) {
+    public int enqueue(Long userId, String nickname, QueueKey queueKey) {
         if (userQueueMap.putIfAbsent(userId, queueKey) != null) {
             throw new IllegalStateException("이미 매칭 대기열에 참가 중인 사용자입니다.");
         }
@@ -125,7 +126,7 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         Deque<WaitingUser> queue = waitingQueues.computeIfAbsent(queueKey, key -> new ConcurrentLinkedDeque<>());
 
         synchronized (queue) {
-            queue.addLast(new WaitingUser(userId, queueKey));
+            queue.addLast(new WaitingUser(userId, nickname, queueKey));
             return queue.size();
         }
     }
@@ -283,8 +284,14 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         // 세션 본문에는 결국 userId 목록만 남기면 되므로 여기서 변환한다.
         List<Long> participantIds =
                 matchedUsers.stream().map(WaitingUser::getUserId).toList();
+        // participantIds 는 기존처럼 room 생성 요청과 응답 순서를 고정하는 용도로 유지한다.
+        // nickname snapshot 은 같은 userId 키로 묶어서 matches/me 가 DB 조회 없이 참가자 목록을 조립하게 한다.
+        // 예: participantIds = [1,2,3,4], participantNicknames = {1:"m1", 2:"m2", 3:"m3", 4:"m4"}
+        Map<Long, String> participantNicknames = new LinkedHashMap<>();
+        matchedUsers.forEach(user -> participantNicknames.put(user.getUserId(), user.getNickname()));
 
-        MatchSession matchSession = MatchSession.acceptPending(matchId, queueKey, participantIds, deadline);
+        MatchSession matchSession =
+                MatchSession.acceptPending(matchId, queueKey, participantIds, participantNicknames, deadline);
 
         // 세션 본문을 먼저 저장한 뒤
         // user -> match 연결을 만든다.

--- a/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
@@ -29,7 +29,7 @@ public interface MatchStateStore {
      * 유저를 큐에 넣고 현재 큐 크기를 반환한다.
      * 이미 같은 유저가 대기 중이면 예외를 던진다.
      */
-    int enqueue(Long userId, QueueKey queueKey);
+    int enqueue(Long userId, String nickname, QueueKey queueKey);
 
     /**
      * SEARCHING 상태 유저를 큐에서 제거한다.

--- a/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
@@ -29,34 +29,25 @@ import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
 import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
 import com.back.domain.matching.queue.store.MatchStateStore;
-import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.repository.MemberRepository;
 
 class ReadyCheckServiceTest {
 
     private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
     private final QueueProblemPicker queueProblemPicker = mock(QueueProblemPicker.class);
-    private final MemberRepository memberRepository = mock(MemberRepository.class);
     private final MatchStateStore matchStateStore = new InMemoryMatchStateStore();
 
     private final ReadyCheckService readyCheckService =
-            new ReadyCheckService(battleRoomService, queueProblemPicker, matchStateStore, memberRepository);
+            new ReadyCheckService(battleRoomService, queueProblemPicker, matchStateStore);
 
     @BeforeEach
     void setUp() {
         when(queueProblemPicker.pick(any(QueueKey.class), anyList())).thenReturn(1L);
-        when(memberRepository.findAllById(anyList())).thenAnswer(invocation -> {
-            List<Long> ids = invocation.getArgument(0);
-            return ids.stream()
-                    .map(id -> Member.of(id, "user" + id + "@test.com", "user" + id))
-                    .toList();
-        });
     }
 
     @Test
     @DisplayName("v2 queue/me는 SEARCHING 동안 waitingCount와 requiredCount를 반환한다")
     void getMyQueueStateV2_returnsSearchingInfo() {
-        QueueStatusResponse response = readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
+        QueueStatusResponse response = joinUser(1L);
 
         QueueStateV2Response queueState = readyCheckService.getMyQueueStateV2(1L);
 
@@ -71,10 +62,10 @@ class ReadyCheckServiceTest {
     @Test
     @DisplayName("4명이 모이면 v2 matches/me는 ACCEPT_PENDING을 반환한다")
     void getMyMatchStateV2_returnsAcceptPending_whenFourthUserJoins() {
-        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
-        QueueStatusResponse fourthResponse = readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        QueueStatusResponse fourthResponse = joinUser(4L);
 
         MatchStateV2Response response = readyCheckService.getMyMatchStateV2(1L);
 
@@ -87,6 +78,9 @@ class ReadyCheckServiceTest {
         assertThat(response.readyCheck().requiredCount()).isEqualTo(4);
         assertThat(response.readyCheck().acceptedByMe()).isFalse();
         assertThat(response.readyCheck().participants()).hasSize(4);
+        assertThat(response.readyCheck().participants())
+                .extracting(participant -> participant.nickname())
+                .containsExactly("m1", "m2", "m3", "m4");
     }
 
     @Test
@@ -95,10 +89,10 @@ class ReadyCheckServiceTest {
         when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
                 .thenReturn(new CreateRoomResponse(100L, "WAITING"));
 
-        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
 
         Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
 
@@ -117,10 +111,10 @@ class ReadyCheckServiceTest {
     @Test
     @DisplayName("한 명이라도 거절하면 세션 전체가 CANCELLED로 종료된다")
     void declineMatch_returnsCancelled() {
-        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
 
         Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
 
@@ -140,10 +134,10 @@ class ReadyCheckServiceTest {
     void getMyMatchStateV2_returnsExpired_whenDeadlinePassed() {
         QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
         List<WaitingUser> users = List.of(
-                new WaitingUser(1L, queueKey),
-                new WaitingUser(2L, queueKey),
-                new WaitingUser(3L, queueKey),
-                new WaitingUser(4L, queueKey));
+                new WaitingUser(1L, "m1", queueKey),
+                new WaitingUser(2L, "m2", queueKey),
+                new WaitingUser(3L, "m3", queueKey),
+                new WaitingUser(4L, "m4", queueKey));
 
         matchStateStore.markAcceptPending(queueKey, users, LocalDateTime.now().minusSeconds(1));
 
@@ -159,10 +153,10 @@ class ReadyCheckServiceTest {
         when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
                 .thenThrow(new RuntimeException("room create failed"));
 
-        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
 
         Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
 
@@ -181,10 +175,10 @@ class ReadyCheckServiceTest {
         when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
                 .thenReturn(new CreateRoomResponse(100L, "WAITING"));
 
-        readyCheckService.joinQueueV2(1L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(2L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(3L, createRequest("Array", Difficulty.EASY));
-        readyCheckService.joinQueueV2(4L, createRequest("Array", Difficulty.EASY));
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
 
         Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
 
@@ -203,5 +197,9 @@ class ReadyCheckServiceTest {
 
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {
         return new QueueJoinRequest(category, difficulty);
+    }
+
+    private QueueStatusResponse joinUser(Long userId) {
+        return readyCheckService.joinQueueV2(userId, "m" + userId, createRequest("Array", Difficulty.EASY));
     }
 }


### PR DESCRIPTION
# rebase 과정에서 브랜치 히스토리가 꼬여, 최신 `dev` 위에서 동일 작업을 안전하게 재구성한 복구 PR로 이어갑니다.

# 대체 PR: #112 



---











<html>
<body>
<h1>[refactor] ready-check 닉네임 snapshot 저장으로 matches/me DB 조회 제거</h1>

<h3>개요</h3>
<p>이번 PR은 ready-check 매칭에서 <code>GET /api/v2/matches/me</code> 호출 시마다 회원 정보를 다시 조회하던 구조를 제거하고, <strong>queue join 시점의 nickname snapshot을 세션에 저장해서 그대로 응답에 재사용</strong>하도록 정리한 refactor 작업입니다.</p>
<p>기존에는 <code>matches/me</code> 응답을 만들 때마다 <code>participantIds</code>를 기준으로 <code>MemberRepository.findAllById(...)</code>를 호출해 nickname을 다시 조합하고 있었습니다. ready-check는 프론트에서 짧은 주기로 상태를 조회하는 구조이기 때문에, 이 방식은 같은 세션에 대해 불필요한 DB hit가 반복되는 문제가 있었습니다.</p>
<p>이번 PR에서는 <code>queue/join</code> 시점에 사용자 닉네임을 함께 받아 <code>WaitingUser</code>와 <code>MatchSession</code>에 snapshot으로 저장하고, 이후 <code>matches/me</code>에서는 그 snapshot만 사용해 참가자 목록을 조립하도록 변경했습니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) <code>joinQueueV2()</code>에서 userId와 함께 nickname도 전달하도록 변경</h3>
<p>기존 <code>ReadyCheckService.joinQueueV2()</code>는 <code>userId</code>와 <code>QueueJoinRequest</code>만 받아 queue 참가를 처리했습니다. 이번 PR에서는 join 시점의 nickname도 함께 전달받도록 메서드 시그니처를 변경했습니다.</p>

<pre><code class="language-java">public QueueStatusResponse joinQueueV2(Long userId, String nickname, QueueJoinRequest request)
</code></pre>

<p>즉, ready-check에 들어가는 순간의 사용자 닉네임을 queue 상태와 함께 저장할 수 있도록 했습니다.</p>

<h3>2) <code>MatchingQueueV2Controller</code>에서 actor nickname snapshot을 함께 넘기도록 변경</h3>
<p>컨트롤러에서는 로그인 사용자 정보를 가져올 때 기존처럼 <code>id</code>만 쓰지 않고, <code>nickname</code>까지 함께 꺼내 서비스로 전달하도록 변경했습니다.</p>

<pre><code class="language-java">@PostMapping("/join")
public QueueStatusResponse joinQueue(@Valid @RequestBody QueueJoinRequest request) {
    Member actor = requireActor();
    return readyCheckService.joinQueueV2(actor.getId(), actor.getNickname(), request);
}
</code></pre>

<p>이 변경으로 인해 nickname snapshot의 출발점은 아래 흐름으로 정리됩니다.</p>
<ul>
<li>로그인 사용자 조회</li>
<li><code>actor.getId()</code>, <code>actor.getNickname()</code> 확보</li>
<li>queue 참가 시 두 값을 함께 저장</li>
</ul>

<p>즉, 이후 <code>matches/me</code>에서는 회원 테이블을 다시 조회하지 않아도 ready-check 참가자 닉네임을 바로 사용할 수 있습니다.</p>

<h3>3) <code>MatchStateStore.enqueue()</code> 계약 확장</h3>
<p>store 인터페이스도 join 시 nickname을 같이 저장할 수 있도록 시그니처를 확장했습니다.</p>

<pre><code class="language-java">int enqueue(Long userId, String nickname, QueueKey queueKey);
</code></pre>

<p>즉, 이제 queue 참가 저장의 최소 단위는 단순한 <code>userId + queueKey</code>가 아니라, <code>userId + nickname + queueKey</code> 조합이 됩니다.</p>

<h3>4) <code>WaitingUser</code>에 nickname 필드 추가</h3>
<p>기존 <code>WaitingUser</code>는 대기 중인 사용자의 <code>userId</code>와 <code>queueKey</code>만 들고 있었습니다. 이번 PR에서는 ready-check 응답에서 재사용할 수 있도록 nickname 필드를 추가했습니다.</p>

<pre><code class="language-java">private final Long userId;
private final String nickname;
private final QueueKey queueKey;
</code></pre>

<pre><code class="language-java">public WaitingUser(Long userId, String nickname, QueueKey queueKey) {
    this.userId = userId;
    this.nickname = nickname;
    this.queueKey = queueKey;
    this.joinedAt = LocalDateTime.now();
}
</code></pre>

<p>즉, queue 대기열에 들어가는 순간부터 이미 nickname snapshot을 같이 들고 있게 됩니다.</p>

<h3>5) 4명 매칭 시 <code>participantNicknames</code> snapshot map 생성</h3>
<p><code>InMemoryMatchStateStore.markAcceptPending()</code>에서는 4명이 모여 ready-check 세션을 만들 때, 기존처럼 <code>participantIds</code>만 추출하는 것이 아니라 nickname snapshot map도 함께 만듭니다.</p>

<pre><code class="language-java">List&lt;Long&gt; participantIds =
        matchedUsers.stream().map(WaitingUser::getUserId).toList();

Map&lt;Long, String&gt; participantNicknames = new LinkedHashMap&lt;&gt;();
matchedUsers.forEach(user -&gt; participantNicknames.put(user.getUserId(), user.getNickname()));

MatchSession matchSession =
        MatchSession.acceptPending(matchId, queueKey, participantIds, participantNicknames, deadline);
</code></pre>

<p>여기서 중요한 포인트는 두 가지입니다.</p>
<ul>
<li><code>participantIds</code>는 기존처럼 room 생성 요청 순서와 응답 참가자 순서를 유지하는 용도</li>
<li><code>participantNicknames</code>는 같은 userId 키를 기준으로 nickname snapshot을 보관하는 용도</li>
</ul>

<p>즉, 순서는 리스트로 유지하고, 표시용 nickname은 맵으로 분리해 저장하는 구조입니다.</p>

<h3>6) <code>MatchSession</code>에 <code>participantNicknames</code> 필드 추가</h3>
<p>기존 <code>MatchSession</code>은 아래 핵심 정보를 저장하고 있었습니다.</p>
<ul>
<li><code>participantIds</code></li>
<li><code>participantDecisions</code></li>
<li><code>status</code></li>
<li><code>roomId</code></li>
<li><code>deadline</code></li>
</ul>

<p>이번 PR에서는 여기에 join 시점 nickname snapshot인 <code>participantNicknames</code>를 추가했습니다.</p>

<pre><code class="language-java">List&lt;Long&gt; participantIds,
Map&lt;Long, String&gt; participantNicknames,
Map&lt;Long, ReadyDecision&gt; participantDecisions,
</code></pre>

<p>또한 생성 시 아래 검증과 방어 복사를 추가했습니다.</p>

<pre><code class="language-java">if (participantNicknames == null || participantNicknames.isEmpty()) {
    throw new IllegalArgumentException("participantNicknames 는 비어 있을 수 없습니다.");
}

participantNicknames = Map.copyOf(participantNicknames);
</code></pre>

<p>즉, 세션이 한 번 만들어지면 nickname snapshot도 외부 변경 없이 안정적으로 유지됩니다.</p>

<h3>7) 세션 상태 전이 시에도 nickname snapshot 유지</h3>
<p><code>MatchSession</code>은 ready-check 동안 여러 상태 전이를 거칩니다.</p>
<ul>
<li><code>withDecision()</code></li>
<li><code>roomReady()</code></li>
<li><code>expired()</code></li>
<li><code>cancelled()</code></li>
</ul>

<p>이번 PR에서는 이 모든 상태 전이 메서드가 기존 nickname snapshot을 그대로 유지하도록 수정했습니다.</p>

<pre><code class="language-java">return new MatchSession(
        matchId,
        queueKey,
        participantIds,
        participantNicknames,
        updatedDecisions,
        status,
        roomId,
        deadline,
        createdAt);
</code></pre>

<p>즉, 세션이 <code>ACCEPT_PENDING</code>에서 <code>ROOM_READY</code>, <code>EXPIRED</code>, <code>CANCELLED</code>로 바뀌더라도 참가자 닉네임은 다시 조회하지 않고 같은 snapshot을 계속 사용합니다.</p>

<h3>8) <code>ReadyCheckService</code>에서 <code>MemberRepository</code> 의존성 제거</h3>
<p>기존 <code>ReadyCheckService</code>는 <code>matches/me</code> 응답을 만들 때마다 <code>memberRepository.findAllById(...)</code>로 참가자 닉네임을 다시 조회하고 있었습니다.</p>

<pre><code class="language-java">Map&lt;Long, String&gt; nicknameByUserId = StreamSupport.stream(
                memberRepository.findAllById(matchSession.participantIds()).spliterator(),
                false)
        .collect(Collectors.toMap(Member::getId, Member::getNickname, (left, right) -&gt; left));
</code></pre>

<p>이번 PR에서는 위 로직을 제거하고, <code>MatchSession</code>에 저장된 snapshot을 그대로 사용하도록 바꿨습니다.</p>

<pre><code class="language-java">List&lt;ReadyParticipantSnapshot&gt; participants = matchSession.participantIds().stream()
        .map(participantId -&gt; new ReadyParticipantSnapshot(
                participantId,
                matchSession.participantNicknames().getOrDefault(participantId, String.valueOf(participantId)),
                matchSession.decisionOf(participantId)))
        .toList();
</code></pre>

<p>즉, <code>matches/me</code> 응답은 이제 세션에 이미 들어 있는 정보만으로 조립되며, 별도의 members 조회가 필요 없습니다.</p>

<h3>9) <code>matches/me</code>에서 DB 재조회가 사라지는 효과</h3>
<p>이번 refactor의 핵심 효과는 <code>GET /api/v2/matches/me</code>가 더 이상 아래 과정을 수행하지 않는다는 점입니다.</p>

<pre><code class="language-text">기존
matches/me 요청
  ↓
participantIds 확인
  ↓
members 테이블 재조회
  ↓
nicknameByUserId 맵 생성
  ↓
ReadyParticipantSnapshot 조립

변경 후
matches/me 요청
  ↓
MatchSession.participantIds + participantNicknames 사용
  ↓
ReadyParticipantSnapshot 바로 조립
</code></pre>

<p>즉, 프론트가 ready-check 상태를 폴링하더라도 같은 세션에 대해 반복적인 member 조회가 발생하지 않습니다.</p>

<h3>10) 응답 순서는 기존과 동일하게 유지</h3>
<p>nickname 저장 방식을 map으로 바꾸면 응답 순서가 흔들릴 수 있는데, 이번 구현은 순서가 필요한 부분과 표시값을 분리해서 이 문제를 피했습니다.</p>

<ul>
<li><code>participantIds</code> : 응답 참가자 순서의 기준</li>
<li><code>participantNicknames</code> : userId별 nickname lookup 용도</li>
</ul>

<p>따라서 <code>participants</code> 응답은 여전히 <code>participantIds</code> 순서를 따라 생성되고, 각 슬롯의 닉네임만 snapshot map에서 꺼내 씁니다. 프론트는 이전과 동일한 안정적인 순서로 UI를 그릴 수 있습니다.</p>

<h3>11) 테스트도 snapshot 방식 기준으로 정리</h3>
<p><code>ReadyCheckServiceTest</code>도 이번 구조 변경에 맞춰 업데이트했습니다.</p>

<ul>
<li><code>MemberRepository</code> mock 제거</li>
<li><code>ReadyCheckService</code> 생성자에서 repository 의존성 제거</li>
<li><code>joinUser()</code> 헬퍼를 통해 join 시 nickname(<code>m1</code>, <code>m2</code> ...) 전달</li>
<li><code>WaitingUser</code> 직접 생성 시에도 nickname 포함</li>
</ul>

<p>특히 ready-check 참가자 목록에 nickname snapshot이 그대로 반영되는지 명시적으로 검증합니다.</p>

<pre><code class="language-java">assertThat(response.readyCheck().participants())
        .extracting(participant -> participant.nickname())
        .containsExactly("m1", "m2", "m3", "m4");
</code></pre>

<p>즉, 테스트 관점에서도 이제 nickname은 DB 조회 결과가 아니라 세션 snapshot에서 나오는 값임을 확인하고 있습니다.</p>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">POST /api/v2/queue/join
  ↓
controller 가 로그인 사용자 id + nickname 확보
  ↓
ReadyCheckService.joinQueueV2(userId, nickname, request)
  ↓
MatchStateStore.enqueue(userId, nickname, queueKey)
  ↓
WaitingUser(userId, nickname, queueKey) 저장
  ↓
4명 충족 시 markAcceptPending()
  ↓
participantIds + participantNicknames snapshot으로 MatchSession 생성
  ↓
GET /api/v2/matches/me
  ↓
MemberRepository 재조회 없이
MatchSession.participantNicknames() 로 participants 응답 조립
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li><code>matches/me</code> 호출 시 반복적인 회원 DB 조회를 제거합니다.</li>
<li>ready-check 세션이 가진 정보만으로 참가자 nickname 응답을 만들 수 있습니다.</li>
<li>참가자 응답 순서는 기존처럼 안정적으로 유지됩니다.</li>
<li>서비스 책임이 단순해지고, <code>ReadyCheckService</code>에서 member 조회 의존성이 사라집니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li><code>/api/v2/queue/join</code> 시 로그인 사용자의 nickname이 queue 참가와 함께 저장되는지 확인</li>
<li><code>/api/v2/matches/me</code> 호출 시 participant nickname이 snapshot 기준으로 정상 내려오는지 확인</li>
<li>ready-check 중 repeated polling 상황에서 더 이상 <code>MemberRepository.findAllById(...)</code> 조회가 발생하지 않는지 확인</li>
<li>참가자 응답 순서가 기존과 동일하게 <code>participantIds</code> 기준으로 유지되는지 확인</li>
</ol>
</body>
</html>
