### PR TITLE
[refactor] 로그인 시 refreshToken을 redis에 저장, accessToken 재발급

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:junit-jupiter")
-    testImplementation("org.testcontainers:redis")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:redis")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
 }
 

--- a/src/main/java/com/back/domain/auth/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/auth/controller/AuthController.java
@@ -1,11 +1,57 @@
 package com.back.domain.auth.auth.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.jwt.JwtProvider;
+import com.back.global.jwt.RefreshTokenService;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/auth")
-public class AuthController {}
+public class AuthController {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final MemberRepository memberRepository;
+    private final Rq rq;
+
+    // accessToken 재발급 — refreshToken 쿠키로 검증
+    @PostMapping("/reissue")
+    public RsData<Void> reissue() {
+        String refreshToken = rq.getCookieValue("refreshToken", null);
+
+        if (refreshToken == null || !jwtProvider.validateToken(refreshToken)) {
+            throw new ServiceException("AUTH_401", "유효하지 않은 refreshToken입니다");
+        }
+
+        Claims claims = jwtProvider.parseToken(refreshToken);
+        Long memberId = Long.parseLong(claims.getSubject());
+
+        // Redis에 저장된 토큰과 비교
+        String stored = refreshTokenService.get(memberId);
+        if (!refreshToken.equals(stored)) {
+            throw new ServiceException("AUTH_401", "만료되었거나 이미 사용된 refreshToken입니다");
+        }
+
+        // 회원 정보 조회 후 새 accessToken 발급
+        Member member = memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new ServiceException("AUTH_404", "존재하지 않는 회원입니다"));
+
+        String newAccessToken = jwtProvider.createToken(
+                member.getId(), member.getEmail(), member.getNickname(), member.getRole().getKey());
+
+        rq.setCookie("accessToken", newAccessToken);
+        return RsData.of("200", "accessToken이 재발급되었습니다");
+    }
+}

--- a/src/main/java/com/back/domain/auth/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/auth/controller/AuthController.java
@@ -49,7 +49,10 @@ public class AuthController {
                 .orElseThrow(() -> new ServiceException("AUTH_404", "존재하지 않는 회원입니다"));
 
         String newAccessToken = jwtProvider.createToken(
-                member.getId(), member.getEmail(), member.getNickname(), member.getRole().getKey());
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getRole().getKey());
 
         rq.setCookie("accessToken", newAccessToken);
         return RsData.of("200", "accessToken이 재발급되었습니다");

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -6,10 +6,12 @@ import com.back.domain.battle.result.dto.MyBattleResultsResponse;
 import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.dto.JoinRequest;
 import com.back.domain.member.member.dto.LoginRequest;
+import com.back.domain.member.member.dto.LoginTokens;
 import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.exception.ServiceException;
+import com.back.global.jwt.RefreshTokenService;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 
@@ -22,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
     private final MemberService memberService;
     private final BattleResultService battleResultService;
+    private final RefreshTokenService refreshTokenService;
     private final Rq rq;
 
     // 회원가입
@@ -33,15 +36,21 @@ public class MemberController {
     // 로그인 — 발급된 토큰을 HttpOnly 쿠키에 저장
     @PostMapping("/login")
     public RsData<Void> login(@Valid @RequestBody LoginRequest req) {
-        String accessToken = memberService.login(req);
-        rq.setCookie("accessToken", accessToken);
+        LoginTokens tokens = memberService.login(req);
+        rq.setCookie("accessToken", tokens.accessToken());
+        rq.setCookie("refreshToken", tokens.refreshToken());
         return RsData.of("200", "로그인 성공");
     }
 
-    // 로그아웃 — accessToken 쿠키 만료
+    // 로그아웃 — 두 쿠키 만료 + Redis refreshToken 삭제
     @PostMapping("/logout")
     public RsData<Void> logout() {
+        Member actor = rq.getActor();
+        if (actor != null) {
+            refreshTokenService.delete(actor.getId());
+        }
         rq.deleteCookie("accessToken");
+        rq.deleteCookie("refreshToken");
         return RsData.of("200", "로그아웃 성공");
     }
 

--- a/src/main/java/com/back/domain/member/member/dto/LoginTokens.java
+++ b/src/main/java/com/back/domain/member/member/dto/LoginTokens.java
@@ -1,0 +1,3 @@
+package com.back.domain.member.member.dto;
+
+public record LoginTokens(String accessToken, String refreshToken) {}

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -8,11 +8,13 @@ import org.springframework.validation.annotation.Validated;
 
 import com.back.domain.member.member.dto.JoinRequest;
 import com.back.domain.member.member.dto.LoginRequest;
+import com.back.domain.member.member.dto.LoginTokens;
 import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.global.exception.ServiceException;
 import com.back.global.jwt.JwtProvider;
+import com.back.global.jwt.RefreshTokenService;
 import com.back.global.rsData.RsData;
 
 import jakarta.validation.Valid;
@@ -25,6 +27,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
 
     public RsData<Void> join(@Valid JoinRequest req) {
 
@@ -69,8 +72,8 @@ public class MemberService {
         return RsData.of("200", "내 정보 조회 성공", MyInfoResponse.from(member));
     }
 
-    // 로그인 — 인증 성공 시 accessToken 문자열 반환 (쿠키 설정은 컨트롤러가 담당)
-    public String login(@Valid LoginRequest req) {
+    // 로그인 — 인증 성공 시 accessToken + refreshToken 반환 (쿠키 설정은 컨트롤러가 담당)
+    public LoginTokens login(@Valid LoginRequest req) {
 
         // req null 방어
         if (req == null) {
@@ -90,11 +93,17 @@ public class MemberService {
             throw new ServiceException("MEMBER_401", "이메일 또는 비밀번호가 올바르지 않습니다");
         }
 
-        // JWT 토큰 생성 후 반환
-        return jwtProvider.createToken(
+        // accessToken + refreshToken 생성
+        String accessToken = jwtProvider.createToken(
                 member.getId(),
                 member.getEmail(),
                 member.getNickname(),
                 member.getRole().getKey());
+        String refreshToken = jwtProvider.createRefreshToken(member.getId());
+
+        // refreshToken Redis에 저장
+        refreshTokenService.save(member.getId(), refreshToken);
+
+        return new LoginTokens(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/back/global/jwt/JwtProvider.java
+++ b/src/main/java/com/back/global/jwt/JwtProvider.java
@@ -23,6 +23,9 @@ public class JwtProvider {
     @Value("${jwt.expiration}")
     private long expiration; // ms 단위
 
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpiration; // ms 단위
+
     private SecretKey key;
 
     // 의존성 주입 완료 후, JWT 서명에 사용할 HMAC-SHA 키를 생성
@@ -43,6 +46,21 @@ public class JwtProvider {
                 .expiration(new Date(now.getTime() + expiration))
                 .signWith(key, Jwts.SIG.HS256)
                 .compact();
+    }
+
+    // refreshToken 생성 — memberId만 담아 최소화
+    public String createRefreshToken(Long memberId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + refreshExpiration))
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public long getRefreshExpiration() {
+        return refreshExpiration;
     }
 
     // 토큰 파싱

--- a/src/main/java/com/back/global/jwt/RefreshTokenService.java
+++ b/src/main/java/com/back/global/jwt/RefreshTokenService.java
@@ -1,0 +1,36 @@
+package com.back.global.jwt;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final String KEY_PREFIX = "RT:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final JwtProvider jwtProvider;
+
+    public void save(Long memberId, String refreshToken) {
+        log.debug("Redis save: key={}, ttl={}ms", KEY_PREFIX + memberId, jwtProvider.getRefreshExpiration());
+        redisTemplate
+                .opsForValue()
+                .set(KEY_PREFIX + memberId, refreshToken, jwtProvider.getRefreshExpiration(), TimeUnit.MILLISECONDS);
+        log.debug("Redis save complete: key={}", KEY_PREFIX + memberId);
+    }
+
+    public String get(Long memberId) {
+        return redisTemplate.opsForValue().get(KEY_PREFIX + memberId);
+    }
+
+    public void delete(Long memberId) {
+        redisTemplate.delete(KEY_PREFIX + memberId);
+    }
+}

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -36,6 +36,8 @@ public class SecurityConfig {
                                 "/api/v1/members/login",
                                 // 로그아웃은 인증 없이도 호출 가능해야 함
                                 "/api/v1/members/logout",
+                                // refreshToken으로 accessToken 재발급 — 인증 없이 접근 허용
+                                "/api/v1/auth/reissue",
                                 // WebSocket 핸드셰이크는 HTTP 레벨에서 허용:
                                 // - 로컬 환경: JWT 쿠키가 자동 전송되어 JwtAuthenticationFilter가 인증 처리
                                 // - 배포 환경: cross-origin으로 쿠키 자동 전송 불가 → 쿠키 없이 핸드셰이크 허용

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,8 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET:back-application-jwt-secret-key-must-be-at-least-32-bytes}
-  expiration: 3600000 # 1시간 (ms)
+  expiration: 360000 # 30초 (ms)
+  refresh-expiration: 604800000 # 7일 (ms)
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
 logging:

--- a/src/test/java/com/back/BackApplicationTests.java
+++ b/src/test/java/com/back/BackApplicationTests.java
@@ -1,12 +1,10 @@
 package com.back;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class BackApplicationTests {
+import com.back.global.IntegrationTestBase;
+
+class BackApplicationTests extends IntegrationTestBase {
 
     @Test
     void contextLoads() {}

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerBattleResultsTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerBattleResultsTest.java
@@ -20,19 +20,21 @@ import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.globalExceptionHandler.GlobalExceptionHandler;
+import com.back.global.jwt.RefreshTokenService;
 import com.back.global.rq.Rq;
 
 class MemberControllerBattleResultsTest {
 
     private final MemberService memberService = mock(MemberService.class);
     private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
     private final Rq rq = mock(Rq.class);
 
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
-        MemberController controller = new MemberController(memberService, battleResultService, rq);
+        MemberController controller = new MemberController(memberService, battleResultService, refreshTokenService, rq);
 
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -14,21 +14,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
+import com.back.global.IntegrationTestBase;
 
-@SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
-class MemberControllerTest {
+class MemberControllerTest extends IntegrationTestBase {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/back/domain/problem/pick/repository/ProblemPickQueryRepositoryTest.java
+++ b/src/test/java/com/back/domain/problem/pick/repository/ProblemPickQueryRepositoryTest.java
@@ -7,14 +7,11 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.back.domain.problem.problem.enums.DifficultyLevel;
+import com.back.global.IntegrationTestBase;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class ProblemPickQueryRepositoryTest {
+class ProblemPickQueryRepositoryTest extends IntegrationTestBase {
 
     @Autowired
     private ProblemPickQueryRepository problemPickQueryRepository;

--- a/src/test/java/com/back/global/IntegrationTestBase.java
+++ b/src/test/java/com/back/global/IntegrationTestBase.java
@@ -1,0 +1,12 @@
+package com.back.global;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.back.global.config.TestcontainersConfiguration;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
+public abstract class IntegrationTestBase {}

--- a/src/test/java/com/back/global/config/TestcontainersConfiguration.java
+++ b/src/test/java/com/back/global/config/TestcontainersConfiguration.java
@@ -1,0 +1,17 @@
+package com.back.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfiguration {
+
+    @Bean
+    @ServiceConnection(name = "redis")
+    GenericContainer<?> redisContainer() {
+        return new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #113 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #113 

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
기존에는 accessToken(1시간)만 발급하여 만료 시 강제 로그아웃되는 문제가 있었습니다.
Redis를 활용한 refreshToken을 도입해 accessToken 재발급 흐름을 구현했습니다.   

---

## ✅ 주요 변경 사항
### 신규 파일                                                                                                                                                                  
  - `RefreshTokenService` — Redis에 `RT:{memberId}` 키로 refreshToken 저장/조회/삭제
  - `LoginTokens` — 로그인 응답용 record DTO (accessToken, refreshToken)                                                                                                         
                                                                                                                                                                                 
### 수정 파일                                                                                                                                                                  
  - `JwtProvider` — `createRefreshToken()` 추가 (만료 7일, memberId만 포함)                                                                                                      
  - `MemberService` — 로그인 시 refreshToken 생성 및 Redis 저장                                                                                                                  
  - `MemberController` — 로그인/로그아웃 시 두 쿠키(accessToken, refreshToken) 처리                                                                                              
  - `AuthController` — `POST /api/v1/auth/reissue` 엔드포인트 추가                                                                                                               
  - `SecurityConfig` — `/api/v1/auth/reissue` permitAll 추가                                                                                                                     
  - `application.yml` — `jwt.refresh-expiration: 604800000` (7일) 추가                                                                                                           
                                                                                                                                                                                 
## 토큰 흐름                                                                                                                                                                 
  1. **로그인** → accessToken(1시간) + refreshToken(7일) 쿠키 발급, Redis 저장                                                                                                   
  2. **재발급** → `POST /api/v1/auth/reissue` — refreshToken 검증 + Redis 일치 확인 → 새 accessToken 발급                                                                        
  3. **로그아웃** → 두 쿠키 만료 + Redis에서 refreshToken 삭제                                                                                                                   
                                                                                                                                                                                 
## 설계 결정                                                                                                                                                                   
  - **토큰 로테이션 미적용** — 다중 디바이스 동시 사용 시 Race Condition 발생 우려                                                                                               
  - **Redis 선택 이유** — 빠른 조회, TTL 자동 관리, 강제 로그아웃 지원  

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
1. `POST /api/v1/members/login` → 두 쿠키 발급 확인                                                                                                                            
2. accessToken 만료 후 `GET /api/v1/members/me` → 401 확인                                                                                                                     3. `POST /api/v1/auth/reissue` → 새 accessToken 발급 확인                                                                                                                      
4. `POST /api/v1/members/logout` → `redis-cli KEYS "RT:*"` 비어있는지 확인    

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
