### PR TITLE
[fix] run SSM deploy script with bash via heredoc to support pipefail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,6 @@ jobs:
       - name: AWS SSM 배포
         run: |
           DEPLOY_SCRIPT=$(cat << 'SCRIPT_EOF'
-            #!/bin/bash
             set -Eeuo pipefail
 
             # 실행 로그 (타임스탬프 부착)
@@ -299,7 +298,7 @@ jobs:
           SCRIPT_EOF
           )
 
-          PARAMS=$(jq -nc --arg s "$DEPLOY_SCRIPT" '{"commands":[$s]}')
+          PARAMS=$(jq -nc --arg s "$DEPLOY_SCRIPT" '{"commands":["bash << '\''ENDBASH'\''", $s, "ENDBASH"]}')
 
           COMMAND_ID=$(aws ssm send-command \
             --region "${{ secrets.AWS_REGION }}" \


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #이슈번호
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #이슈번호

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
run SSM deploy script with bash via heredoc to support pipefail

---

## ✅ 주요 변경 사항
1) run SSM deploy script with bash via heredoc to support pipefail

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->


---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
