### PR TITLE
[fix] remove cp /bin/zsh lines incompatible with bash heredoc execution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,10 +132,6 @@ jobs:
             exec > >(awk '{ fflush(); print strftime("[%Y-%m-%d %H:%M:%S]"), $0 }' | tee -a "$LOG")
             exec 2> >(awk '{ fflush(); print strftime("[%Y-%m-%d %H:%M:%S]"), $0 }' | tee -a "$LOG" >&2)
 
-            cp "$0" "/tmp/blue_green.${SCRIPT_TS}.sh"
-            cp "$0" "/tmp/blue_green.sh"
-            chmod 755 "/tmp/blue_green.${SCRIPT_TS}.sh" "/tmp/blue_green.sh"
-
             # jq 설치 확인 (없으면 설치)
             which jq || apt-get install -y jq -qq
 


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #이슈번호
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #이슈번호

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
remove cp /bin/zsh lines incompatible with bash heredoc execution

---

## ✅ 주요 변경 사항
1) remove cp /bin/zsh lines incompatible with bash heredoc execution

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
```bash
# 예) ./gradlew test --tests "com.back.domain.email.scheduler.DdayEmailSchedulerTest"
```

- [ ] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
