### PR TITLE
[Feat] queue 상태 변화 및 ready check 시작 handoff websocket 이벤트 추가

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/dto/MatchingEventResponse.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/MatchingEventResponse.java
@@ -1,0 +1,9 @@
+package com.back.domain.matching.queue.dto;
+
+/**
+ * matching WebSocket 이벤트 공통 envelope
+ *
+ * queue 변화와 ready-check 시작 handoff가 같은 채널 규약을 쓰도록
+ * type + payload 조합으로 감싸서 보낸다.
+ */
+public record MatchingEventResponse(MatchingEventType type, QueueStateV2Response queue, MatchStateV2Response match) {}

--- a/src/main/java/com/back/domain/matching/queue/dto/MatchingEventType.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/MatchingEventType.java
@@ -1,0 +1,6 @@
+package com.back.domain.matching.queue.dto;
+
+public enum MatchingEventType {
+    QUEUE_STATE_CHANGED,
+    READY_CHECK_STARTED
+}

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingEventPublisher.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingEventPublisher.java
@@ -1,0 +1,48 @@
+package com.back.domain.matching.queue.service;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import com.back.domain.matching.queue.dto.MatchStateV2Response;
+import com.back.domain.matching.queue.dto.MatchingEventResponse;
+import com.back.domain.matching.queue.dto.MatchingEventType;
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
+import com.back.domain.matching.queue.model.QueueKey;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatchingEventPublisher {
+
+    private static final int REQUIRED_MATCH_SIZE = 4;
+    private static final String USER_MATCHING_DESTINATION = "/queue/matching";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void publishQueueStateChanged(QueueKey queueKey, int waitingCount) {
+        // queue topic 은 "같은 queueKey 대기자 공용" 채널이므로 inQueue=true snapshot 으로 통일한다.
+        // 예: ARRAY/EASY 대기자가 3명 남아 있으면 모두 같은 waitingCount=3 이벤트를 받는다.
+        QueueStateV2Response queueState = new QueueStateV2Response(
+                true, queueKey.category(), queueKey.difficulty().name(), waitingCount, REQUIRED_MATCH_SIZE);
+
+        messagingTemplate.convertAndSend(
+                toQueueTopic(queueKey),
+                new MatchingEventResponse(MatchingEventType.QUEUE_STATE_CHANGED, queueState, null));
+    }
+
+    public void publishReadyCheckStarted(Long userId, MatchStateV2Response matchState) {
+        log.info("READY_CHECK_STARTED 발행 - userId={}, destination={}", userId, USER_MATCHING_DESTINATION);
+        messagingTemplate.convertAndSendToUser(
+                String.valueOf(userId),
+                USER_MATCHING_DESTINATION,
+                new MatchingEventResponse(MatchingEventType.READY_CHECK_STARTED, null, matchState));
+    }
+
+    String toQueueTopic(QueueKey queueKey) {
+        return "/topic/matching/queue/" + queueKey.category() + "/"
+                + queueKey.difficulty().name();
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
@@ -24,7 +24,9 @@ import com.back.domain.matching.queue.model.WaitingUser;
 import com.back.domain.matching.queue.store.MatchStateStore;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 /**
@@ -46,6 +48,7 @@ public class ReadyCheckService {
     private final BattleRoomService battleRoomService;
     private final QueueProblemPicker queueProblemPicker;
     private final MatchStateStore matchStateStore;
+    private final MatchingEventPublisher matchingEventPublisher;
 
     /**
      * v2 큐 참가
@@ -63,6 +66,7 @@ public class ReadyCheckService {
         int currentSize = matchStateStore.enqueue(userId, nickname, queueKey);
 
         if (currentSize < REQUIRED_MATCH_SIZE) {
+            matchingEventPublisher.publishQueueStateChanged(queueKey, currentSize);
             // 아직 4명이 안 찼다면 기존 SEARCHING 단계로 머문다.
             return new QueueStatusResponse(
                     "매칭 대기열에 참가했습니다.",
@@ -72,7 +76,17 @@ public class ReadyCheckService {
         }
 
         // 4명이 찬 시점에만 SEARCHING -> ACCEPT_PENDING 전환을 시도한다.
-        tryCreateReadyCheckSession(queueKey);
+        MatchSession matchSession = tryCreateReadyCheckSession(queueKey);
+
+        if (matchSession != null) {
+            publishReadyCheckStarted(matchSession);
+
+            int remainingCount = matchStateStore.getWaitingCount(queueKey);
+            if (remainingCount > 0) {
+                // 예: user1~4가 handoff 되고 user5가 queue에 남아 있다면 남은 대기 인원도 즉시 갱신해준다.
+                matchingEventPublisher.publishQueueStateChanged(queueKey, remainingCount);
+            }
+        }
 
         return new QueueStatusResponse(
                 "매칭이 성사되어 수락 대기 상태로 전환되었습니다.",
@@ -85,6 +99,7 @@ public class ReadyCheckService {
         // cancel은 아직 queue에 남아 있는 SEARCHING 사용자만 대상으로 한다.
         MatchStateStore.CancelResult cancelResult = matchStateStore.cancel(userId);
         QueueKey queueKey = cancelResult.queueKey();
+        matchingEventPublisher.publishQueueStateChanged(queueKey, cancelResult.waitingCount());
 
         return new QueueStatusResponse(
                 "매칭 대기열에서 취소했습니다.", queueKey.category(), queueKey.difficulty().name(), cancelResult.waitingCount());
@@ -162,23 +177,34 @@ public class ReadyCheckService {
      * 이 시점에는 아직 problem pick이나 room 생성이 일어나지 않는다.
      * ready-check가 실패할 수 있기 때문에, 방 생성은 마지막 accept까지 미룬다.
      */
-    private void tryCreateReadyCheckSession(QueueKey queueKey) {
+    private MatchSession tryCreateReadyCheckSession(QueueKey queueKey) {
         List<WaitingUser> matchedUsers = matchStateStore.pollMatchCandidates(queueKey, REQUIRED_MATCH_SIZE);
 
         if (matchedUsers == null) {
-            return;
+            return null;
         }
 
         LocalDateTime deadline = LocalDateTime.now().plusSeconds(READY_CHECK_TIMEOUT_SECONDS);
 
         try {
             // 이 시점에 userQueueMap에서 빠지고 userMatchMap / matchSessionMap으로 이동한다.
-            matchStateStore.markAcceptPending(queueKey, matchedUsers, deadline);
+            return matchStateStore.markAcceptPending(queueKey, matchedUsers, deadline);
         } catch (RuntimeException e) {
             // 세션 생성 도중 실패하면 poll했던 유저들을 다시 queue 앞쪽으로 복구한다.
             matchStateStore.rollbackPolledUsers(queueKey, matchedUsers);
+            matchingEventPublisher.publishQueueStateChanged(queueKey, matchStateStore.getWaitingCount(queueKey));
             throw e;
         }
+    }
+
+    private void publishReadyCheckStarted(MatchSession matchSession) {
+        log.info("READY_CHECK_STARTED handoff 준비 - participants={}", matchSession.participantIds());
+        // handoff 는 같은 세션 참여자 4명에게만 개인 채널로 보낸다.
+        // 예: [1,2,3,4]가 매칭되면 /user/queue/matching 으로 각각 ACCEPT_PENDING snapshot 을 받는다.
+        matchSession
+                .participantIds()
+                .forEach(participantId -> matchingEventPublisher.publishReadyCheckStarted(
+                        participantId, toMatchStateV2Response(participantId, matchSession)));
     }
 
     /**
@@ -196,7 +222,6 @@ public class ReadyCheckService {
         }
 
         // readyCheck / room / message를 나눠 담아두면 프론트가 상태별 UI를 단순하게 분기할 수 있다.
-        // TODO : 내가 생각했을땐 이거 닉네임 그냥 jwt에서 받아 쓰면 이거 필요없을거같음
         ReadyCheckSnapshot readyCheckSnapshot = buildReadyCheckSnapshot(userId, matchSession);
         RoomSnapshot roomSnapshot = matchSession.roomId() == null ? null : new RoomSnapshot(matchSession.roomId());
         String message = resolveMessage(matchSession);

--- a/src/main/java/com/back/global/websocket/WebSocketConfig.java
+++ b/src/main/java/com/back/global/websocket/WebSocketConfig.java
@@ -63,6 +63,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                     if (principal instanceof UsernamePasswordAuthenticationToken cookieAuth
                             && cookieAuth.getPrincipal() instanceof SecurityUser cookieUser) {
                         // ① 쿠키 기반: Spring이 이미 Principal을 전파해둔 상태
+                        accessor.setUser(createWsAuthentication(cookieUser));
                         log.info("WebSocket 연결 (쿠키 인증) - memberId={}", cookieUser.getId());
 
                     } else {
@@ -83,9 +84,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                         }
 
                         // 검증 성공: SecurityUser를 STOMP Principal로 등록
-                        UsernamePasswordAuthenticationToken auth =
-                                new UsernamePasswordAuthenticationToken(tokenUser, null, tokenUser.getAuthorities());
-                        accessor.setUser(auth);
+                        accessor.setUser(createWsAuthentication(tokenUser));
                         log.info("WebSocket 연결 (토큰 인증) - memberId={}", tokenUser.getId());
                     }
                 }
@@ -93,6 +92,17 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 return message;
             }
         });
+    }
+
+    private UsernamePasswordAuthenticationToken createWsAuthentication(SecurityUser securityUser) {
+        // /user 목적지는 Principal name 으로 대상을 찾기 때문에,
+        // matching handoff 는 memberId 기반으로 주소를 맞추도록 이름을 userId 문자열로 고정한다.
+        return new UsernamePasswordAuthenticationToken(securityUser, null, securityUser.getAuthorities()) {
+            @Override
+            public String getName() {
+                return String.valueOf(securityUser.getId());
+            }
+        };
     }
 
     /**
@@ -119,6 +129,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
         // 클라이언트가 서버로 메시지를 보낼 때 쓰는 prefix
         registry.setApplicationDestinationPrefixes("/app");
+        // 사용자별 matching handoff는 /user/queue/matching 으로 보낸다.
+        // 예: memberId=1 사용자는 /user/queue/matching 을 구독하고 개인 이벤트만 받는다.
+        registry.setUserDestinationPrefix("/user");
     }
 
     @Override

--- a/src/main/java/com/back/global/websocket/WebSocketConfig.java
+++ b/src/main/java/com/back/global/websocket/WebSocketConfig.java
@@ -120,7 +120,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         ((ThreadPoolTaskScheduler) scheduler).initialize();
 
         // 클라이언트가 서버로부터 메시지를 받기 위해 구독하는 prefix
-        registry.enableSimpleBroker("/topic")
+        registry.enableSimpleBroker("/topic", "/queue")
                 .setHeartbeatValue(new long[] {10000, 10000}) // 10초마다 ping/pong
                 .setTaskScheduler(scheduler);
         // 서버 → 클라이언트: 10초마다 ping

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingEventPublisherTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingEventPublisherTest.java
@@ -1,0 +1,62 @@
+package com.back.domain.matching.queue.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.back.domain.matching.queue.dto.MatchStateV2Response;
+import com.back.domain.matching.queue.dto.MatchStatus;
+import com.back.domain.matching.queue.dto.MatchingEventResponse;
+import com.back.domain.matching.queue.dto.MatchingEventType;
+import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.QueueKey;
+
+class MatchingEventPublisherTest {
+
+    private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+    private final MatchingEventPublisher matchingEventPublisher = new MatchingEventPublisher(messagingTemplate);
+
+    @Test
+    @DisplayName("queue 상태 변화는 category/difficulty 기준 topic 으로 발행된다")
+    void publishQueueStateChanged_usesQueueTopic() {
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+        ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<MatchingEventResponse> eventCaptor = ArgumentCaptor.forClass(MatchingEventResponse.class);
+
+        matchingEventPublisher.publishQueueStateChanged(queueKey, 3);
+
+        verify(messagingTemplate).convertAndSend(destinationCaptor.capture(), eventCaptor.capture());
+
+        assertThat(destinationCaptor.getValue()).isEqualTo("/topic/matching/queue/ARRAY/EASY");
+        assertThat(eventCaptor.getValue().type()).isEqualTo(MatchingEventType.QUEUE_STATE_CHANGED);
+        assertThat(eventCaptor.getValue().queue()).isNotNull();
+        assertThat(eventCaptor.getValue().queue().waitingCount()).isEqualTo(3);
+        assertThat(eventCaptor.getValue().queue().requiredCount()).isEqualTo(4);
+        assertThat(eventCaptor.getValue().match()).isNull();
+    }
+
+    @Test
+    @DisplayName("ready-check 시작 이벤트는 사용자별 matching 채널로 발행된다")
+    void publishReadyCheckStarted_usesUserDestination() {
+        MatchStateV2Response matchState = new MatchStateV2Response(MatchStatus.ACCEPT_PENDING, null, null, null);
+        ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<MatchingEventResponse> eventCaptor = ArgumentCaptor.forClass(MatchingEventResponse.class);
+
+        matchingEventPublisher.publishReadyCheckStarted(1L, matchState);
+
+        verify(messagingTemplate)
+                .convertAndSendToUser(userCaptor.capture(), destinationCaptor.capture(), eventCaptor.capture());
+
+        assertThat(userCaptor.getValue()).isEqualTo("1");
+        assertThat(destinationCaptor.getValue()).isEqualTo("/queue/matching");
+        assertThat(eventCaptor.getValue().type()).isEqualTo(MatchingEventType.READY_CHECK_STARTED);
+        assertThat(eventCaptor.getValue().queue()).isNull();
+        assertThat(eventCaptor.getValue().match()).isEqualTo(matchState);
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
@@ -3,7 +3,9 @@ package com.back.domain.matching.queue.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
 import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
@@ -42,9 +45,10 @@ class ReadyCheckServiceTest {
     private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
     private final QueueProblemPicker queueProblemPicker = mock(QueueProblemPicker.class);
     private final InMemoryMatchStateStore matchStateStore = new InMemoryMatchStateStore();
+    private final MatchingEventPublisher matchingEventPublisher = mock(MatchingEventPublisher.class);
 
     private final ReadyCheckService readyCheckService =
-            new ReadyCheckService(battleRoomService, queueProblemPicker, matchStateStore);
+            new ReadyCheckService(battleRoomService, queueProblemPicker, matchStateStore, matchingEventPublisher);
 
     @BeforeEach
     void setUp() {
@@ -64,6 +68,20 @@ class ReadyCheckServiceTest {
         assertThat(queueState.difficulty()).isEqualTo("EASY");
         assertThat(queueState.waitingCount()).isEqualTo(1);
         assertThat(queueState.requiredCount()).isEqualTo(4);
+        verify(matchingEventPublisher).publishQueueStateChanged(any(QueueKey.class), eq(1));
+    }
+
+    @Test
+    @DisplayName("queue cancel 후에는 감소한 waitingCount를 queue topic 이벤트로 발행한다")
+    void cancelQueueV2_publishesQueueStateChanged() {
+        joinUser(1L);
+        joinUser(2L);
+
+        QueueStatusResponse response = readyCheckService.cancelQueueV2(2L);
+
+        assertThat(response.getWaitingCount()).isEqualTo(1);
+        verify(matchingEventPublisher, times(2)).publishQueueStateChanged(any(QueueKey.class), eq(1));
+        verify(matchingEventPublisher, times(1)).publishQueueStateChanged(any(QueueKey.class), eq(2));
     }
 
     @Test
@@ -88,6 +106,33 @@ class ReadyCheckServiceTest {
         assertThat(response.readyCheck().participants())
                 .extracting(participant -> participant.nickname())
                 .containsExactly("m1", "m2", "m3", "m4");
+        verify(matchingEventPublisher, never()).publishQueueStateChanged(any(QueueKey.class), eq(4));
+    }
+
+    @Test
+    @DisplayName("4번째 join 시 matched 4명에게 READY_CHECK_STARTED를 발행한다")
+    void joinQueueV2_publishesReadyCheckStarted_whenFourthUserJoins() {
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+
+        readyCheckService.joinQueueV2(4L, "m4", createRequest("Array", Difficulty.EASY));
+
+        ArgumentCaptor<Long> userIdCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<MatchStateV2Response> responseCaptor = ArgumentCaptor.forClass(MatchStateV2Response.class);
+
+        verify(matchingEventPublisher, times(4))
+                .publishReadyCheckStarted(userIdCaptor.capture(), responseCaptor.capture());
+
+        assertThat(userIdCaptor.getAllValues()).containsExactlyInAnyOrder(1L, 2L, 3L, 4L);
+        assertThat(responseCaptor.getAllValues()).allSatisfy(response -> {
+            assertThat(response.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+            assertThat(response.readyCheck()).isNotNull();
+            assertThat(response.readyCheck().acceptedCount()).isEqualTo(0);
+            assertThat(response.readyCheck().requiredCount()).isEqualTo(4);
+            assertThat(response.room()).isNull();
+            assertThat(response.message()).isNull();
+        });
     }
 
     @Test
@@ -303,6 +348,35 @@ class ReadyCheckServiceTest {
         assertThat(response.status()).isEqualTo(MatchStatus.ROOM_READY);
         assertThat(response.room()).isNotNull();
         verify(battleRoomService, times(1)).createRoom(any(CreateRoomRequest.class));
+    }
+
+    @Test
+    @DisplayName("ready-check 세션 생성 실패 시 rollback 후 queue waitingCount 복구 이벤트를 발행한다")
+    void joinQueueV2_publishesRecoveredQueueEvent_whenMarkAcceptPendingFails() {
+        MatchStateStore failingStore = mock(MatchStateStore.class);
+        MatchingEventPublisher failingPublisher = mock(MatchingEventPublisher.class);
+        ReadyCheckService failingService =
+                new ReadyCheckService(battleRoomService, queueProblemPicker, failingStore, failingPublisher);
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+        List<WaitingUser> users = List.of(
+                new WaitingUser(1L, "m1", queueKey),
+                new WaitingUser(2L, "m2", queueKey),
+                new WaitingUser(3L, "m3", queueKey),
+                new WaitingUser(4L, "m4", queueKey));
+
+        when(failingStore.enqueue(1L, "m1", queueKey)).thenReturn(4);
+        when(failingStore.pollMatchCandidates(queueKey, 4)).thenReturn(users);
+        when(failingStore.markAcceptPending(any(QueueKey.class), anyList(), any(LocalDateTime.class)))
+                .thenThrow(new RuntimeException("mark failed"));
+        when(failingStore.getWaitingCount(queueKey)).thenReturn(4);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> failingService.joinQueueV2(1L, "m1", createRequest("Array", Difficulty.EASY)))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("mark failed");
+
+        verify(failingStore).rollbackPolledUsers(queueKey, users);
+        verify(failingPublisher).publishQueueStateChanged(queueKey, 4);
     }
 
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {

--- a/src/test/java/com/back/global/websocket/WebSocketConfigTest.java
+++ b/src/test/java/com/back/global/websocket/WebSocketConfigTest.java
@@ -1,0 +1,34 @@
+package com.back.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.support.ExecutorSubscribableChannel;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class WebSocketConfigTest {
+
+    @Test
+    @DisplayName("개인 matching 채널 라우팅을 위해 simple broker에 /queue prefix를 포함한다")
+    @SuppressWarnings("unchecked")
+    void configureMessageBroker_includesQueuePrefixForUserDestination() {
+        WebSocketConfig webSocketConfig = new WebSocketConfig(mock(WsTokenStore.class));
+        MessageBrokerRegistry registry =
+                new MessageBrokerRegistry(new ExecutorSubscribableChannel(), new ExecutorSubscribableChannel());
+
+        webSocketConfig.configureMessageBroker(registry);
+
+        Object simpleBrokerRegistration = ReflectionTestUtils.getField(registry, "simpleBrokerRegistration");
+        Collection<String> destinationPrefixes =
+                (Collection<String>) ReflectionTestUtils.getField(simpleBrokerRegistration, "destinationPrefixes");
+
+        assertThat(destinationPrefixes).containsExactly("/topic", "/queue");
+        assertThat(ReflectionTestUtils.getField(registry, "userDestinationPrefix"))
+                .isEqualTo("/user");
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #115 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #115 

---

<html>
<body>
<h1>[feat] 매칭 큐 상태 변화 및 ready-check 시작 handoff WebSocket 이벤트 추가</h1>

<h3>개요</h3>
<p>이번 PR은 매칭 v2 흐름에서 프론트가 polling만으로 상태를 추적하던 부분을 보완하기 위해, <strong>큐 대기 인원 변화</strong>와 <strong>ready-check 시작 handoff</strong>를 WebSocket 이벤트로 즉시 전달하는 기능을 추가한 작업입니다.</p>
<p>기존에는 사용자가 queue에 들어가거나 취소해도 같은 큐를 보고 있는 다른 대기자들은 다음 polling 전까지 대기 인원 변화를 즉시 알 수 없었고, 4명이 모여 <code>ACCEPT_PENDING</code> 세션이 시작되는 순간도 참여자 각자가 <code>matches/me</code>를 다시 조회해야만 감지할 수 있었습니다.</p>
<p>이번 PR에서는 queue 상태 변화는 <strong>같은 queueKey를 구독하는 공용 topic</strong>으로, ready-check 시작은 <strong>매칭된 4명에게만 가는 개인 채널</strong>로 분리해서 push 하도록 구성했습니다. 또한 사용자별 handoff가 실제로 라우팅되도록 WebSocket broker prefix와 Principal name 처리도 함께 보완했습니다.</p>

<p>신규 파일 5개 / 수정 파일 3개</p>
<ul>
<li><code>MatchingEventResponse.java</code> - matching 이벤트 공통 envelope</li>
<li><code>MatchingEventType.java</code> - 이벤트 타입 enum</li>
<li><code>MatchingEventPublisher.java</code> - queue/ready-check WebSocket 발행 서비스</li>
<li><code>MatchingEventPublisherTest.java</code> - 이벤트 발행 단위 테스트</li>
<li><code>WebSocketConfigTest.java</code> - user destination/broker prefix 설정 테스트</li>
</ul>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) matching WebSocket 이벤트 공통 envelope 추가</h3>
<p>queue 상태 변화와 ready-check handoff가 서로 다른 성격의 이벤트이지만, 프론트에서 같은 규약으로 처리할 수 있도록 공통 응답 envelope를 추가했습니다.</p>

<pre><code class="language-java">public record MatchingEventResponse(
        MatchingEventType type,
        QueueStateV2Response queue,
        MatchStateV2Response match
) {}
</code></pre>

<p>이 구조의 의도는 아래와 같습니다.</p>
<ul>
<li><code>type</code>으로 이벤트 종류를 먼저 구분</li>
<li>queue 관련 이벤트면 <code>queue</code> 필드 사용, <code>match</code>는 null</li>
<li>ready-check handoff 이벤트면 <code>match</code> 필드 사용, <code>queue</code>는 null</li>
</ul>

<p>즉, 프론트는 하나의 matching 이벤트 채널 규약만 이해하면 됩니다.</p>

<h3>2) 이벤트 타입 enum 추가</h3>
<p>이번 단계에서는 아래 2가지 이벤트 타입을 정의했습니다.</p>

<pre><code class="language-java">public enum MatchingEventType {
    QUEUE_STATE_CHANGED,
    READY_CHECK_STARTED
}
</code></pre>

<ul>
<li><code>QUEUE_STATE_CHANGED</code> : 같은 queueKey 대기자들에게 현재 waitingCount를 알려주는 이벤트</li>
<li><code>READY_CHECK_STARTED</code> : 막 매칭된 4명에게 <code>ACCEPT_PENDING</code> snapshot을 handoff 하는 이벤트</li>
</ul>

<p>즉, 이번 PR은 ready-check 전체 lifecycle을 WebSocket으로 모두 밀어주는 단계는 아니고, <strong>queue 변화와 ready-check 시작 시점</strong>을 우선 push 하는 1차 단계입니다.</p>

<h3>3) queue 상태 변화 topic 이벤트 발행 서비스 추가</h3>
<p><code>MatchingEventPublisher</code>를 새로 추가해 matching 관련 WebSocket 발행 책임을 별도 서비스로 분리했습니다.</p>

<p>queue 상태 변화는 아래 메서드로 발행합니다.</p>

<pre><code class="language-java">public void publishQueueStateChanged(QueueKey queueKey, int waitingCount) {
    QueueStateV2Response queueState = new QueueStateV2Response(
            true, queueKey.category(), queueKey.difficulty().name(), waitingCount, REQUIRED_MATCH_SIZE);

    messagingTemplate.convertAndSend(
            toQueueTopic(queueKey),
            new MatchingEventResponse(MatchingEventType.QUEUE_STATE_CHANGED, queueState, null));
}
</code></pre>

<p>topic 경로는 아래 규칙을 따릅니다.</p>

<pre><code class="language-text">/topic/matching/queue/{category}/{difficulty}
예) /topic/matching/queue/ARRAY/EASY
</code></pre>

<p>즉, 같은 category/difficulty queue를 보고 있는 SEARCHING 사용자들은 동일한 waitingCount snapshot을 함께 받습니다.</p>

<h3>4) ready-check 시작 handoff 개인 이벤트 추가</h3>
<p>4명이 모여 ready-check 세션이 생성되면, matched된 4명에게는 공용 queue topic이 아니라 <strong>개인 채널</strong>로 handoff 이벤트를 보냅니다.</p>

<pre><code class="language-java">public void publishReadyCheckStarted(Long userId, MatchStateV2Response matchState) {
    messagingTemplate.convertAndSendToUser(
            String.valueOf(userId),
            "/queue/matching",
            new MatchingEventResponse(MatchingEventType.READY_CHECK_STARTED, null, matchState));
}
</code></pre>

<p>이 이벤트는 각 사용자에게 아래와 같은 의미를 가집니다.</p>
<ul>
<li>이제 SEARCHING이 아니라 <code>ACCEPT_PENDING</code> 상태임</li>
<li>어떤 <code>matchId</code>인지</li>
<li>참가자 4명이 누구인지</li>
<li>deadline이 언제까지인지</li>
<li>지금 바로 ready-check UI로 전환해야 한다는 신호</li>
</ul>

<p>즉, 프론트는 더 이상 4번째 사용자가 들어온 뒤 <code>matches/me</code> polling 결과를 기다리지 않고, 이벤트를 받는 즉시 ready-check 모달/화면으로 전환할 수 있습니다.</p>

<h3>5) <code>ReadyCheckService.joinQueueV2()</code>에 queue 상태 이벤트 연결</h3>
<p>사용자가 queue에 참가했을 때 아직 4명이 안 찬 경우에는 즉시 <code>QUEUE_STATE_CHANGED</code> 이벤트를 발행하도록 연결했습니다.</p>

<pre><code class="language-java">int currentSize = matchStateStore.enqueue(userId, nickname, queueKey);

if (currentSize &lt; REQUIRED_MATCH_SIZE) {
    matchingEventPublisher.publishQueueStateChanged(queueKey, currentSize);
    return new QueueStatusResponse(...);
}
</code></pre>

<p>즉, 1명, 2명, 3명 단계에서는 queue topic 구독자들이 waitingCount 변화를 실시간으로 받을 수 있습니다.</p>

<h3>6) 4번째 join 시에는 queue=4 브로드캐스트 대신 ready-check handoff 수행</h3>
<p>이번 PR의 중요한 정책은 <strong>4번째 join이 들어온 순간</strong> queue waitingCount를 4로 브로드캐스트하는 것이 아니라, 바로 ready-check 세션을 만들고 matched된 사용자들에게 handoff 이벤트를 보내는 것입니다.</p>

<pre><code class="language-java">MatchSession matchSession = tryCreateReadyCheckSession(queueKey);

if (matchSession != null) {
    publishReadyCheckStarted(matchSession);

    int remainingCount = matchStateStore.getWaitingCount(queueKey);
    if (remainingCount > 0) {
        matchingEventPublisher.publishQueueStateChanged(queueKey, remainingCount);
    }
}
</code></pre>

<p>의미는 아래와 같습니다.</p>
<ul>
<li>user1~4가 매칭되면 이 4명은 더 이상 SEARCHING 대기자가 아님</li>
<li>따라서 queue topic에 <code>waitingCount=4</code>를 보내는 것은 UI 의미상 부정확함</li>
<li>대신 이 4명에게는 개인 handoff 이벤트를 보냄</li>
<li>만약 user5가 같은 queue에 남아 있다면, 남은 대기 인원 수만 별도로 다시 queue topic에 발행</li>
</ul>

<p>즉, queue 상태와 ready-check 상태를 서로 다른 이벤트로 정확하게 분리했습니다.</p>

<h3>7) ready-check 시작 handoff를 4명 각각에게 발행</h3>
<p><code>ReadyCheckService</code> 내부에 <code>publishReadyCheckStarted()</code> 보조 메서드를 추가해, 세션 참가자 4명 각각에게 개인 채널 이벤트를 보내도록 했습니다.</p>

<pre><code class="language-java">private void publishReadyCheckStarted(MatchSession matchSession) {
    matchSession.participantIds().forEach(participantId ->
            matchingEventPublisher.publishReadyCheckStarted(
                    participantId,
                    toMatchStateV2Response(participantId, matchSession)));
}
</code></pre>

<p>여기서 각 사용자에게 보내는 payload는 같은 세션을 기반으로 하되, <code>acceptedByMe</code> 같은 값은 사용자별 응답으로 조립됩니다.</p>
<p>즉, 같은 ready-check 세션이라도 응답은 “내 기준 상태”를 담은 snapshot으로 전달됩니다.</p>

<h3>8) queue cancel 시에도 감소한 waitingCount를 topic으로 발행</h3>
<p>사용자가 아직 SEARCHING 상태에서 queue를 취소하면, 기존처럼 HTTP 응답만 반환하는 것이 아니라 감소한 waitingCount를 즉시 queue topic으로 브로드캐스트하도록 했습니다.</p>

<pre><code class="language-java">MatchStateStore.CancelResult cancelResult = matchStateStore.cancel(userId);
QueueKey queueKey = cancelResult.queueKey();
matchingEventPublisher.publishQueueStateChanged(queueKey, cancelResult.waitingCount());
</code></pre>

<p>즉, 같은 queue를 보고 있는 다른 사용자들도 취소 이후 대기 인원 변화를 바로 반영할 수 있습니다.</p>

<h3>9) ready-check 세션 생성 실패 시 rollback 후 복구된 queue 상태도 발행</h3>
<p><code>tryCreateReadyCheckSession()</code>에서 4명을 poll한 뒤 세션 생성 중 예외가 발생하면, 기존처럼 queue rollback만 하는 것이 아니라 복구된 waitingCount를 다시 queue topic으로 발행하도록 보완했습니다.</p>

<pre><code class="language-java">catch (RuntimeException e) {
    matchStateStore.rollbackPolledUsers(queueKey, matchedUsers);
    matchingEventPublisher.publishQueueStateChanged(queueKey, matchStateStore.getWaitingCount(queueKey));
    throw e;
}
</code></pre>

<p>즉, poll 이후 중간 실패가 나더라도 프론트가 잘못된 queue 상태를 계속 보고 있지 않도록 복구 이벤트를 함께 보냅니다.</p>

<h3>10) WebSocket 개인 채널 라우팅을 위한 Principal 보정 추가</h3>
<p>이번 PR에는 이벤트 발행 자체뿐 아니라, 그 이벤트가 실제로 올바른 사용자에게 전달되도록 하는 WebSocket 라우팅 보정도 포함됩니다.</p>
<p><code>WebSocketConfig</code>에서 cookie 인증과 token 인증 모두에 대해 <code>createWsAuthentication()</code>을 사용하도록 변경하고, 이 인증 객체의 <code>getName()</code>을 userId 문자열로 고정했습니다.</p>

<pre><code class="language-java">private UsernamePasswordAuthenticationToken createWsAuthentication(SecurityUser securityUser) {
    return new UsernamePasswordAuthenticationToken(securityUser, null, securityUser.getAuthorities()) {
        @Override
        public String getName() {
            return String.valueOf(securityUser.getId());
        }
    };
}
</code></pre>

<p>왜 필요한가:</p>
<ul>
<li><code>convertAndSendToUser(...)</code>는 내부적으로 Principal name 기반으로 대상을 찾음</li>
<li>matching handoff는 userId 기준 주소로 보내고 싶음</li>
<li>그래서 WebSocket Principal name을 명시적으로 memberId 문자열로 맞춤</li>
</ul>

<p>즉, cookie 기반이든 token 기반이든 사용자별 matching 이벤트 라우팅 기준을 동일하게 맞췄습니다.</p>

<h3>11) simple broker에 <code>/queue</code> prefix 추가 및 user destination prefix 설정</h3>
<p>이번 브랜치에는 개인 matching handoff가 실제로 전송되도록 broker 설정을 보정한 fix도 함께 포함되어 있습니다.</p>

<pre><code class="language-java">registry.enableSimpleBroker("/topic", "/queue")
        .setHeartbeatValue(new long[] {10000, 10000})
        .setTaskScheduler(scheduler);

registry.setApplicationDestinationPrefixes("/app");
registry.setUserDestinationPrefix("/user");
</code></pre>

<p>핵심은 아래 2가지입니다.</p>
<ul>
<li><code>enableSimpleBroker("/topic", "/queue")</code> : <code>/user/queue/matching</code> 목적지가 실제 broker prefix로 라우팅되도록 보완</li>
<li><code>setUserDestinationPrefix("/user")</code> : 사용자별 개인 채널 규약을 명확히 설정</li>
</ul>

<p>즉, 이번 PR의 두 번째 커밋은 <code>convertAndSendToUser(..., "/queue/matching", ...)</code>가 실제 구독 채널까지 도달할 수 있도록 라우팅 규칙을 맞추는 fix입니다.</p>

<h3>12) 현재 채널 구분</h3>
<table>
<tr><th>채널</th><th>용도</th><th>구독자</th></tr>
<tr><td><code>/topic/matching/queue/{category}/{difficulty}</code></td><td>같은 queueKey 대기열 waitingCount 변화</td><td>SEARCHING 사용자 공용</td></tr>
<tr><td><code>/user/queue/matching</code></td><td>ready-check 시작 handoff</td><td>매칭된 사용자 개인</td></tr>
<tr><td><code>/app/*</code></td><td>클라이언트 → 서버 STOMP SEND</td><td>클라이언트 송신용</td></tr>
</table>

<p>즉, queue 상태는 공용 topic, ready-check 시작은 개인 user 채널로 분리했습니다.</p>

<h3>13) 테스트 추가 및 보강</h3>
<p>이번 PR에서는 WebSocket 이벤트와 라우팅이 의도대로 동작하는지 검증하기 위해 테스트를 함께 추가했습니다.</p>

<p><code>MatchingEventPublisherTest</code></p>
<ul>
<li>queue 상태 변화가 <code>/topic/matching/queue/ARRAY/EASY</code> 같은 topic으로 발행되는지 확인</li>
<li>ready-check 시작 이벤트가 <code>convertAndSendToUser("1", "/queue/matching", ...)</code> 형태로 발행되는지 확인</li>
</ul>

<p><code>ReadyCheckServiceTest</code></p>
<ul>
<li>queue join 시 waitingCount 변화 이벤트가 발행되는지 확인</li>
<li>queue cancel 시 감소한 waitingCount 이벤트가 발행되는지 확인</li>
<li>4번째 join 시 matched 4명에게 <code>READY_CHECK_STARTED</code>가 발행되는지 확인</li>
<li>4번째 join 시 queue waitingCount=4 이벤트는 발행되지 않는지 확인</li>
<li>ready-check 세션 생성 실패 시 rollback 후 복구된 queue 이벤트가 발행되는지 확인</li>
</ul>

<p><code>WebSocketConfigTest</code></p>
<ul>
<li>simple broker에 <code>/queue</code> prefix가 포함되는지 확인</li>
<li>user destination prefix가 <code>/user</code>로 설정되는지 확인</li>
</ul>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">[SEARCHING]
POST /api/v2/queue/join
      ↓
1명/2명/3명 단계
      ↓
QUEUE_STATE_CHANGED 발행
/topic/matching/queue/{category}/{difficulty}
      ↓
프론트가 waitingCount 즉시 갱신

4번째 user join
      ↓
queue 에서 4명 poll
      ↓
ACCEPT_PENDING ready-check 세션 생성
      ↓
READY_CHECK_STARTED 발행
/user/queue/matching
      ↓
매칭된 4명은 ready-check UI로 handoff
      ↓
같은 queue 에 user5 이상이 남아 있으면
남은 waitingCount 를 다시 queue topic 으로 발행

queue cancel
      ↓
감소한 waitingCount 를 queue topic 으로 발행

ready-check 세션 생성 실패
      ↓
poll 했던 4명 rollback
      ↓
복구된 waitingCount 를 queue topic 으로 발행
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>SEARCHING 사용자는 같은 queue의 waitingCount 변화를 polling 없이 즉시 반영할 수 있습니다.</li>
<li>4인 매칭 성사 순간 matched 사용자들은 개인 채널 이벤트로 바로 ready-check UI로 전환할 수 있습니다.</li>
<li>queue topic과 ready-check handoff 채널이 분리되어 프론트 상태 전환이 더 명확해집니다.</li>
<li><code>/queue</code> broker prefix와 user destination 라우팅을 함께 보정해 개인 matching 이벤트 전달이 안정적으로 동작합니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li>같은 queueKey를 구독 중일 때 join/cancel마다 <code>QUEUE_STATE_CHANGED</code> 이벤트가 즉시 오는지 확인</li>
<li>4번째 user join 시 matched 4명만 <code>/user/queue/matching</code>으로 <code>READY_CHECK_STARTED</code>를 받는지 확인</li>
<li>4번째 join 시 queue topic으로 <code>waitingCount=4</code> 이벤트가 가지 않고, handoff 이벤트로 전환되는지 확인</li>
<li>ready-check 세션 생성 실패 시 queue rollback 이후 복구된 waitingCount 이벤트가 다시 발행되는지 확인</li>
<li>cookie 인증 / token 인증 모두에서 user destination 라우팅이 memberId 기준으로 정상 동작하는지 확인</li>
</ol>
</body>
</html>

