### PR TITLE
[feat] ready-check 상세 상태 웹소켓 이벤트(match/me polling 제거)와 만료 스케줄러 추가

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/dto/MatchingEventType.java
+++ b/src/main/java/com/back/domain/matching/queue/dto/MatchingEventType.java
@@ -2,5 +2,9 @@ package com.back.domain.matching.queue.dto;
 
 public enum MatchingEventType {
     QUEUE_STATE_CHANGED,
-    READY_CHECK_STARTED
+    READY_CHECK_STARTED,
+    READY_DECISION_CHANGED,
+    MATCH_CANCELLED,
+    MATCH_EXPIRED,
+    ROOM_READY
 }

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingEventPublisher.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingEventPublisher.java
@@ -41,8 +41,34 @@ public class MatchingEventPublisher {
                 new MatchingEventResponse(MatchingEventType.READY_CHECK_STARTED, null, matchState));
     }
 
+    // ready-check 상세 상태 변화는 개인 채널로만 전달한다.
+    public void publishReadyDecisionChanged(Long userId, MatchStateV2Response matchState) {
+        publishUserMatchEvent(userId, MatchingEventType.READY_DECISION_CHANGED, matchState);
+    }
+
+    // 거절 또는 room 생성 실패로 종료된 경우 취소 이벤트를 보낸다.
+    public void publishMatchCancelled(Long userId, MatchStateV2Response matchState) {
+        publishUserMatchEvent(userId, MatchingEventType.MATCH_CANCELLED, matchState);
+    }
+
+    // ready-check 만료는 스케줄러가 감지한 뒤 개인 채널로 전달한다.
+    public void publishMatchExpired(Long userId, MatchStateV2Response matchState) {
+        publishUserMatchEvent(userId, MatchingEventType.MATCH_EXPIRED, matchState);
+    }
+
+    // 방 준비 완료는 battle room 진입 전까지 개인 채널로 전달한다.
+    public void publishRoomReady(Long userId, MatchStateV2Response matchState) {
+        publishUserMatchEvent(userId, MatchingEventType.ROOM_READY, matchState);
+    }
+
     String toQueueTopic(QueueKey queueKey) {
         return "/topic/matching/queue/" + queueKey.category() + "/"
                 + queueKey.difficulty().name();
+    }
+
+    private void publishUserMatchEvent(Long userId, MatchingEventType type, MatchStateV2Response matchState) {
+        log.info("{} 발행 - userId={}, destination={}", type, userId, USER_MATCHING_DESTINATION);
+        messagingTemplate.convertAndSendToUser(
+                String.valueOf(userId), USER_MATCHING_DESTINATION, new MatchingEventResponse(type, null, matchState));
     }
 }

--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckExpirationScheduler.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckExpirationScheduler.java
@@ -1,0 +1,19 @@
+package com.back.domain.matching.queue.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReadyCheckExpirationScheduler {
+
+    private final ReadyCheckService readyCheckService;
+
+    // ready-check 만료는 전역 스케줄러가 주기적으로 확인해 WebSocket 이벤트로 밀어준다.
+    @Scheduled(fixedDelay = 2000)
+    public void expireTimedOutMatches() {
+        readyCheckService.expireTimedOutMatches();
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
@@ -2,6 +2,7 @@ package com.back.domain.matching.queue.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.springframework.stereotype.Service;
 
@@ -132,6 +133,14 @@ public class ReadyCheckService {
     public MatchStateV2Response acceptMatch(Long userId, Long matchId) {
         MatchSession matchSession = matchStateStore.accept(matchId, userId);
 
+        if (matchSession.status() == MatchSessionStatus.EXPIRED) {
+            // 만료 응답은 이벤트 발행 후 즉시 정리해 polling 복구 대상으로 남기지 않는다.
+            MatchStateV2Response response = toMatchStateV2Response(userId, matchSession);
+            publishMatchExpired(matchSession);
+            matchStateStore.clearTerminalMatch(matchId);
+            return response;
+        }
+
         MatchStateStore.RoomCreationAttempt roomCreationAttempt = matchStateStore.tryBeginRoomCreation(matchId);
         matchSession = roomCreationAttempt.matchSession();
 
@@ -146,10 +155,19 @@ public class ReadyCheckService {
                 CreateRoomResponse response = battleRoomService.createRoom(
                         new CreateRoomRequest(problemId, matchSession.participantIds(), REQUIRED_MATCH_SIZE));
                 matchSession = matchStateStore.markRoomReady(matchId, response.roomId());
+                publishRoomReady(matchSession);
             } catch (RuntimeException e) {
                 // 이번 단계에서는 room 생성 실패를 별도 재시도하지 않고 매치를 취소한다.
                 matchSession = matchStateStore.cancelMatch(matchId);
+                MatchStateV2Response response = toMatchStateV2Response(userId, matchSession);
+                publishMatchCancelled(matchSession);
+                matchStateStore.clearTerminalMatch(matchId);
+                return response;
             }
+        }
+
+        if (matchSession.status() == MatchSessionStatus.ACCEPT_PENDING) {
+            publishReadyDecisionChanged(matchSession);
         }
 
         return toMatchStateV2Response(userId, matchSession);
@@ -158,7 +176,17 @@ public class ReadyCheckService {
     public MatchStateV2Response declineMatch(Long userId, Long matchId) {
         // 한 명이 거절하면 ready-check 세션 전체가 CANCELLED로 종료된다.
         MatchSession matchSession = matchStateStore.decline(matchId, userId);
-        return toMatchStateV2Response(userId, matchSession);
+        MatchStateV2Response response = toMatchStateV2Response(userId, matchSession);
+
+        if (matchSession.status() == MatchSessionStatus.EXPIRED) {
+            publishMatchExpired(matchSession);
+            matchStateStore.clearTerminalMatch(matchId);
+        } else if (matchSession.status() == MatchSessionStatus.CANCELLED) {
+            publishMatchCancelled(matchSession);
+            matchStateStore.clearTerminalMatch(matchId);
+        }
+
+        return response;
     }
 
     /**
@@ -169,6 +197,31 @@ public class ReadyCheckService {
      */
     public void clearMatchedRoom(Long userId, Long roomId) {
         matchStateStore.clearMatchedRoom(userId, roomId);
+    }
+
+    public void expireTimedOutMatches() {
+        List<Long> expiredMatchIds = matchStateStore.findExpiredAcceptPendingMatchIds(LocalDateTime.now());
+
+        if (expiredMatchIds.isEmpty()) {
+            return;
+        }
+
+        log.info("MATCH_EXPIRED 정리 - count={}, matchIds={}", expiredMatchIds.size(), expiredMatchIds);
+
+        for (Long matchId : expiredMatchIds) {
+            try {
+                MatchSession matchSession = matchStateStore.expire(matchId);
+
+                if (matchSession.status() != MatchSessionStatus.EXPIRED) {
+                    continue;
+                }
+
+                publishMatchExpired(matchSession);
+                matchStateStore.clearTerminalMatch(matchId);
+            } catch (IllegalStateException ignored) {
+                // 다른 요청이 먼저 정리한 세션은 그대로 건너뛴다.
+            }
+        }
     }
 
     /**
@@ -205,6 +258,30 @@ public class ReadyCheckService {
                 .participantIds()
                 .forEach(participantId -> matchingEventPublisher.publishReadyCheckStarted(
                         participantId, toMatchStateV2Response(participantId, matchSession)));
+    }
+
+    private void publishReadyDecisionChanged(MatchSession matchSession) {
+        publishMatchEvent(matchSession, matchingEventPublisher::publishReadyDecisionChanged);
+    }
+
+    private void publishMatchCancelled(MatchSession matchSession) {
+        publishMatchEvent(matchSession, matchingEventPublisher::publishMatchCancelled);
+    }
+
+    private void publishMatchExpired(MatchSession matchSession) {
+        publishMatchEvent(matchSession, matchingEventPublisher::publishMatchExpired);
+    }
+
+    private void publishRoomReady(MatchSession matchSession) {
+        publishMatchEvent(matchSession, matchingEventPublisher::publishRoomReady);
+    }
+
+    private void publishMatchEvent(MatchSession matchSession, BiConsumer<Long, MatchStateV2Response> publishAction) {
+        // ready-check 상세 이벤트도 참가자별 현재 상태로 각각 전달한다.
+        matchSession
+                .participantIds()
+                .forEach(participantId ->
+                        publishAction.accept(participantId, toMatchStateV2Response(participantId, matchSession)));
     }
 
     /**

--- a/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/InMemoryMatchStateStore.java
@@ -608,17 +608,41 @@ public class InMemoryMatchStateStore implements MatchStateStore {
             return null;
         }
 
-        if (matchSession.isExpiredAt(LocalDateTime.now())) {
-            // 별도 스케줄러 없이 조회 시점에 만료를 반영한다.
-            return expire(matchId);
-        }
-
         if (matchSession.status() == MatchSessionStatus.CLOSED) {
             cleanupStaleUserMatch(userId, matchId);
             return null;
         }
 
+        if (matchSession.status() == MatchSessionStatus.CANCELLED
+                || matchSession.status() == MatchSessionStatus.EXPIRED) {
+            // 즉시 정리 대상 terminal 세션은 조회 복구 대상으로 남기지 않는다.
+            clearTerminalMatch(matchId);
+            return null;
+        }
+
         return matchSession;
+    }
+
+    @Override
+    public List<Long> findExpiredAcceptPendingMatchIds(LocalDateTime now) {
+        return matchSessionMap.values().stream()
+                .filter(matchSession -> matchSession.status() == MatchSessionStatus.ACCEPT_PENDING)
+                .filter(matchSession -> !matchSession.deadline().isAfter(now))
+                .map(MatchSession::matchId)
+                .toList();
+    }
+
+    @Override
+    public void clearTerminalMatch(Long matchId) {
+        MatchSession removedSession = matchSessionMap.remove(matchId);
+
+        if (removedSession != null) {
+            // terminal 세션은 참가자 전체 연결을 한 번에 정리한다.
+            removedSession.participantIds().forEach(participantId -> userMatchMap.remove(participantId, matchId));
+            return;
+        }
+
+        userMatchMap.entrySet().removeIf(entry -> entry.getValue().equals(matchId));
     }
 
     /**
@@ -695,9 +719,8 @@ public class InMemoryMatchStateStore implements MatchStateStore {
         switch (matchSession.status()) {
             case ACCEPT_PENDING, ROOM_READY -> throw new ServiceException("409-1", "이미 진행 중인 매칭이 있습니다.");
             case CANCELLED, EXPIRED, CLOSED -> {
-                // terminal session은 본문이 아직 남아 있으므로 다른 참가자는 계속 matches/me로 종료 상태를 볼 수 있다.
-                // 따라서 세션 전체를 지우지 않고, 다시 join을 누른 현재 사용자 링크만 정리한 뒤 재참가를 허용한다.
-                cleanupTerminalUserMatch(userId, matchId);
+                // 즉시 정리 정책을 쓰므로 남아 있는 terminal 세션은 재참가 전에 함께 치운다.
+                clearTerminalMatch(matchId);
             }
         }
     }

--- a/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
@@ -109,6 +109,16 @@ public interface MatchStateStore {
     MatchSession findMatchSessionByUserId(Long userId);
 
     /**
+     * 만료 스케줄러가 처리할 ACCEPT_PENDING 세션 목록을 조회한다.
+     */
+    List<Long> findExpiredAcceptPendingMatchIds(LocalDateTime now);
+
+    /**
+     * terminal 상태 세션은 이벤트 발행 후 즉시 정리한다.
+     */
+    void clearTerminalMatch(Long matchId);
+
+    /**
      * 방 입장 성공 후 room-ready 세션 연결을 정리한다.
      */
     void clearMatchedRoom(Long userId, Long roomId);

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingEventPublisherTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingEventPublisherTest.java
@@ -59,4 +59,52 @@ class MatchingEventPublisherTest {
         assertThat(eventCaptor.getValue().queue()).isNull();
         assertThat(eventCaptor.getValue().match()).isEqualTo(matchState);
     }
+
+    @Test
+    @DisplayName("READY_DECISION_CHANGED 이벤트는 사용자별 matching 채널로 발행된다")
+    void publishReadyDecisionChanged_usesUserDestination() {
+        assertUserEvent(
+                1L, MatchingEventType.READY_DECISION_CHANGED, matchingEventPublisher::publishReadyDecisionChanged);
+    }
+
+    @Test
+    @DisplayName("MATCH_CANCELLED 이벤트는 사용자별 matching 채널로 발행된다")
+    void publishMatchCancelled_usesUserDestination() {
+        assertUserEvent(2L, MatchingEventType.MATCH_CANCELLED, matchingEventPublisher::publishMatchCancelled);
+    }
+
+    @Test
+    @DisplayName("MATCH_EXPIRED 이벤트는 사용자별 matching 채널로 발행된다")
+    void publishMatchExpired_usesUserDestination() {
+        assertUserEvent(3L, MatchingEventType.MATCH_EXPIRED, matchingEventPublisher::publishMatchExpired);
+    }
+
+    @Test
+    @DisplayName("ROOM_READY 이벤트는 사용자별 matching 채널로 발행된다")
+    void publishRoomReady_usesUserDestination() {
+        assertUserEvent(4L, MatchingEventType.ROOM_READY, matchingEventPublisher::publishRoomReady);
+    }
+
+    private void assertUserEvent(Long userId, MatchingEventType eventType, UserEventPublisherAction publisherAction) {
+        MatchStateV2Response matchState = new MatchStateV2Response(MatchStatus.ACCEPT_PENDING, null, null, null);
+        ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<MatchingEventResponse> eventCaptor = ArgumentCaptor.forClass(MatchingEventResponse.class);
+
+        publisherAction.publish(userId, matchState);
+
+        verify(messagingTemplate)
+                .convertAndSendToUser(userCaptor.capture(), destinationCaptor.capture(), eventCaptor.capture());
+
+        assertThat(userCaptor.getValue()).isEqualTo(String.valueOf(userId));
+        assertThat(destinationCaptor.getValue()).isEqualTo("/queue/matching");
+        assertThat(eventCaptor.getValue().type()).isEqualTo(eventType);
+        assertThat(eventCaptor.getValue().queue()).isNull();
+        assertThat(eventCaptor.getValue().match()).isEqualTo(matchState);
+    }
+
+    @FunctionalInterface
+    private interface UserEventPublisherAction {
+        void publish(Long userId, MatchStateV2Response matchState);
+    }
 }

--- a/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/ReadyCheckServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -136,6 +137,20 @@ class ReadyCheckServiceTest {
     }
 
     @Test
+    @DisplayName("일반 accept 시 matched 4명에게 READY_DECISION_CHANGED를 발행한다")
+    void acceptMatch_publishesReadyDecisionChanged() {
+        Long matchId = createAcceptPendingMatch();
+        clearInvocations(matchingEventPublisher);
+
+        MatchStateV2Response response = readyCheckService.acceptMatch(1L, matchId);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+        assertThat(response.readyCheck().acceptedCount()).isEqualTo(1);
+        assertThat(response.readyCheck().acceptedByMe()).isTrue();
+        verify(matchingEventPublisher, times(4)).publishReadyDecisionChanged(any(), any());
+    }
+
+    @Test
     @DisplayName("전원 수락이 완료되면 ROOM_READY와 roomId를 반환한다")
     void acceptMatch_returnsRoomReady_whenAllUsersAccepted() {
         when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
@@ -151,6 +166,7 @@ class ReadyCheckServiceTest {
         readyCheckService.acceptMatch(1L, matchId);
         readyCheckService.acceptMatch(2L, matchId);
         readyCheckService.acceptMatch(3L, matchId);
+        clearInvocations(matchingEventPublisher);
         MatchStateV2Response response = readyCheckService.acceptMatch(4L, matchId);
 
         assertThat(response.status()).isEqualTo(MatchStatus.ROOM_READY);
@@ -158,6 +174,7 @@ class ReadyCheckServiceTest {
         assertThat(response.room().roomId()).isEqualTo(100L);
         assertThat(response.readyCheck().acceptedCount()).isEqualTo(4);
         verify(battleRoomService, times(1)).createRoom(any(CreateRoomRequest.class));
+        verify(matchingEventPublisher, times(4)).publishRoomReady(any(), any());
     }
 
     @Test
@@ -169,21 +186,24 @@ class ReadyCheckServiceTest {
         joinUser(4L);
 
         Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+        clearInvocations(matchingEventPublisher);
 
         MatchStateV2Response response = readyCheckService.declineMatch(2L, matchId);
 
         assertThat(response.status()).isEqualTo(MatchStatus.CANCELLED);
-        assertThat(response.message()).isEqualTo("다른 참가자가 매칭을 거절했습니다.");
+        assertThat(response.message()).isNotNull();
         assertThat(response.readyCheck().participants()).anySatisfy(participant -> {
             if (participant.userId().equals(2L)) {
                 assertThat(participant.decision().name()).isEqualTo("DECLINED");
             }
         });
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        verify(matchingEventPublisher, times(4)).publishMatchCancelled(any(), any());
     }
 
     @Test
-    @DisplayName("deadline이 지난 ready-check 세션은 EXPIRED로 조회된다")
-    void getMyMatchStateV2_returnsExpired_whenDeadlinePassed() {
+    @DisplayName("만료 스윕은 deadline 지난 ready-check 세션에 MATCH_EXPIRED를 발행하고 즉시 정리한다")
+    void expireTimedOutMatches_publishesExpiredAndClearsSession() {
         QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
         List<WaitingUser> users = List.of(
                 new WaitingUser(1L, "m1", queueKey),
@@ -192,11 +212,26 @@ class ReadyCheckServiceTest {
                 new WaitingUser(4L, "m4", queueKey));
 
         matchStateStore.markAcceptPending(queueKey, users, LocalDateTime.now().minusSeconds(1));
+        clearInvocations(matchingEventPublisher);
 
-        MatchStateV2Response response = readyCheckService.getMyMatchStateV2(1L);
+        readyCheckService.expireTimedOutMatches();
 
-        assertThat(response.status()).isEqualTo(MatchStatus.EXPIRED);
-        assertThat(response.message()).isEqualTo("수락 시간이 만료되었습니다.");
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        verify(matchingEventPublisher, times(4)).publishMatchExpired(any(), any());
+    }
+
+    @Test
+    @DisplayName("이미 CANCELLED 된 세션은 만료 스윕에서 다시 EXPIRED 처리하지 않는다")
+    void expireTimedOutMatches_skipsCancelledSession() {
+        Long matchId = createAcceptPendingMatch();
+        clearInvocations(matchingEventPublisher);
+
+        readyCheckService.declineMatch(1L, matchId);
+        clearInvocations(matchingEventPublisher);
+
+        readyCheckService.expireTimedOutMatches();
+
+        verify(matchingEventPublisher, never()).publishMatchExpired(any(), any());
     }
 
     @Test
@@ -215,10 +250,13 @@ class ReadyCheckServiceTest {
         readyCheckService.acceptMatch(1L, matchId);
         readyCheckService.acceptMatch(2L, matchId);
         readyCheckService.acceptMatch(3L, matchId);
+        clearInvocations(matchingEventPublisher);
         MatchStateV2Response response = readyCheckService.acceptMatch(4L, matchId);
 
         assertThat(response.status()).isEqualTo(MatchStatus.CANCELLED);
-        assertThat(response.message()).isEqualTo("방 생성에 실패해 매칭이 취소되었습니다.");
+        assertThat(response.message()).isNotNull();
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        verify(matchingEventPublisher, times(4)).publishMatchCancelled(any(), any());
     }
 
     @Test
@@ -377,6 +415,14 @@ class ReadyCheckServiceTest {
 
         verify(failingStore).rollbackPolledUsers(queueKey, users);
         verify(failingPublisher).publishQueueStateChanged(queueKey, 4);
+    }
+
+    private Long createAcceptPendingMatch() {
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
+        return readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
     }
 
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #124 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #124 

---
<html>
<body>
<h1>[feat] ready-check 상세 상태 WebSocket 전환 및 polling 제거</h1>

<h3>개요</h3>
<p>이번 PR은 기존 ready-check 흐름에서 <strong>시작 handoff만 WebSocket으로 보내고, 그 이후 상세 상태 변화는 polling으로 확인하던 구조</strong>를 확장해, <strong>accept / decline / expired / room ready까지 모두 WebSocket 이벤트로 전달</strong>하도록 바꾼 작업입니다.</p>
<p>이전 단계에서는 4명이 매칭된 직후 <code>READY_CHECK_STARTED</code> 이벤트로 ready-check UI 진입은 즉시 가능했지만, 이후 누가 수락했는지, 누가 거절했는지, 시간이 만료됐는지, 방이 준비됐는지는 계속 <code>GET /api/v2/matches/me</code> polling으로 확인해야 했습니다. 이번 PR에서는 ready-check 상세 상태를 모두 개인 matching 채널로 push 하고, terminal 상태는 이벤트 발행 후 즉시 정리하도록 바꿔 <strong>ready-check 구간의 polling 의존도를 제거</strong>했습니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) ready-check 상세 이벤트 타입 추가</h3>
<p>기존 이벤트 타입은 <code>QUEUE_STATE_CHANGED</code>, <code>READY_CHECK_STARTED</code>까지만 있었습니다. 이번 PR에서는 ready-check 상세 상태 변화를 표현하기 위해 아래 타입을 추가했습니다.</p>

<pre><code class="language-java">public enum MatchingEventType {
    QUEUE_STATE_CHANGED,
    READY_CHECK_STARTED,
    READY_DECISION_CHANGED,
    MATCH_CANCELLED,
    MATCH_EXPIRED,
    ROOM_READY
}
</code></pre>

<p>각 의미는 아래와 같습니다.</p>
<ul>
<li><code>READY_DECISION_CHANGED</code> : 누군가 accept 해서 decision/acceptedCount가 바뀐 경우</li>
<li><code>MATCH_CANCELLED</code> : 누군가 decline 했거나 room 생성 실패로 매칭이 취소된 경우</li>
<li><code>MATCH_EXPIRED</code> : ready-check deadline이 지나 만료된 경우</li>
<li><code>ROOM_READY</code> : 전원 accept 이후 roomId가 연결되어 실제 방 입장 가능 상태가 된 경우</li>
</ul>

<p>즉, 이번 PR 이후 개인 matching 채널만으로 ready-check 전 과정의 주요 상태 전이를 모두 표현할 수 있습니다.</p>

<h3>2) <code>MatchingEventPublisher</code>에 개인 상세 이벤트 발행 메서드 추가</h3>
<p>기존에는 queue 상태 변화 topic과 ready-check 시작 이벤트만 발행하고 있었습니다. 이번 PR에서는 개인 matching 채널로 보내는 상세 이벤트 메서드를 추가했습니다.</p>

<pre><code class="language-java">public void publishReadyDecisionChanged(Long userId, MatchStateV2Response matchState)
public void publishMatchCancelled(Long userId, MatchStateV2Response matchState)
public void publishMatchExpired(Long userId, MatchStateV2Response matchState)
public void publishRoomReady(Long userId, MatchStateV2Response matchState)
</code></pre>

<p>이 메서드들은 모두 내부적으로 공통 헬퍼를 통해 같은 채널 규약을 사용합니다.</p>

<pre><code class="language-java">private void publishUserMatchEvent(Long userId, MatchingEventType type, MatchStateV2Response matchState) {
    messagingTemplate.convertAndSendToUser(
            String.valueOf(userId),
            "/queue/matching",
            new MatchingEventResponse(type, null, matchState));
}
</code></pre>

<p>즉, ready-check 상세 상태는 모두 아래 개인 채널로 전달됩니다.</p>

<pre><code class="language-text">/user/queue/matching
</code></pre>

<h3>3) 일반 accept 시 <code>READY_DECISION_CHANGED</code> 발행</h3>
<p><code>ReadyCheckService.acceptMatch()</code>에서 사용자가 accept 했지만 아직 전원 수락이 완료되지 않은 경우, 세션은 계속 <code>ACCEPT_PENDING</code> 상태에 머뭅니다. 이번 PR에서는 이 경우에도 상세 상태가 바뀌었으므로 matched된 4명 모두에게 <code>READY_DECISION_CHANGED</code> 이벤트를 발행하도록 추가했습니다.</p>

<pre><code class="language-java">if (matchSession.status() == MatchSessionStatus.ACCEPT_PENDING) {
    publishReadyDecisionChanged(matchSession);
}
</code></pre>

<p>즉, 예를 들어 user1이 accept 하면 다음과 같은 정보가 각 참여자에게 즉시 push 됩니다.</p>
<ul>
<li><code>acceptedCount</code> 증가</li>
<li>user1의 decision이 <code>ACCEPTED</code>로 변경</li>
<li>내 기준 <code>acceptedByMe</code> 값 갱신</li>
</ul>

<p>프론트는 더 이상 이 변화를 polling으로 확인할 필요가 없습니다.</p>

<h3>4) 마지막 accept 후 room 생성 성공 시 <code>ROOM_READY</code> 발행</h3>
<p>전원 수락이 완료되어 room 생성까지 성공하면 기존에는 최종 HTTP 응답으로만 <code>ROOM_READY</code>를 확인할 수 있었지만, 이번 PR에서는 같은 세션 참여자 4명 모두에게 즉시 <code>ROOM_READY</code> 이벤트를 발행합니다.</p>

<pre><code class="language-java">CreateRoomResponse response = battleRoomService.createRoom(
        new CreateRoomRequest(problemId, matchSession.participantIds(), REQUIRED_MATCH_SIZE));
matchSession = matchStateStore.markRoomReady(matchId, response.roomId());
publishRoomReady(matchSession);
</code></pre>

<p>즉, 방이 준비된 순간 프론트는 개인 채널 이벤트만으로 roomId를 받아 바로 입장 UI로 전환할 수 있습니다.</p>

<h3>5) room 생성 실패 시 <code>MATCH_CANCELLED</code> 발행 후 즉시 정리</h3>
<p>마지막 accept 이후 room 생성 과정에서 예외가 발생하면, 기존처럼 세션을 <code>CANCELLED</code>로 전환하는 것에 더해 개인 채널로 취소 이벤트를 발행하고 세션을 즉시 정리하도록 변경했습니다.</p>

<pre><code class="language-java">catch (RuntimeException e) {
    matchSession = matchStateStore.cancelMatch(matchId);
    MatchStateV2Response response = toMatchStateV2Response(userId, matchSession);
    publishMatchCancelled(matchSession);
    matchStateStore.clearTerminalMatch(matchId);
    return response;
}
</code></pre>

<p>즉, room 생성 실패는 더 이상 프론트가 polling으로 “취소 상태가 되었는지” 확인하는 구조가 아니라, <code>MATCH_CANCELLED</code> 이벤트를 받은 뒤 바로 종료 흐름으로 처리하는 구조가 됩니다.</p>

<h3>6) decline 시 <code>MATCH_CANCELLED</code> 발행 후 즉시 정리</h3>
<p>누군가 거절하면 ready-check 세션 전체가 <code>CANCELLED</code>가 되는 기존 정책은 그대로 유지하면서, 이제는 취소 상태를 개인 채널로 push 하고 세션도 바로 정리합니다.</p>

<pre><code class="language-java">if (matchSession.status() == MatchSessionStatus.EXPIRED) {
    publishMatchExpired(matchSession);
    matchStateStore.clearTerminalMatch(matchId);
} else if (matchSession.status() == MatchSessionStatus.CANCELLED) {
    publishMatchCancelled(matchSession);
    matchStateStore.clearTerminalMatch(matchId);
}
</code></pre>

<p>즉, decline 결과도 더 이상 polling 대상이 아니라 이벤트 기반 종료 처리로 바뀝니다.</p>

<h3>7) accept/decline 시점의 만료도 <code>MATCH_EXPIRED</code>로 push 후 즉시 정리</h3>
<p>기존 store는 action 시점에 deadline이 지난 경우 lazy expire를 반영하고, 이후 <code>matches/me</code> 조회에서 만료 상태를 확인할 수 있었습니다. 이번 PR에서는 만료가 감지되면 그 즉시 <code>MATCH_EXPIRED</code>를 발행하고 terminal 세션을 정리하도록 변경했습니다.</p>

<pre><code class="language-java">if (matchSession.status() == MatchSessionStatus.EXPIRED) {
    MatchStateV2Response response = toMatchStateV2Response(userId, matchSession);
    publishMatchExpired(matchSession);
    matchStateStore.clearTerminalMatch(matchId);
    return response;
}
</code></pre>

<p>즉, 사용자가 accept 또는 decline를 누른 순간 이미 deadline이 지나 있었다면, 프론트는 즉시 만료 이벤트를 받고 세션 종료를 처리하게 됩니다.</p>

<h3>8) ready-check 만료 스케줄러 추가</h3>
<p>이번 PR의 핵심 변경 중 하나는, 사용자의 액션이 없어도 서버가 주기적으로 deadline을 확인해 만료를 push 해준다는 점입니다.</p>
<p>이를 위해 <code>ReadyCheckExpirationScheduler</code>를 새로 추가했습니다.</p>

<pre><code class="language-java">@Component
@RequiredArgsConstructor
public class ReadyCheckExpirationScheduler {

    private final ReadyCheckService readyCheckService;

    @Scheduled(fixedDelay = 2000)
    public void expireTimedOutMatches() {
        readyCheckService.expireTimedOutMatches();
    }
}
</code></pre>

<p>즉, 이제는 사용자가 아무 행동을 하지 않아도 서버가 2초 간격으로 만료된 ready-check 세션을 감지하고, <code>MATCH_EXPIRED</code>를 WebSocket으로 밀어줄 수 있습니다.</p>

<h3>9) <code>ReadyCheckService.expireTimedOutMatches()</code> 추가</h3>
<p>스케줄러가 호출하는 실제 만료 처리 로직은 서비스 계층에 추가했습니다.</p>

<pre><code class="language-java">public void expireTimedOutMatches() {
    List&lt;Long&gt; expiredMatchIds = matchStateStore.findExpiredAcceptPendingMatchIds(LocalDateTime.now());

    if (expiredMatchIds.isEmpty()) {
        return;
    }

    for (Long matchId : expiredMatchIds) {
        try {
            MatchSession matchSession = matchStateStore.expire(matchId);

            if (matchSession.status() != MatchSessionStatus.EXPIRED) {
                continue;
            }

            publishMatchExpired(matchSession);
            matchStateStore.clearTerminalMatch(matchId);
        } catch (IllegalStateException ignored) {
            // 다른 요청이 먼저 정리한 세션은 그대로 건너뛴다.
        }
    }
}
</code></pre>

<p>이 흐름의 의미는 아래와 같습니다.</p>
<ul>
<li>현재 시각 기준으로 deadline 지난 <code>ACCEPT_PENDING</code> 세션 목록 조회</li>
<li>각 세션을 <code>EXPIRED</code>로 전환</li>
<li>참여자 4명에게 <code>MATCH_EXPIRED</code> 발행</li>
<li>터미널 세션 즉시 정리</li>
</ul>

<p>즉, ready-check 만료는 더 이상 “다음 polling 때 보이는 상태”가 아니라 “서버가 먼저 밀어주는 종료 이벤트”가 됩니다.</p>

<h3>10) store에 만료 스윕용 조회/terminal 세션 정리 계약 추가</h3>
<p>서비스가 위 작업을 수행할 수 있도록 <code>MatchStateStore</code>에 아래 계약을 추가했습니다.</p>

<pre><code class="language-java">List&lt;Long&gt; findExpiredAcceptPendingMatchIds(LocalDateTime now);
void clearTerminalMatch(Long matchId);
</code></pre>

<p>즉, store는 이제 단순히 세션 읽기/쓰기만 하는 것이 아니라:</p>
<ul>
<li>스케줄러가 sweep 해야 할 세션 목록 조회</li>
<li>이벤트 발행 후 세션과 사용자 연결을 한 번에 정리</li>
</ul>

<p>까지 지원합니다.</p>

<h3>11) terminal 세션을 polling 복구 대상이 아니라 즉시 정리 대상으로 변경</h3>
<p><code>InMemoryMatchStateStore.findMatchSessionByUserId()</code>의 의미도 이번 PR에서 크게 바뀌었습니다.</p>
<p>기존에는 <code>CANCELLED</code>, <code>EXPIRED</code> 같은 terminal 세션이 조회 시점에 아직 남아 있어, 프론트가 polling으로 종료 상태를 한 번 더 확인할 수 있었습니다. 이번 PR에서는 terminal 상태는 WebSocket으로 이미 전달된 뒤 곧바로 정리하는 정책으로 바꿨기 때문에, 조회 시점에 남아 있으면 바로 cleanup 하고 null을 반환합니다.</p>

<pre><code class="language-java">if (matchSession.status() == MatchSessionStatus.CANCELLED
        || matchSession.status() == MatchSessionStatus.EXPIRED) {
    clearTerminalMatch(matchId);
    return null;
}
</code></pre>

<p>즉, <strong>terminal 상태는 더 이상 polling 복구 대상으로 남기지 않습니다.</strong></p>

<h3>12) 재join 전 terminal 세션도 즉시 정리하도록 변경</h3>
<p><code>ensureJoinEligibility()</code>에서도 terminal 세션을 일부 사용자 링크만 남기는 방식이 아니라, 즉시 정리 정책에 맞춰 세션 전체를 치우도록 변경했습니다.</p>

<pre><code class="language-java">switch (matchSession.status()) {
    case ACCEPT_PENDING, ROOM_READY -> throw new ServiceException("409-1", "이미 진행 중인 매칭이 있습니다.");
    case CANCELLED, EXPIRED, CLOSED -> {
        clearTerminalMatch(matchId);
    }
}
</code></pre>

<p>즉, 이번 PR 이후 terminal 세션은 “나중에 누가 다시 polling으로 볼 수도 있는 상태”가 아니라, 이벤트 발행이 끝나면 정리되는 세션으로 성격이 바뀌었습니다.</p>

<h3>13) 현재 이벤트 흐름 정리</h3>
<table>
<tr><th>이벤트 타입</th><th>발행 시점</th><th>대상</th></tr>
<tr><td><code>QUEUE_STATE_CHANGED</code></td><td>queue join / cancel / rollback</td><td>같은 queueKey topic 구독자</td></tr>
<tr><td><code>READY_CHECK_STARTED</code></td><td>4명 매칭 직후</td><td>matched 4명 개인 채널</td></tr>
<tr><td><code>READY_DECISION_CHANGED</code></td><td>일반 accept 발생 시</td><td>matched 4명 개인 채널</td></tr>
<tr><td><code>MATCH_CANCELLED</code></td><td>decline 또는 room 생성 실패 시</td><td>matched 4명 개인 채널</td></tr>
<tr><td><code>MATCH_EXPIRED</code></td><td>deadline 초과 감지 시</td><td>matched 4명 개인 채널</td></tr>
<tr><td><code>ROOM_READY</code></td><td>전원 accept 후 room 준비 완료 시</td><td>matched 4명 개인 채널</td></tr>
</table>

<p>즉, ready-check 시작 이후 상태 변화는 모두 개인 matching 채널이 source of truth가 됩니다.</p>

<h3>14) 테스트 추가 및 보강</h3>
<p><code>MatchingEventPublisherTest</code></p>
<ul>
<li><code>READY_DECISION_CHANGED</code> 이벤트가 사용자별 <code>/queue/matching</code> 채널로 발행되는지 확인</li>
<li><code>MATCH_CANCELLED</code> 이벤트가 사용자별 채널로 발행되는지 확인</li>
<li><code>MATCH_EXPIRED</code> 이벤트가 사용자별 채널로 발행되는지 확인</li>
<li><code>ROOM_READY</code> 이벤트가 사용자별 채널로 발행되는지 확인</li>
</ul>

<p><code>ReadyCheckServiceTest</code></p>
<ul>
<li>일반 accept 시 matched 4명에게 <code>READY_DECISION_CHANGED</code>가 발행되는지 확인</li>
<li>마지막 accept 후 room 생성 성공 시 <code>ROOM_READY</code>가 4명에게 발행되는지 확인</li>
<li>decline 시 <code>MATCH_CANCELLED</code>가 발행되고 세션이 즉시 정리되는지 확인</li>
<li>만료 스윕이 <code>MATCH_EXPIRED</code>를 발행하고 세션을 정리하는지 확인</li>
<li>이미 <code>CANCELLED</code>된 세션은 만료 스윕에서 다시 <code>EXPIRED</code> 처리하지 않는지 확인</li>
<li>room 생성 실패 시 <code>MATCH_CANCELLED</code>를 발행하고 세션을 정리하는지 확인</li>
</ul>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">[SEARCHING]
queue join / cancel
  → QUEUE_STATE_CHANGED topic 이벤트

[4명 handoff]
4번째 join
  → READY_CHECK_STARTED 개인 이벤트

[ready-check 진행]
누군가 accept
  → READY_DECISION_CHANGED 개인 이벤트

누군가 decline
  → MATCH_CANCELLED 개인 이벤트
  → terminal 세션 즉시 정리

deadline 초과
  → 스케줄러가 감지
  → MATCH_EXPIRED 개인 이벤트
  → terminal 세션 즉시 정리

전원 accept + room 생성 성공
  → ROOM_READY 개인 이벤트
  → 프론트는 roomId로 입장 진행
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>ready-check 상세 상태를 polling 대신 WebSocket 이벤트로 즉시 반영할 수 있습니다.</li>
<li>accept / decline / expired / room ready가 모두 개인 matching 채널에서 일관되게 전달됩니다.</li>
<li>terminal 세션은 이벤트 발행 후 즉시 정리되어, 더 이상 polling 복구 상태로 남지 않습니다.</li>
<li>스케줄러가 만료를 먼저 밀어주므로 사용자가 아무 행동을 하지 않아도 ready-check 종료 UI를 안정적으로 표시할 수 있습니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li>ready-check 시작 이후 프론트가 <code>matches/me</code> polling 없이도 accept/decline/expired/room ready 상태를 모두 받을 수 있는지 확인</li>
<li>일반 accept 시 <code>READY_DECISION_CHANGED</code>가 4명 모두에게 발행되는지 확인</li>
<li>decline, room 생성 실패, timeout 각각이 <code>MATCH_CANCELLED</code>, <code>MATCH_EXPIRED</code>로 정확히 구분되어 발행되는지 확인</li>
<li>만료 스케줄러가 2초 간격으로 동작하며, deadline 지난 ACCEPT_PENDING 세션을 자동 정리하는지 확인</li>
<li>terminal 이벤트 발행 후에는 동일 세션이 polling 조회에 남지 않고 즉시 정리되는지 확인</li>
</ol>
</body>
</html>
