### PR TITLE
[feat] 중도 퇴장 & 진행 중 방 조회 구현

### DIFF
--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
@@ -58,6 +58,10 @@ public class BattleParticipant extends BaseEntity {
         this.status = BattleParticipantStatus.ABANDONED;
     }
 
+    public void quit() {
+        this.status = BattleParticipantStatus.QUIT;
+    }
+
     public void applyResult(int rank, long delta) {
         this.finalRank = rank;
         this.scoreDelta = delta;

--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipantStatus.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipantStatus.java
@@ -4,5 +4,6 @@ public enum BattleParticipantStatus {
     READY,
     PLAYING,
     EXIT,
-    ABANDONED
+    ABANDONED,
+    QUIT
 }

--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.member.member.entity.Member;
@@ -67,8 +68,28 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
             select p from BattleParticipant p
             join fetch p.battleRoom r
             where p.member.id = :memberId
-              and p.status = com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.PLAYING
-              and r.status = com.back.domain.battle.battleroom.entity.BattleRoomStatus.PLAYING
+              and p.status = :status
+              and r.status = :roomStatus
             """)
-    Optional<BattleParticipant> findPlayingParticipantByMemberId(@Param("memberId") Long memberId);
+    Optional<BattleParticipant> findPlayingParticipantByMemberId(
+            @Param("memberId") Long memberId,
+            @Param("status") BattleParticipantStatus status,
+            @Param("roomStatus") BattleRoomStatus roomStatus);
+
+    /**
+     * 현재 배틀 중인 방에서 ABANDONED 상태인 특정 유저의 참여자 정보를 조회
+     * 네트워크 이탈로 ABANDONED된 유저가 사이트에 재접속했을 때 진행 중인 방이 있는지 확인하는 용도
+     * join fetch p.battleRoom을 쓰는 이유는 서비스에서 roomId를 꺼낼 때 N+1 방지
+     */
+    @Query("""
+            select p from BattleParticipant p
+            join fetch p.battleRoom r
+            where p.member.id = :memberId
+              and p.status = :status
+              and r.status = :roomStatus
+            """)
+    Optional<BattleParticipant> findAbandonedParticipantByMemberId(
+            @Param("memberId") Long memberId,
+            @Param("status") BattleParticipantStatus status,
+            @Param("roomStatus") BattleRoomStatus roomStatus);
 }

--- a/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
+++ b/src/main/java/com/back/domain/battle/battleroom/controller/BattleRoomController.java
@@ -13,6 +13,7 @@ import com.back.domain.battle.battleroom.dto.BattleRoomStateResponse;
 import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
+import com.back.domain.battle.battleroom.dto.OngoingRoomResponse;
 import com.back.domain.battle.battleroom.dto.RoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.service.ReadyCheckService;
@@ -57,5 +58,26 @@ public class BattleRoomController {
     public BattleRoomStateResponse getRoomState(@PathVariable Long roomId) {
         Long memberId = rq.getActor().getId();
         return battleRoomService.getRoomState(roomId, memberId);
+    }
+
+    /**
+     * 뒤로가기 확인 시 의도적 퇴장 처리
+     * PLAYING → QUIT (꼴찌, 재입장 불가)
+     */
+    @PostMapping("/{roomId}/exit")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void exitRoom(@PathVariable Long roomId) {
+        Long memberId = rq.getActor().getId();
+        battleRoomService.exitRoom(roomId, memberId);
+    }
+
+    /**
+     * 네트워크 이탈(ABANDONED) 상태로 진행 중인 방이 있는지 조회
+     * 상단 메뉴 재입장 버튼 및 매칭 버튼 가드용
+     */
+    @GetMapping("/ongoing")
+    public OngoingRoomResponse getOngoingRoom() {
+        Long memberId = rq.getActor().getId();
+        return battleRoomService.getOngoingRoom(memberId);
     }
 }

--- a/src/main/java/com/back/domain/battle/battleroom/dto/OngoingRoomResponse.java
+++ b/src/main/java/com/back/domain/battle/battleroom/dto/OngoingRoomResponse.java
@@ -1,0 +1,3 @@
+package com.back.domain.battle.battleroom.dto;
+
+public record OngoingRoomResponse(Long roomId) {}

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -17,6 +17,7 @@ import com.back.domain.battle.battleroom.dto.BattleRoomStateResponse;
 import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
+import com.back.domain.battle.battleroom.dto.OngoingRoomResponse;
 import com.back.domain.battle.battleroom.dto.RoomResponse;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
@@ -25,6 +26,7 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.global.exception.ServiceException;
 import com.back.global.websocket.BattleCodeStore;
 
 import lombok.RequiredArgsConstructor;
@@ -142,6 +144,40 @@ public class BattleRoomService {
 
         List<BattleParticipant> participants = battleParticipantRepository.findByBattleRoom(room);
         return RoomResponse.from(room, participants);
+    }
+
+    @Transactional
+    public void exitRoom(Long roomId, Long memberId) {
+
+        BattleRoom room =
+                battleRoomRepository.findById(roomId).orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 방입니다."));
+
+        if (room.getStatus() != BattleRoomStatus.PLAYING) {
+            throw new ServiceException("400-1", "진행 중인 방이 아닙니다.");
+        }
+
+        Member member =
+                memberRepository.findById(memberId).orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 회원입니다."));
+
+        BattleParticipant participant = battleParticipantRepository
+                .findByBattleRoomAndMember(room, member)
+                .orElseThrow(() -> new ServiceException("403-1", "해당 방의 참여자가 아닙니다."));
+
+        if (participant.getStatus() != BattleParticipantStatus.PLAYING) {
+            throw new ServiceException("400-1", "게임 중인 상태가 아닙니다. 현재 상태: " + participant.getStatus());
+        }
+
+        participant.quit();
+        battleParticipantRepository.save(participant);
+    }
+
+    @Transactional(readOnly = true)
+    public OngoingRoomResponse getOngoingRoom(Long memberId) {
+        return battleParticipantRepository
+                .findAbandonedParticipantByMemberId(
+                        memberId, BattleParticipantStatus.ABANDONED, BattleRoomStatus.PLAYING)
+                .map(p -> new OngoingRoomResponse(p.getBattleRoom().getId()))
+                .orElse(null);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
 import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.global.security.SecurityUser;
 
 import lombok.RequiredArgsConstructor;
@@ -50,16 +52,18 @@ public class BattleDisconnectHandler {
 
         Long memberId = user.getId();
 
-        battleParticipantRepository.findPlayingParticipantByMemberId(memberId).ifPresent(participant -> {
-            Long roomId = participant.getBattleRoom().getId();
+        battleParticipantRepository
+                .findPlayingParticipantByMemberId(memberId, BattleParticipantStatus.PLAYING, BattleRoomStatus.PLAYING)
+                .ifPresent(participant -> {
+                    Long roomId = participant.getBattleRoom().getId();
 
-            participant.abandon();
-            battleParticipantRepository.save(participant);
+                    participant.abandon();
+                    battleParticipantRepository.save(participant);
 
-            log.info("배틀 이탈 처리 - memberId={}, roomId={}", memberId, roomId);
+                    log.info("배틀 이탈 처리 - memberId={}, roomId={}", memberId, roomId);
 
-            messagingTemplate.convertAndSend(
-                    "/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
-        });
+                    messagingTemplate.convertAndSend(
+                            "/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
+                });
     }
 }

--- a/src/test/java/com/back/domain/battle/battleroom/controller/BattleRoomControllerExitOngoingTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/controller/BattleRoomControllerExitOngoingTest.java
@@ -1,0 +1,151 @@
+package com.back.domain.battle.battleroom.controller;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.back.domain.battle.battleroom.dto.OngoingRoomResponse;
+import com.back.domain.battle.battleroom.service.BattleRoomService;
+import com.back.domain.matching.queue.service.ReadyCheckService;
+import com.back.domain.member.member.entity.Member;
+import com.back.global.exception.ServiceException;
+import com.back.global.globalExceptionHandler.GlobalExceptionHandler;
+import com.back.global.rq.Rq;
+
+class BattleRoomControllerExitOngoingTest {
+
+    private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
+    private final ReadyCheckService readyCheckService = mock(ReadyCheckService.class);
+    private final Rq rq = mock(Rq.class);
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        BattleRoomController controller = new BattleRoomController(battleRoomService, readyCheckService, rq);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    // ──────────────────────────────────────────────
+    // POST /{roomId}/exit
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("PLAYING 참여자가 exit 호출하면 204를 반환한다")
+    void exitRoom_success() throws Exception {
+        // given
+        Long roomId = 1L;
+        Member actor = Member.of(10L, "user@test.com", "user");
+
+        when(rq.getActor()).thenReturn(actor);
+        doNothing().when(battleRoomService).exitRoom(roomId, actor.getId());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/battle/rooms/{roomId}/exit", roomId)).andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("진행 중인 방이 아니면 exit 호출 시 400을 반환한다")
+    void exitRoom_fail_whenRoomNotPlaying() throws Exception {
+        // given
+        Long roomId = 1L;
+        Member actor = Member.of(10L, "user@test.com", "user");
+
+        when(rq.getActor()).thenReturn(actor);
+        doThrow(new ServiceException("400-1", "진행 중인 방이 아닙니다."))
+                .when(battleRoomService)
+                .exitRoom(roomId, actor.getId());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/battle/rooms/{roomId}/exit", roomId))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode").value("400-1"))
+                .andExpect(jsonPath("$.msg").value("진행 중인 방이 아닙니다."));
+    }
+
+    @Test
+    @DisplayName("PLAYING 상태가 아닌 참여자가 exit 호출하면 400을 반환한다")
+    void exitRoom_fail_whenParticipantNotPlaying() throws Exception {
+        // given
+        Long roomId = 1L;
+        Member actor = Member.of(10L, "user@test.com", "user");
+
+        when(rq.getActor()).thenReturn(actor);
+        doThrow(new ServiceException("400-1", "게임 중인 상태가 아닙니다."))
+                .when(battleRoomService)
+                .exitRoom(roomId, actor.getId());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/battle/rooms/{roomId}/exit", roomId))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode").value("400-1"))
+                .andExpect(jsonPath("$.msg").value("게임 중인 상태가 아닙니다."));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 방에 exit 호출하면 404를 반환한다")
+    void exitRoom_fail_whenRoomNotFound() throws Exception {
+        // given
+        Long roomId = 999L;
+        Member actor = Member.of(10L, "user@test.com", "user");
+
+        when(rq.getActor()).thenReturn(actor);
+        doThrow(new ServiceException("404-1", "존재하지 않는 방입니다."))
+                .when(battleRoomService)
+                .exitRoom(roomId, actor.getId());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/battle/rooms/{roomId}/exit", roomId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404-1"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 방입니다."));
+    }
+
+    // ──────────────────────────────────────────────
+    // GET /ongoing
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("ABANDONED 상태로 진행 중인 방이 있으면 roomId를 반환한다")
+    void getOngoingRoom_whenExists() throws Exception {
+        // given
+        Member actor = Member.of(10L, "user@test.com", "user");
+
+        when(rq.getActor()).thenReturn(actor);
+        when(battleRoomService.getOngoingRoom(actor.getId())).thenReturn(new OngoingRoomResponse(42L));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/battle/rooms/ongoing"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").value(42));
+    }
+
+    @Test
+    @DisplayName("진행 중인 방이 없으면 null을 반환한다")
+    void getOngoingRoom_whenNotExists() throws Exception {
+        // given
+        Member actor = Member.of(10L, "user@test.com", "user");
+
+        when(rq.getActor()).thenReturn(actor);
+        when(battleRoomService.getOngoingRoom(actor.getId())).thenReturn(null);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/battle/rooms/ongoing"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").doesNotExist());
+    }
+}


### PR DESCRIPTION
### 추가된 API 스펙

1. 의도적 퇴장 (뒤로가기 확인 시 호출)

```java
POST /api/v1/battle/rooms/{roomId}/exit
Authorization: 필요 (로그인)
```

Response: 204 No Content

- 호출 시점: 뒤로가기 확인 창에서 "나가기" 버튼 클릭
- 효과: 해당 유저 QUIT 처리, 재입장 불가, 정산 시 꼴찌

---

2. 진행 중인 방 조회

```java
GET /api/v1/battle/rooms/ongoing
Authorization: 필요 (로그인)

Response 200 - 진행 중인 방 있을 때:
{ "roomId": 42 }

Response 200 - 없을 때:
null
```

- 호출 시점: 앱 초기화 시 1회 + 매칭 버튼 클릭 전
- 효과: roomId 있으면 상단 재입장 버튼 표시 / 매칭 진입 차단 후 재참여 모달

<html>
<body>
<!--StartFragment--><h3>상단 메뉴 재입장 버튼 흐름</h3>
<pre><code class="language-java">앱 초기화 (로그인 확인 시점)
  ↓
GET /api/v1/battle/rooms/ongoing 호출
  ↓
null이면 → 버튼 숨김
roomId 있으면 → 전역 상태에 저장
  ↓
헤더 컴포넌트에서 전역 상태 읽어서 버튼 표시
  ↓
버튼 클릭
  ↓
POST /api/v1/battle/rooms/{roomId}/join 호출
  ↓
성공 → 배틀룸 페이지로 이동
GET /api/v1/battle/rooms/{roomId}/state 호출 → 타이머 잔여시간 + 내 코드 복원
</code></pre>
<h3>버튼이 사라져야 하는 시점</h3>

상황 | 처리
-- | --
재입장 성공 | 전역 상태 ongoingRoomId = null
뒤로가기로 퇴장 (POST /exit) | 전역 상태 ongoingRoomId = null
타이머 만료 WebSocket BATTLE_FINISHED 수신 | 전역 상태 ongoingRoomId = null


<h3>매칭 버튼 가드</h3>
<p>매칭 버튼 클릭 시 전역 상태에 ongoingRoomId가 있으면 매칭 진입 차단하고 재참여 모달 띄우기
별도 API 호출 없이 이미 저장된 상태를 보면돼서 추가 비용 없음</p>
<!-- notionvc: a1e49862-72f2-4bf7-9222-916084cc140a --><!--EndFragment-->
</body>
</html>