### PR TITLE
[fix] permit /error endpoint to expose actual health check response

### DIFF
--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
                                 // (쿠키 기반 Principal 전파 또는 X-WS-Token 1회용 토큰 검증)
                                 "/ws/**",
                                 "/actuator/health",
-                                "/actuator/prometheus")
+                                "/actuator/prometheus",
+                                "/error")
                         .permitAll()
                         // 그 외 모든 요청은 인증 필요 (POST /api/v1/ws/token 포함)
                         .anyRequest()


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #이슈번호
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #이슈번호

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
permit /error endpoint to expose actual health check response

---

## ✅ 주요 변경 사항
1) permit /error endpoint to expose actual health check response

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
```bash
# 예) ./gradlew test --tests "com.back.domain.email.scheduler.DdayEmailSchedulerTest"
```

- [ ] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
