### PR TITLE
[fix] 문제/프로필 적재 시 ID 50 점프 현상 수정

### DIFF
--- a/docs/local-db-compose-guide.md
+++ b/docs/local-db-compose-guide.md
@@ -1,243 +1,41 @@
-# 로컬 DB/데이터 적재 가이드
+# 로컬 DB/데이터 적재 가이드 (5단계)
 
-로컬 개발/데이터 적재를 팀 공통으로 맞추기 위한 최소 실행 가이드입니다.
-아래 명령은 현재 위치와 관계없이 프로젝트 루트를 자동으로 찾아 실행하도록 작성했습니다.
+아래 5단계만 실행하면 됩니다.
 
-## 0) `.env` 준비 (필수)
-
-민감한 값은 저장소에 커밋하지 않고 `.env`에서 관리합니다.
-
-```bash
-cd "$(git rev-parse --show-toplevel)" && cp .env.example .env
-```
-
-- `.env`의 `DB_PASSWORD`는 로컬 전용 강한 값으로 변경하세요.
-- `.env`는 `.gitignore`에 포함되어 있어 커밋되지 않습니다.
-
-## 1) PostgreSQL 실행 (Docker Compose)
-
-주의: 실행 전에 docker desktop이 켜져 있어야 합니다.
-로컬 컨테이너 이미지는 `pgvector/pgvector:pg16`을 사용합니다.
+## 1) PostgreSQL 실행/확인
 
 ```bash
 cd "$(git rev-parse --show-toplevel)" && docker compose up -d postgres
 cd "$(git rev-parse --show-toplevel)" && docker compose ps
 ```
 
-- 기본 포트: `5432`
-- 기본 DB: `back`
-- 기본 계정: `DB_USERNAME / DB_PASSWORD`
-- 실제 값은 `.env`를 따릅니다.
-- DB 최초 초기화 시 `vector` extension이 자동 생성됩니다.
+## 2) Spring Boot 실행 (스키마 생성)
 
-## 2) Spring Boot 실행 (스키마 반영)
+- IntelliJ에서 `BackApplication`을 1회 실행
 
-- IntelliJ에서 `BackApplication`을 실행한다. (권장)
-- 대체 방법(터미널):
-
-```bash
-cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && ./gradlew bootRun
-```
-
-- `application-dev.yml`은 `DB_HOST/DB_PORT/DB_NAME/DB_USERNAME/DB_PASSWORD`를 사용합니다.
-- 앱 1회 기동 후 `problems`, `test_cases`, `tags`, `problem_tag_connect` 테이블이 생성됩니다.
-
-## 3) open-r1/codeforces 데이터 적재
-
-원칙: 원본 데이터 파일(parquet/json/csv 등)은 저장소에 커밋하지 않고 로컬에서만 사용합니다.
+## 3) 문제 데이터 적재
 
 ```bash
 cd "$(git rev-parse --show-toplevel)" && python3 -m pip install -U requests "psycopg[binary]"
 cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/load_openr1_verifiable.py --limit 200 --chunk-size 50
 ```
 
-- `--limit`은 "이번 실행에서 가져올 최대 문제 수"입니다.
-- 위 예시는 동작 확인용 샘플 적재(200건)입니다.
-- `--chunk-size`는 HF API 요청 1회당 조회 건수입니다.
-- 현재 로더는 HF API에서 바로 읽어 DB에 넣으며, 데이터 파일을 저장소에 저장하지 않습니다.
-- `input_format`, `output_format`은 `problems` 컬럼에 분리 저장됩니다.
-- 중복 판별은 `source_problem_id`(예: `852/A`)를 우선 사용합니다.
-- 같은 구간을 다시 실행하면 기존 문제는 건너뜁니다. (`skipped_existing_problem` 증가)
-- `difficulty`는 `EASY`, `MEDIUM`, `HARD` 3단계 enum 문자열로 저장됩니다.
-
-실행 후 요약 로그는 아래 형태로 출력됩니다. (숫자는 실행마다 달라집니다)
-
-```text
-[2026-03-30T10:42:15] load summary
-- rows_fetched: 200
-- rows_loaded: 173
-- problems_inserted: 160
-- skipped_existing_problem: 13
-- sample_tests: 346
-- hidden_tests: 1180
-```
-
-빠르게 동작 확인만 할 때는 10건만 먼저 적재해도 됩니다.
-
-```bash
-cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/load_openr1_verifiable.py --truncate --limit 10 --chunk-size 10
-```
-
-전체 적재에 가깝게 넣고 싶으면 `limit`을 충분히 크게 줍니다.
-
-```bash
-cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/load_openr1_verifiable.py --truncate --limit 10000 --chunk-size 100
-```
-
-- 실제 데이터가 `limit`보다 적으면 가능한 행까지만 적재하고 종료합니다.
-- 기본 DSN도 동일한 `DB_*` 환경변수를 사용합니다.
-- `--truncate`는 `problems`를 참조하는 연관 테이블까지 `CASCADE`로 비웁니다(개발 DB에서만 사용).
-- 샘플 데이터를 초기화 후 다시 넣을 때:
-
-```bash
-cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/load_openr1_verifiable.py --truncate --limit 200 --chunk-size 50
-```
-
-## 4) 언어 starter 생성 (선택)
-
-문제 상세 응답에서 `supportedLanguages/defaultLanguage/starterCodes`를 쓰려면 실행합니다.
+## 4) starter code 기본 생성
 
 ```bash
 cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/generate_problem_language_profiles.py --limit 200
 ```
 
-- 기본 생성 언어: `python3, java, c, cpp17, javascript`
-- 기본 선택 언어: `python3`
-- `(problem_id, language_code)` 기준 upsert
-
-실행 후 요약 로그 예시:
-
-```text
-[2026-03-30T10:45:02] generation summary
-- problems_targeted: 200
-- profiles_upserted: 1000
-- dry_run: False
-- languages: python3,java,c,cpp17,javascript
-```
-
-`load`를 `--truncate`로 다시 돌렸으면 아래도 함께 실행하세요.
-
-```bash
-cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/generate_problem_language_profiles.py --truncate --limit 200
-```
-
-문제별 커스텀 시그니처가 필요하면 override 파일을 사용합니다.
+## 5) starter code override 적용 (선택)
 
 ```bash
 cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/generate_problem_language_profiles.py --overrides-json scripts/starter_overrides.example.json
 ```
 
-override JSON 예시는 아래 구조를 따릅니다.
+의미(아주 간단히):
+- 4번은 전체 문제 starter를 기본 템플릿으로 생성
+- 5번은 `overrides-json`에 적어둔 문제만 덮어씀
 
-```json
-{
-  "problem_id": {
-    "9951": {
-      "java": "class Solution {\\n    public int solve(int[] nums) {\\n        return 0;\\n    }\\n}\\n"
-    }
-  },
-  "source_problem_id": {
-    "852/A": {
-      "java": "class Solution {\\n    public int[] twoSum(int[] nums, int target) {\\n        return new int[]{};\\n    }\\n}\\n"
-    }
-  }
-}
-```
-
-- `problem_id`: DB의 `problems.id` 기준으로 starter override
-- `source_problem_id`: 원본 문제 키(예: `852/A`) 기준으로 starter override
-- 두 조건이 동시에 있으면 `problem_id` override가 우선됩니다.
-
-특정 문제만 재생성하고 싶으면:
-
-```bash
-cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/generate_problem_language_profiles.py --problem-ids 1,2,3 --languages python3,java,c,cpp17,javascript --default-language python3
-```
-
-## 5) IntelliJ/DBeaver에서 확인
-
-### IntelliJ 접속 설정
-
-아래 값으로 Data Source를 생성합니다.
-- Host: `localhost`
-- Port: `5432`
-- User: `back`
-- Password: `.env`의 `DB_PASSWORD` 값
-- Database: `back`
-
-![IntelliJ PostgreSQL 데이터소스 설정 화면](./assets/intellij-postgresql-datasource.png)
-
-1. `Database` 탭에서 PostgreSQL 데이터소스 추가  
-   host=`localhost`, port=`5432`, db=`back`, user=`back`, password=`.env의 DB_PASSWORD`
-2. 아래 쿼리로 적재/생성 결과 확인
-
-```sql
-select count(*) as problems from problems;
-select count(*) as tags from tags;
-select count(*) as problem_tag_connect from problem_tag_connect;
-select count(*) as test_cases from test_cases;
-select count(*) as language_profiles from problem_language_profiles;
-
-select id, source_problem_id, title, difficulty, difficulty_rating, input_mode, judge_type
-from problems
-order by id desc
-limit 20;
-
-select p.id, p.title, lp.language_code, lp.is_default
-from problems p
-join problem_language_profiles lp on lp.problem_id = p.id
-order by p.id desc, lp.is_default desc, lp.language_code asc
-limit 30;
-```
-
-빠른 확인 기준:
-- `language_profiles`가 `problems * 5`에 가깝게 나오면 기본 5개 언어 starter가 정상 생성된 상태입니다.
-- `is_default = true` 행은 문제당 1개여야 합니다.
-
-### DBeaver 접속 설정
-
-1. `Database > New Database Connection > PostgreSQL`
-2. Host=`localhost`, Port=`5432`, Database=`back`, User=`back`, Password=`.env의 DB_PASSWORD`
-3. `Test Connection` 성공 후 `Finish`
-4. 좌측 `Database Navigator`에서 `Schemas > public > Tables` 확인
-
-## 6) 자주 나는 오류
-
-- `SyntaxError: future feature annotations is not defined`
-  - 원인: Python 3.6 이하로 스크립트를 실행한 경우
-  - 조치: `python3 --version` 확인 후 3.9+로 실행
-  - 예시:
-    ```bash
-    pyenv local 3.10.13
-    exec "$SHELL" -l
-    python3 --version
-    ```
-
-- `FATAL: password authentication failed for user "${DB_USERNAME}"`
-  - 원인: `.env`가 export되지 않아 플레이스홀더 문자열이 그대로 들어간 경우
-  - 조치: `set -a && source .env && set +a` 후 재실행
-
-- `relation "problems" does not exist`
-  - 원인: 스키마 생성 전에 로더를 먼저 실행한 경우
-  - 조치: `BackApplication` 1회 실행 후 다시 로더 실행
-
-- `null value in column "id" ... violates not-null constraint`
-  - 원인: 스키마 생성이 덜 되었거나 로더 실행 시점에 시퀀스를 찾지 못한 경우
-  - 조치: `BackApplication`을 먼저 1회 실행 후 로더를 다시 실행
-
-- `type "vector" does not exist`
-  - 원인: 기존 볼륨(이전 postgres 이미지)으로 실행 중이어서 pgvector extension이 아직 없는 경우
-  - 조치: 아래 중 하나를 수행
-    - `docker compose exec postgres psql -U "$DB_USERNAME" -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS vector;"`
-    - 또는 개발용이면 `docker compose down -v` 후 다시 `docker compose up -d postgres`로 볼륨을 재초기화
-
-- 현재 폴더가 `docs`이면 아래처럼 실행해도 됩니다.
-
-```bash
-set -a && source ../.env && set +a && python3 ../scripts/load_openr1_verifiable.py --limit 200 --chunk-size 50
-```
-
-## 7) 마무리 체크
-
-- 문서의 모든 명령어 블록이 닫혀 있는지 확인합니다.
-- `docker compose ps`에서 `postgres`가 `healthy` 상태인지 확인합니다.
+예시(`scripts/starter_overrides.example.json` 기준):
+- `source_problem_id = "852/A"`의 `java` starter만 지정한 코드로 교체
+- 그 외 언어(`python3` 등)는 4번에서 만든 기본 starter 유지

--- a/scripts/generate_problem_language_profiles.py
+++ b/scripts/generate_problem_language_profiles.py
@@ -31,6 +31,7 @@ import json
 import os
 import re
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -38,6 +39,27 @@ from typing import Any
 psycopg = None
 
 DEFAULT_LANGUAGES = ["python3", "java", "c", "cpp17", "javascript"]
+
+
+@dataclass
+class SequenceBlockAllocator:
+    """시퀀스 증가폭 단위로 id 블록을 예약하고 로컬에서 순차 배정한다."""
+
+    sequence_name: str
+    block_size: int
+    next_candidate: int | None = None
+    block_end: int | None = None
+
+    def allocate(self, cur: psycopg.Cursor[Any]) -> int:
+        if self.next_candidate is None or self.block_end is None or self.next_candidate > self.block_end:
+            cur.execute("SELECT nextval(%s::regclass)", (self.sequence_name,))
+            block_start = int(cur.fetchone()[0])
+            self.next_candidate = block_start
+            self.block_end = block_start + self.block_size - 1
+
+        allocated_id = self.next_candidate
+        self.next_candidate += 1
+        return allocated_id
 
 
 def ensure_psycopg() -> None:
@@ -110,6 +132,26 @@ def resolve_id_sequence(
         f"Cannot resolve sequence/default for {table_name}.id. "
         "Run BackApplication once to create schema or fix id generation."
     )
+
+
+def resolve_sequence_increment(cur: psycopg.Cursor[Any], sequence_name: str) -> int:
+    """시퀀스 increment 값을 조회한다."""
+    cur.execute(
+        """
+        SELECT seqincrement
+        FROM pg_catalog.pg_sequence
+        WHERE seqrelid = %s::regclass
+        """,
+        (sequence_name,),
+    )
+    row = cur.fetchone()
+    if not row or row[0] is None:
+        raise RuntimeError(f"Cannot resolve increment for sequence: {sequence_name}")
+
+    increment = int(row[0])
+    if increment <= 0:
+        raise RuntimeError(f"Invalid increment {increment} for sequence: {sequence_name}")
+    return increment
 
 
 def slugify(text: str, max_len: int = 40) -> str:
@@ -250,25 +292,40 @@ def resolve_starter(
 
 def upsert_profile(
     cur: psycopg.Cursor[Any],
-    id_sequence: str | None,
+    id_allocator: SequenceBlockAllocator | None,
     problem_id: int,
     language_code: str,
     starter_code: str,
     is_default: bool,
 ) -> None:
-    if id_sequence:
+    # update가 먼저 성공하면 id를 새로 소비하지 않는다.
+    cur.execute(
+        """
+        UPDATE problem_language_profiles
+        SET starter_code = %s,
+            is_default = %s
+        WHERE problem_id = %s
+          AND language_code = %s
+        """,
+        (starter_code, is_default, problem_id, language_code),
+    )
+    if cur.rowcount:
+        return
+
+    if id_allocator:
+        allocated_id = id_allocator.allocate(cur)
         cur.execute(
-            f"""
+            """
             INSERT INTO problem_language_profiles
                 (id, problem_id, language_code, starter_code, is_default)
             VALUES
-                (nextval('{id_sequence}'), %s, %s, %s, %s)
+                (%s, %s, %s, %s, %s)
             ON CONFLICT (problem_id, language_code)
             DO UPDATE SET
                 starter_code = EXCLUDED.starter_code,
                 is_default = EXCLUDED.is_default
             """,
-            (problem_id, language_code, starter_code, is_default),
+            (allocated_id, problem_id, language_code, starter_code, is_default),
         )
     else:
         cur.execute(
@@ -415,6 +472,12 @@ def main() -> int:
                 "problem_language_profiles",
                 ("problem_language_profile_id_seq",),
             )
+            profile_id_allocator: SequenceBlockAllocator | None = None
+            if profile_id_seq:
+                profile_id_allocator = SequenceBlockAllocator(
+                    sequence_name=profile_id_seq,
+                    block_size=resolve_sequence_increment(cur, profile_id_seq),
+                )
 
             query, params = build_problem_query(problem_ids, args.limit)
             cur.execute(query, params)
@@ -425,7 +488,10 @@ def main() -> int:
             stats["problems_targeted"] = len(rows)
 
             if args.truncate and not args.dry_run:
-                cur.execute("TRUNCATE TABLE problem_language_profiles RESTART IDENTITY")
+                cur.execute("TRUNCATE TABLE problem_language_profiles")
+                if profile_id_seq:
+                    # JPA sequence는 table-owned identity가 아니므로 명시적으로 초기화한다.
+                    cur.execute("SELECT setval(%s::regclass, 1, false)", (profile_id_seq,))
 
             for problem_id, source_problem_id, title in rows:
                 for language in languages:
@@ -443,7 +509,7 @@ def main() -> int:
 
                     upsert_profile(
                         cur,
-                        id_sequence=profile_id_seq,
+                        id_allocator=profile_id_allocator,
                         problem_id=int(problem_id),
                         language_code=language,
                         starter_code=starter,

--- a/scripts/load_openr1_verifiable.py
+++ b/scripts/load_openr1_verifiable.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import os
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 from urllib.parse import quote
@@ -34,6 +35,27 @@ HF_DATASET = "open-r1/codeforces"
 HF_CONFIG = "verifiable"
 HF_SPLIT = "train"
 # open-r1 rows API에서 `tags` 필드를 제공한다. (list[str])
+
+
+@dataclass
+class SequenceBlockAllocator:
+    """시퀀스 증가폭 단위로 id 블록을 예약하고 로컬에서 순차 배정한다."""
+
+    sequence_name: str
+    block_size: int
+    next_candidate: int | None = None
+    block_end: int | None = None
+
+    def allocate(self, cur: psycopg.Cursor[Any]) -> int:
+        if self.next_candidate is None or self.block_end is None or self.next_candidate > self.block_end:
+            cur.execute("SELECT nextval(%s::regclass)", (self.sequence_name,))
+            block_start = int(cur.fetchone()[0])
+            self.next_candidate = block_start
+            self.block_end = block_start + self.block_size - 1
+
+        allocated_id = self.next_candidate
+        self.next_candidate += 1
+        return allocated_id
 
 
 def ensure_psycopg() -> None:
@@ -82,7 +104,10 @@ def get_rows(offset: int, length: int) -> list[dict[str, Any]]:
 
 
 def get_or_create_tag(
-    cur: psycopg.Cursor[Any], cache: dict[str, int], name: str, tag_id_sequence: str | None
+    cur: psycopg.Cursor[Any],
+    cache: dict[str, int],
+    name: str,
+    tag_id_allocator: SequenceBlockAllocator | None,
 ) -> int:
     """태그를 upsert 성격으로 조회/생성한다."""
     cached = cache.get(name)
@@ -96,10 +121,11 @@ def get_or_create_tag(
         cache[name] = tag_id
         return tag_id
 
-    if tag_id_sequence:
+    if tag_id_allocator:
+        tag_id = tag_id_allocator.allocate(cur)
         cur.execute(
-            f"INSERT INTO tags (id, name) VALUES (nextval('{tag_id_sequence}'), %s) RETURNING id",
-            (name,),
+            "INSERT INTO tags (id, name) VALUES (%s, %s) RETURNING id",
+            (tag_id, name),
         )
     else:
         cur.execute("INSERT INTO tags (name) VALUES (%s) RETURNING id", (name,))
@@ -217,8 +243,28 @@ def resolve_id_sequence(
     )
 
 
+def resolve_sequence_increment(cur: psycopg.Cursor[Any], sequence_name: str) -> int:
+    """시퀀스 increment 값을 조회한다."""
+    cur.execute(
+        """
+        SELECT seqincrement
+        FROM pg_catalog.pg_sequence
+        WHERE seqrelid = %s::regclass
+        """,
+        (sequence_name,),
+    )
+    row = cur.fetchone()
+    if not row or row[0] is None:
+        raise RuntimeError(f"Cannot resolve increment for sequence: {sequence_name}")
+
+    increment = int(row[0])
+    if increment <= 0:
+        raise RuntimeError(f"Invalid increment {increment} for sequence: {sequence_name}")
+    return increment
+
+
 def insert_problem(
-    cur: psycopg.Cursor[Any], row: dict[str, Any], problem_id_sequence: str | None
+    cur: psycopg.Cursor[Any], row: dict[str, Any], problem_id_allocator: SequenceBlockAllocator | None
 ) -> tuple[int, bool]:
     """problems 테이블에 1건 적재하고 (problem_id, 신규삽입여부)를 반환한다."""
     rating = row.get("rating")
@@ -233,10 +279,11 @@ def insert_problem(
     if existing is not None:
         return existing, False
 
-    if problem_id_sequence:
-        # id 기본값이 없을 때는 시퀀스를 명시적으로 사용한다.
+    if problem_id_allocator:
+        # 시퀀스 증가폭(예: 50) 단위로 예약한 블록 안에서 연속 id를 배정한다.
+        allocated_problem_id = problem_id_allocator.allocate(cur)
         cur.execute(
-            f"""
+            """
             INSERT INTO problems (
                 id,
                 source_problem_id,
@@ -251,10 +298,11 @@ def insert_problem(
                 input_mode,
                 checker_code,
                 judge_type
-            ) VALUES (nextval('{problem_id_sequence}'), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
+                allocated_problem_id,
                 source_problem_id,
                 title,
                 difficulty,
@@ -311,15 +359,15 @@ def insert_problem_tags(
     tag_cache: dict[str, int],
     problem_id: int,
     tags: list[str],
-    tag_id_sequence: str | None,
-    problem_tag_connect_id_sequence: str | None,
+    tag_id_allocator: SequenceBlockAllocator | None,
+    problem_tag_connect_id_allocator: SequenceBlockAllocator | None,
 ) -> None:
     """문제-태그 연결 테이블을 채운다(중복 연결 방지)."""
     for tag in tags:
         tag_name = tag.strip()
         if not tag_name:
             continue
-        tag_id = get_or_create_tag(cur, tag_cache, tag_name, tag_id_sequence)
+        tag_id = get_or_create_tag(cur, tag_cache, tag_name, tag_id_allocator)
         cur.execute(
             """
             SELECT 1
@@ -331,13 +379,14 @@ def insert_problem_tags(
         )
         if cur.fetchone():
             continue
-        if problem_tag_connect_id_sequence:
+        if problem_tag_connect_id_allocator:
+            allocated_connect_id = problem_tag_connect_id_allocator.allocate(cur)
             cur.execute(
-                f"""
+                """
                 INSERT INTO problem_tag_connect (id, problem_id, tag_id)
-                VALUES (nextval('{problem_tag_connect_id_sequence}'), %s, %s)
+                VALUES (%s, %s, %s)
                 """,
-                (problem_id, tag_id),
+                (allocated_connect_id, problem_id, tag_id),
             )
         else:
             cur.execute(
@@ -355,7 +404,7 @@ def insert_test_cases(
     examples: list[dict[str, str]],
     official_tests: list[dict[str, str]],
     max_tests_per_problem: int,
-    test_case_id_sequence: str | None,
+    test_case_id_allocator: SequenceBlockAllocator | None,
 ) -> tuple[int, int]:
     """examples는 sample, official_tests는 hidden 테스트로 분리 적재한다."""
     inserted_sample = 0
@@ -365,13 +414,14 @@ def insert_test_cases(
     hidden_cases = official_tests[: max_tests_per_problem]
 
     for case in sample_cases:
-        if test_case_id_sequence:
+        if test_case_id_allocator:
+            allocated_test_case_id = test_case_id_allocator.allocate(cur)
             cur.execute(
-                f"""
+                """
                 INSERT INTO test_cases (id, problem_id, input, expected_output, is_sample)
-                VALUES (nextval('{test_case_id_sequence}'), %s, %s, %s, true)
+                VALUES (%s, %s, %s, %s, true)
                 """,
-                (problem_id, case.get("input", ""), case.get("output", "")),
+                (allocated_test_case_id, problem_id, case.get("input", ""), case.get("output", "")),
             )
         else:
             cur.execute(
@@ -384,13 +434,14 @@ def insert_test_cases(
         inserted_sample += 1
 
     for case in hidden_cases:
-        if test_case_id_sequence:
+        if test_case_id_allocator:
+            allocated_test_case_id = test_case_id_allocator.allocate(cur)
             cur.execute(
-                f"""
+                """
                 INSERT INTO test_cases (id, problem_id, input, expected_output, is_sample)
-                VALUES (nextval('{test_case_id_sequence}'), %s, %s, %s, false)
+                VALUES (%s, %s, %s, %s, false)
                 """,
-                (problem_id, case.get("input", ""), case.get("output", "")),
+                (allocated_test_case_id, problem_id, case.get("input", ""), case.get("output", "")),
             )
         else:
             cur.execute(
@@ -507,6 +558,10 @@ def main() -> int:
     tag_id_sequence: str | None = None
     test_case_id_sequence: str | None = None
     problem_tag_connect_id_sequence: str | None = None
+    problem_id_allocator: SequenceBlockAllocator | None = None
+    tag_id_allocator: SequenceBlockAllocator | None = None
+    test_case_id_allocator: SequenceBlockAllocator | None = None
+    problem_tag_connect_id_allocator: SequenceBlockAllocator | None = None
 
     try:
         if not args.dry_run:
@@ -520,9 +575,38 @@ def main() -> int:
             problem_tag_connect_id_sequence = resolve_id_sequence(
                 cur, "problem_tag_connect", ("problem_tag_id_seq",)
             )
+            if problem_id_sequence:
+                problem_id_allocator = SequenceBlockAllocator(
+                    sequence_name=problem_id_sequence,
+                    block_size=resolve_sequence_increment(cur, problem_id_sequence),
+                )
+            if tag_id_sequence:
+                tag_id_allocator = SequenceBlockAllocator(
+                    sequence_name=tag_id_sequence,
+                    block_size=resolve_sequence_increment(cur, tag_id_sequence),
+                )
+            if test_case_id_sequence:
+                test_case_id_allocator = SequenceBlockAllocator(
+                    sequence_name=test_case_id_sequence,
+                    block_size=resolve_sequence_increment(cur, test_case_id_sequence),
+                )
+            if problem_tag_connect_id_sequence:
+                problem_tag_connect_id_allocator = SequenceBlockAllocator(
+                    sequence_name=problem_tag_connect_id_sequence,
+                    block_size=resolve_sequence_increment(cur, problem_tag_connect_id_sequence),
+                )
             if args.truncate:
                 # problems를 참조하는 연관 테이블(FK)까지 함께 비우기 위해 CASCADE를 사용한다.
-                cur.execute("TRUNCATE TABLE test_cases, problem_tag_connect, tags, problems RESTART IDENTITY CASCADE")
+                cur.execute("TRUNCATE TABLE test_cases, problem_tag_connect, tags, problems CASCADE")
+                # JPA sequence는 table-owned identity가 아니므로 명시적으로 초기화한다.
+                if problem_id_sequence:
+                    cur.execute("SELECT setval(%s::regclass, 1, false)", (problem_id_sequence,))
+                if tag_id_sequence:
+                    cur.execute("SELECT setval(%s::regclass, 1, false)", (tag_id_sequence,))
+                if test_case_id_sequence:
+                    cur.execute("SELECT setval(%s::regclass, 1, false)", (test_case_id_sequence,))
+                if problem_tag_connect_id_sequence:
+                    cur.execute("SELECT setval(%s::regclass, 1, false)", (problem_tag_connect_id_sequence,))
                 print("truncated tables")
 
         remaining = args.limit
@@ -551,7 +635,7 @@ def main() -> int:
 
                 # dry-run 모드가 아니면 DB 커서는 항상 존재한다.
                 assert cur is not None
-                problem_id, inserted = insert_problem(cur, row, problem_id_sequence)
+                problem_id, inserted = insert_problem(cur, row, problem_id_allocator)
                 if not inserted:
                     stats["skipped_existing_problem"] += 1
                     continue
@@ -562,8 +646,8 @@ def main() -> int:
                     tag_cache,
                     problem_id,
                     normalize_tags(row.get("tags")),
-                    tag_id_sequence,
-                    problem_tag_connect_id_sequence,
+                    tag_id_allocator,
+                    problem_tag_connect_id_allocator,
                 )
                 sample_n, hidden_n = insert_test_cases(
                     cur,
@@ -571,7 +655,7 @@ def main() -> int:
                     row.get("examples") or [],
                     row.get("official_tests") or [],
                     args.max_tests_per_problem,
-                    test_case_id_sequence,
+                    test_case_id_allocator,
                 )
                 stats["sample_tests"] += sample_n
                 stats["hidden_tests"] += hidden_n


### PR DESCRIPTION
## 한눈에 보는 원인/해결
### 왜 ID가 50씩 올라갔나?
- 엔티티 `@SequenceGenerator(allocationSize = 50)` 때문에 DB 시퀀스가 `increment_by = 50`으로 생성됩니다.
- 기존 적재 스크립트는 **행마다 `nextval(...)`를 직접 호출**했습니다.
- 그래서 DB가 `1 -> 51 -> 101 ...` 값을 매번 내려줘서, ID가 50씩 점프했습니다.

### 어떻게 고쳤나?
- 스크립트에서 `nextval`을 행마다 호출하지 않고,
  **시퀀스 블록(50개)을 한 번 예약한 뒤 내부에서 1씩 배정**하도록 변경했습니다.
- `--truncate` 시에는 JPA 시퀀스를 `setval(..., 1, false)`로 명시 초기화해서
  새로 적재하면 다시 1부터 시작하도록 맞췄습니다.
- `problem_language_profiles` 생성 스크립트도 동일하게 수정했습니다.

### 결과
- `problems.id` / `problem_language_profiles.id`가 적재 시 **연속값(1,2,3...)**으로 들어갑니다.
- DB 시퀀스의 `increment_by = 50` 설정은 유지됩니다.

## 변경 내용
- `scripts/load_openr1_verifiable.py`
  - 시퀀스 블록 할당 방식으로 ID 배정
  - `nextval` 행 단위 호출 제거
  - `--truncate` 시 관련 시퀀스 명시 초기화
- `scripts/generate_problem_language_profiles.py`
  - 동일한 블록 할당 방식 적용
  - upsert 시 update 선처리로 불필요한 ID 소비 방지
  - `--truncate` 시 `problem_language_profile_id_seq` 명시 초기화
- `docs/local-db-compose-guide.md`
  - 로컬 적재 가이드 5단계로 단순화

## 검증
- `python3 -m py_compile scripts/load_openr1_verifiable.py scripts/generate_problem_language_profiles.py`
- `load --truncate --limit 10 --chunk-size 10` 실행 후 `problems.id` 연속 증가 확인
- `generate --truncate --limit 10` 실행 후 `problem_language_profiles.id` 연속 증가 확인
- 두 시퀀스 `increment_by=50` 유지 확인

## 참고
- 배치를 중간에 끊고 재실행하면(특히 `--truncate` 없이) 미사용 블록 때문에 간격이 생길 수 있습니다.
- 완전 새로 적재할 때는 `--truncate`로 시작하면 가장 예측 가능한 결과를 얻을 수 있습니다.
