### PR TITLE
[fix] add spring-boot-starter-actuator dependency for health and metrics endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-batch")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #이슈번호
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #이슈번호

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
add spring-boot-starter-actuator dependency for health and metrics endpoints

---

## ✅ 주요 변경 사항
1) add spring-boot-starter-actuator dependency for health and metrics endpoints

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
```bash
# 예) ./gradlew test --tests "com.back.domain.email.scheduler.DdayEmailSchedulerTest"
```

- [ ] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
