### PR TITLE
[feat] 이탈과 재입장 그리고 이탈 시 grace period 도입

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,11 +79,13 @@ dependencies {
 
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.redisson:redisson:3.27.2")
 
     // Testcontainers
     testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
 }
 

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -21,12 +21,14 @@ import com.back.domain.battle.battleroom.dto.RoomResponse;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.repository.ProblemRepository;
 import com.back.global.exception.ServiceException;
 import com.back.global.websocket.BattleCodeStore;
+import com.back.global.websocket.BattleReconnectStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 import lombok.RequiredArgsConstructor;
@@ -43,6 +45,8 @@ public class BattleRoomService {
     private final MemberRepository memberRepository;
     private final WebSocketMessagePublisher publisher;
     private final BattleCodeStore battleCodeStore;
+    private final BattleReconnectStore reconnectStore;
+    private final BattleResultService battleResultService;
 
     @Transactional
     public CreateRoomResponse createRoom(CreateRoomRequest request) {
@@ -98,6 +102,9 @@ public class BattleRoomService {
         //    ABANDONED → 재입장 (PLAYING 상태 방)
         if (participant.getStatus() == BattleParticipantStatus.READY
                 || participant.getStatus() == BattleParticipantStatus.ABANDONED) {
+            if (participant.getStatus() == BattleParticipantStatus.ABANDONED) {
+                reconnectStore.cancelGracePeriod(memberId);
+            }
             participant.join();
             battleParticipantRepository.save(participant);
         } else {
@@ -163,12 +170,40 @@ public class BattleRoomService {
                 .findByBattleRoomAndMember(room, member)
                 .orElseThrow(() -> new ServiceException("403-1", "해당 방의 참여자가 아닙니다."));
 
-        if (participant.getStatus() != BattleParticipantStatus.PLAYING) {
-            throw new ServiceException("400-1", "게임 중인 상태가 아닙니다. 현재 상태: " + participant.getStatus());
+        // ABANDONED: WebSocket이 끊긴 상태에서 의도적 퇴장 — grace period 취소 후 QUIT 처리
+        // PLAYING: 정상 접속 상태에서 의도적 퇴장
+        if (participant.getStatus() == BattleParticipantStatus.ABANDONED) {
+            reconnectStore.cancelGracePeriod(memberId);
+        } else if (participant.getStatus() != BattleParticipantStatus.PLAYING) {
+            throw new ServiceException("400-1", "퇴장할 수 없는 상태입니다. 현재 상태: " + participant.getStatus());
         }
 
         participant.quit();
         battleParticipantRepository.save(participant);
+
+        // 남은 활성 참여자 (PLAYING or ABANDONED) 여부 확인
+        List<BattleParticipant> all = battleParticipantRepository.findByBattleRoom(room);
+        boolean noActiveLeft = all.stream()
+                .noneMatch(p -> p.getStatus() == BattleParticipantStatus.PLAYING
+                        || p.getStatus() == BattleParticipantStatus.ABANDONED);
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                try {
+                    publisher.publish("/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
+                } catch (Exception e) {
+                    log.error("PARTICIPANT_LEFT WebSocket 전송 실패 roomId={}", roomId, e);
+                }
+                if (noActiveLeft) {
+                    try {
+                        battleResultService.settle(roomId);
+                    } catch (Exception e) {
+                        log.error("즉시 정산 실패 roomId={}", roomId, e);
+                    }
+                }
+            }
+        });
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/back/global/redis/RedissonConfig.java
+++ b/src/main/java/com/back/global/redis/RedissonConfig.java
@@ -27,6 +27,9 @@ public class RedissonConfig {
     @Bean(destroyMethod = "shutdown")
     public RedissonClient redissonClient() {
         RedisConnectionDetails.Standalone standalone = redisConnectionDetails.getStandalone();
+        if (standalone == null) {
+            throw new IllegalStateException("RedissonConfig은 Standalone 모드만 지원합니다. Sentinel/Cluster 구성은 지원하지 않습니다.");
+        }
         String host = standalone.getHost();
         int port = standalone.getPort();
 

--- a/src/main/java/com/back/global/redis/RedissonConfig.java
+++ b/src/main/java/com/back/global/redis/RedissonConfig.java
@@ -1,0 +1,37 @@
+package com.back.global.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * RedissonClient 빈 설정.
+ *
+ * <p>@Value("${spring.data.redis.host}") 대신 RedisConnectionDetails를 주입받는 이유:
+ * 테스트 환경에서는 @ServiceConnection이 RedisConnectionDetails 빈으로 연결 정보를 제공하며,
+ * 이 값이 Spring Environment 프로퍼티로 노출되지 않는다.
+ * RedisConnectionDetails를 직접 주입하면 운영(application-dev.yml)과
+ * 테스트(@ServiceConnection) 양쪽에서 모두 올바른 연결 정보를 사용할 수 있다.
+ */
+@Configuration
+@RequiredArgsConstructor
+public class RedissonConfig {
+
+    private final RedisConnectionDetails redisConnectionDetails;
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        RedisConnectionDetails.Standalone standalone = redisConnectionDetails.getStandalone();
+        String host = standalone.getHost();
+        int port = standalone.getPort();
+
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/back/global/scheduler/BattleScheduler.java
+++ b/src/main/java/com/back/global/scheduler/BattleScheduler.java
@@ -23,10 +23,12 @@ public class BattleScheduler {
     private final BattleResultService battleResultService;
 
     /**
-     * 10초마다 타이머가 만료된 PLAYING 방을 조회해 결과 정산
-     * BattleResultService.settle() 내부에서 FINISHED 체크로 중복 정산 방지
+     * 10초마다 타이머가 만료된 PLAYING 방을 조회해 결과 정산.
+     * BattleResultService.settle() 내부에서 FINISHED 체크로 중복 정산 방지.
+     *
+     * <p>ABANDONED 참여자 감지는 GracePeriodConsumer(Redisson DelayedQueue)가 담당.
      */
-    @Scheduled(fixedDelay = 10_000_000)
+    @Scheduled(fixedDelay = 10_000)
     public void checkExpiredRooms() {
         List<BattleRoom> expiredRooms =
                 battleRoomRepository.findByStatusAndTimerEndBefore(BattleRoomStatus.PLAYING, LocalDateTime.now());

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -1,7 +1,6 @@
 package com.back.global.websocket;
 
 import java.security.Principal;
-import java.util.Map;
 
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,7 +12,6 @@ import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
 import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.global.security.SecurityUser;
-import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BattleDisconnectHandler {
 
     private final BattleParticipantRepository battleParticipantRepository;
-    private final WebSocketMessagePublisher publisher;
+    private final BattleReconnectStore reconnectStore;
 
     /**
      * WebSocket 연결이 끊길 때 Spring이 자동으로 발생시키는 이벤트 처리.
@@ -60,9 +58,12 @@ public class BattleDisconnectHandler {
                     participant.abandon();
                     battleParticipantRepository.save(participant);
 
-                    log.info("배틀 이탈 처리 - memberId={}, roomId={}", memberId, roomId);
+                    log.info("배틀 이탈 처리 - memberId={}, roomId={}, grace period 시작", memberId, roomId);
 
-                    publisher.publish("/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
+                    // PARTICIPANT_LEFT를 즉시 보내지 않고 15초 유예 기간 부여.
+                    // 새로고침 등 의도치 않은 끊김 시 재연결 기회를 준다.
+                    // 유예 기간 만료 후 미복귀 시 GracePeriodConsumer가 브로드캐스트.
+                    reconnectStore.startGracePeriod(memberId);
                 });
     }
 }

--- a/src/main/java/com/back/global/websocket/BattleReconnectStore.java
+++ b/src/main/java/com/back/global/websocket/BattleReconnectStore.java
@@ -1,0 +1,73 @@
+package com.back.global.websocket;
+
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RBlockingQueue;
+import org.redisson.api.RDelayedQueue;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 배틀 중 WebSocket 연결 끊김에 대한 재연결 유예 기간(Grace Period)을 관리.
+ *
+ * <p>Key 설계:
+ * <pre>
+ * battle:grace:queue  ZSET → List  — Redisson DelayedQueue 내부 저장소
+ * </pre>
+ *
+ * <p>이전 방식(폴링 스케줄러)과의 차이:
+ * 기존에는 5초마다 스케줄러가 ABANDONED 참여자를 폴링하고 left_sent 키로 중복 발행을 방지했다.
+ * 현재는 disconnect 시점에 15초 지연 메시지를 큐에 등록하고, GracePeriodConsumer가 정확히
+ * 15초 후 한 번만 처리한다. left_sent 키와 스케줄러 폴링이 불필요해진다.
+ *
+ * <p>RDelayedQueue 구조:
+ * RDelayedQueue (ZSET) - offer 시 score = 지금+15초 로 저장
+ *   ↓ 15초 후 Redisson 내부 폴링(100ms)이 이동
+ * RBlockingQueue (List) - GracePeriodConsumer.take()가 꺼냄
+ */
+@Component
+@RequiredArgsConstructor
+public class BattleReconnectStore {
+
+    private final RedissonClient redissonClient;
+
+    @Value("${battle.grace-period-seconds:15}")
+    private long gracePeriodSeconds;
+
+    private static final String GRACE_QUEUE = "battle:grace:queue";
+
+    private RBlockingQueue<String> blockingQueue() {
+        return redissonClient.getBlockingQueue(GRACE_QUEUE);
+    }
+
+    private RDelayedQueue<String> delayedQueue() {
+        return redissonClient.getDelayedQueue(blockingQueue());
+    }
+
+    /**
+     * 유예 기간 시작 — disconnect 시 호출.
+     * DelayedQueue에 15초 후 처리할 메시지를 등록한다.
+     */
+    public void startGracePeriod(Long memberId) {
+        delayedQueue().offer(memberId.toString(), gracePeriodSeconds, TimeUnit.SECONDS);
+    }
+
+    /**
+     * 유예 기간 취소 — 재연결(joinRoom) 또는 의도적 퇴장(exitRoom) 시 호출.
+     * 타이밍에 따라 메시지가 ZSET 또는 List에 있을 수 있으므로 양쪽 모두 제거 시도한다.
+     */
+    public void cancelGracePeriod(Long memberId) {
+        delayedQueue().remove(memberId.toString()); // ZSET에 있으면 제거 (offer 직후 ~ 14.9s)
+        blockingQueue().remove(memberId.toString()); // 이미 List로 이동했으면 거기서도 제거 (15s ~ take() 전)
+    }
+
+    /**
+     * GracePeriodConsumer가 15초 후 처리할 메시지를 꺼내는 큐.
+     */
+    public RBlockingQueue<String> getBlockingQueue() {
+        return blockingQueue();
+    }
+}

--- a/src/main/java/com/back/global/websocket/GracePeriodConsumer.java
+++ b/src/main/java/com/back/global/websocket/GracePeriodConsumer.java
@@ -1,0 +1,82 @@
+package com.back.global.websocket;
+
+import java.util.Map;
+
+import org.redisson.RedissonShutdownException;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Grace Period 만료 메시지를 소비하는 백그라운드 컨슈머.
+ *
+ * Redisson DelayedQueue에 등록된 메시지가 15초 후 BlockingQueue로 이동하면
+ * 이 컨슈머가 꺼내서 PARTICIPANT_LEFT 브로드캐스트 여부를 결정한다.
+ *
+ * 처리 흐름:
+ * blockingQueue.take() → memberId 수신
+ *   → DB 조회: 아직 ABANDONED 상태인지 확인
+ *   → ABANDONED → PARTICIPANT_LEFT 브로드캐스트
+ *   → PLAYING   → 이미 재접속함, 스킵
+ *
+ *
+ * DB 조회를 거치는 이유:
+ * cancelGracePeriod()가 타이밍 상 blockingQueue에서 항목을 제거하지 못한 경우에도
+ * 이미 재접속한 참여자에게 PARTICIPANT_LEFT가 잘못 발행되는 것을 방지한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GracePeriodConsumer {
+
+    private final BattleReconnectStore reconnectStore;
+    private final BattleParticipantRepository battleParticipantRepository;
+    private final WebSocketMessagePublisher publisher;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void startConsuming() {
+        Thread.ofVirtual().name("grace-period-consumer").start(this::consume);
+    }
+
+    private void consume() {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                String item = reconnectStore.getBlockingQueue().take(); // blockingQueue.take() → memberId 수신
+                Long memberId = Long.parseLong(item);
+                handle(memberId);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.info("GracePeriodConsumer 종료");
+                break;
+            } catch (RedissonShutdownException e) {
+                log.info("Redisson 종료 감지 - GracePeriodConsumer 중단");
+                break;
+            } catch (Exception e) {
+                log.error("GracePeriodConsumer 처리 중 오류", e);
+            }
+        }
+    }
+
+    // package-private for testing
+    void handle(Long memberId) {
+        battleParticipantRepository
+                .findAbandonedParticipantByMemberId(
+                        memberId, BattleParticipantStatus.ABANDONED, BattleRoomStatus.PLAYING)
+                .ifPresentOrElse(
+                        p -> {
+                            Long roomId = p.getBattleRoom().getId();
+                            log.info("grace period 만료 - PARTICIPANT_LEFT 전송 memberId={}, roomId={}", memberId, roomId);
+                            publisher.publish(
+                                    "/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
+                        },
+                        () -> log.debug("grace period 만료 - 이미 재접속함, 스킵 memberId={}", memberId));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceExitRoomTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceExitRoomTest.java
@@ -1,0 +1,242 @@
+package com.back.domain.battle.battleroom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.websocket.BattleCodeStore;
+import com.back.global.websocket.BattleReconnectStore;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
+
+class BattleRoomServiceExitRoomTest {
+
+    private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final ProblemRepository problemRepository = mock(ProblemRepository.class);
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
+    private final BattleCodeStore battleCodeStore = mock(BattleCodeStore.class);
+    private final BattleReconnectStore reconnectStore = mock(BattleReconnectStore.class);
+    private final BattleResultService battleResultService = mock(BattleResultService.class);
+
+    private final BattleRoomService sut = new BattleRoomService(
+            battleRoomRepository,
+            battleParticipantRepository,
+            problemRepository,
+            memberRepository,
+            publisher,
+            battleCodeStore,
+            reconnectStore,
+            battleResultService);
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long MEMBER_ID = 10L;
+
+    @Test
+    @DisplayName("PLAYING 참여자가 퇴장하면 QUIT으로 변경되고 PARTICIPANT_LEFT가 브로드캐스트된다")
+    void exitRoom_PLAYING상태_정상퇴장() {
+        BattleRoom room = playingRoom();
+        Member member = mockMember();
+        BattleParticipant participant = playingParticipant(room, member);
+
+        given_room_member_participant(room, member, participant, List.of(participant));
+
+        withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
+
+        assertThat(participant.getStatus()).isEqualTo(BattleParticipantStatus.QUIT);
+        verify(publisher).publish(eq("/topic/room/" + ROOM_ID), any());
+        verify(reconnectStore, never()).cancelGracePeriod(any());
+    }
+
+    @Test
+    @DisplayName("ABANDONED 참여자가 퇴장하면 cancelGracePeriod 후 QUIT으로 변경된다")
+    void exitRoom_ABANDONED상태_cancelGracePeriod_후_quit() {
+        BattleRoom room = playingRoom();
+        Member member = mockMember();
+        BattleParticipant participant = abandonedParticipant(room, member);
+
+        given_room_member_participant(room, member, participant, List.of(participant));
+
+        withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
+
+        verify(reconnectStore).cancelGracePeriod(MEMBER_ID);
+        assertThat(participant.getStatus()).isEqualTo(BattleParticipantStatus.QUIT);
+        verify(publisher).publish(eq("/topic/room/" + ROOM_ID), any());
+    }
+
+    @Test
+    @DisplayName("마지막 활성 참여자가 퇴장하면 즉시 정산된다")
+    void exitRoom_마지막활성참여자_즉시정산() {
+        BattleRoom room = playingRoom();
+        Member member = mockMember();
+        BattleParticipant participant = playingParticipant(room, member);
+
+        BattleParticipant exitedOther = mock(BattleParticipant.class);
+        when(exitedOther.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+
+        given_room_member_participant(room, member, participant, List.of(participant, exitedOther));
+
+        withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
+
+        verify(battleResultService).settle(ROOM_ID);
+    }
+
+    @Test
+    @DisplayName("활성 참여자가 남아있으면 퇴장 시 정산하지 않는다")
+    void exitRoom_활성참여자_남아있으면_정산안함() {
+        BattleRoom room = playingRoom();
+        Member member = mockMember();
+        BattleParticipant participant = playingParticipant(room, member);
+
+        BattleParticipant activeOther = mock(BattleParticipant.class);
+        when(activeOther.getStatus()).thenReturn(BattleParticipantStatus.PLAYING);
+
+        given_room_member_participant(room, member, participant, List.of(participant, activeOther));
+
+        withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
+
+        verify(battleResultService, never()).settle(any());
+    }
+
+    @Test
+    @DisplayName("ABANDONED 참여자만 남아있는 상황에서 퇴장하면 정산되지 않는다")
+    void exitRoom_ABANDONED참여자_남아있으면_정산안함() {
+        BattleRoom room = playingRoom();
+        Member member = mockMember();
+        BattleParticipant participant = playingParticipant(room, member);
+
+        BattleParticipant abandonedOther = mock(BattleParticipant.class);
+        when(abandonedOther.getStatus()).thenReturn(BattleParticipantStatus.ABANDONED);
+
+        given_room_member_participant(room, member, participant, List.of(participant, abandonedOther));
+
+        withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
+
+        verify(battleResultService, never()).settle(any());
+    }
+
+    @Test
+    @DisplayName("PLAYING 상태가 아닌 방에서 exitRoom 호출하면 예외가 발생한다")
+    void exitRoom_방이PLAYING아닐때_예외() {
+        BattleRoom room = mock(BattleRoom.class);
+        when(room.getStatus()).thenReturn(BattleRoomStatus.FINISHED);
+        when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
+
+        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("진행 중인 방이 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("EXIT 상태 참여자가 exitRoom 호출하면 예외가 발생한다")
+    void exitRoom_EXIT상태_예외() {
+        BattleRoom room = playingRoom();
+        Member member = mockMember();
+        BattleParticipant participant = BattleParticipant.create(room, member);
+        participant.join();
+        participant.complete(LocalDateTime.now());
+
+        given_room_member_participant(room, member, participant, List.of());
+
+        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("퇴장할 수 없는 상태입니다.");
+    }
+
+    @Test
+    @DisplayName("QUIT 상태 참여자가 exitRoom 호출하면 예외가 발생한다")
+    void exitRoom_QUIT상태_예외() {
+        BattleRoom room = playingRoom();
+        Member member = mockMember();
+        BattleParticipant participant = BattleParticipant.create(room, member);
+        participant.join();
+        participant.quit();
+
+        given_room_member_participant(room, member, participant, List.of());
+
+        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("퇴장할 수 없는 상태입니다.");
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private BattleRoom playingRoom() {
+        BattleRoom room = mock(BattleRoom.class);
+        when(room.getId()).thenReturn(ROOM_ID);
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        return room;
+    }
+
+    private Member mockMember() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(MEMBER_ID);
+        return member;
+    }
+
+    private BattleParticipant playingParticipant(BattleRoom room, Member member) {
+        BattleParticipant p = BattleParticipant.create(room, member);
+        p.join();
+        return p;
+    }
+
+    private BattleParticipant abandonedParticipant(BattleRoom room, Member member) {
+        BattleParticipant p = BattleParticipant.create(room, member);
+        p.join();
+        p.abandon();
+        return p;
+    }
+
+    private void given_room_member_participant(
+            BattleRoom room, Member member, BattleParticipant participant, List<BattleParticipant> all) {
+        when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+        when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
+                .thenReturn(Optional.of(participant));
+        when(battleParticipantRepository.save(any())).thenReturn(participant);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(all);
+    }
+
+    /**
+     * TransactionSynchronizationManager.registerSynchronization()을 가로채
+     * afterCommit()을 즉시 실행한다. 단위 테스트에서 트랜잭션 없이 afterCommit 로직을 검증하기 위한 헬퍼.
+     */
+    private void withAfterCommit(Runnable action) {
+        try (MockedStatic<TransactionSynchronizationManager> tsm =
+                mockStatic(TransactionSynchronizationManager.class)) {
+            tsm.when(() -> TransactionSynchronizationManager.registerSynchronization(any()))
+                    .thenAnswer(inv -> {
+                        inv.<TransactionSynchronization>getArgument(0).afterCommit();
+                        return null;
+                    });
+            action.run();
+        }
+    }
+}

--- a/src/test/java/com/back/global/websocket/BattleDisconnectHandlerTest.java
+++ b/src/test/java/com/back/global/websocket/BattleDisconnectHandlerTest.java
@@ -1,0 +1,100 @@
+package com.back.global.websocket;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.global.security.SecurityUser;
+
+class BattleDisconnectHandlerTest {
+
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final BattleReconnectStore reconnectStore = mock(BattleReconnectStore.class);
+
+    private final BattleDisconnectHandler sut =
+            new BattleDisconnectHandler(battleParticipantRepository, reconnectStore);
+
+    private static final Long MEMBER_ID = 10L;
+    private static final Long ROOM_ID = 1L;
+
+    @Test
+    @DisplayName("PLAYING 참여자 disconnect시 ABANDONED로 변경되고 grace period가 시작된다")
+    void handleDisconnect_PLAYING참여자_abandon_후_gracePeriod시작() {
+        SessionDisconnectEvent event = mockAuthenticatedEvent(MEMBER_ID);
+
+        BattleRoom room = mock(BattleRoom.class);
+        when(room.getId()).thenReturn(ROOM_ID);
+
+        BattleParticipant participant =
+                BattleParticipant.create(room, mock(com.back.domain.member.member.entity.Member.class));
+        participant.join();
+
+        when(battleParticipantRepository.findPlayingParticipantByMemberId(
+                        MEMBER_ID, BattleParticipantStatus.PLAYING, BattleRoomStatus.PLAYING))
+                .thenReturn(Optional.of(participant));
+
+        sut.handleDisconnect(event);
+
+        com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus status = participant.getStatus();
+        org.assertj.core.api.Assertions.assertThat(status).isEqualTo(BattleParticipantStatus.ABANDONED);
+        verify(reconnectStore).startGracePeriod(MEMBER_ID);
+        verify(battleParticipantRepository).save(participant);
+    }
+
+    @Test
+    @DisplayName("미인증 세션의 disconnect는 무시된다")
+    void handleDisconnect_미인증세션_무시() {
+        SessionDisconnectEvent event = mock(SessionDisconnectEvent.class);
+        when(event.getUser()).thenReturn(null);
+        when(event.getSessionId()).thenReturn("unauthenticated-session");
+
+        sut.handleDisconnect(event);
+
+        verify(battleParticipantRepository, never()).findPlayingParticipantByMemberId(any(), any(), any());
+        verify(reconnectStore, never()).startGracePeriod(any());
+    }
+
+    @Test
+    @DisplayName("배틀 중인 방이 없는 유저의 disconnect는 무시된다")
+    void handleDisconnect_배틀중인방없으면_무시() {
+        SessionDisconnectEvent event = mockAuthenticatedEvent(MEMBER_ID);
+
+        when(battleParticipantRepository.findPlayingParticipantByMemberId(
+                        MEMBER_ID, BattleParticipantStatus.PLAYING, BattleRoomStatus.PLAYING))
+                .thenReturn(Optional.empty());
+
+        sut.handleDisconnect(event);
+
+        verify(reconnectStore, never()).startGracePeriod(any());
+        verify(battleParticipantRepository, never()).save(any());
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private SessionDisconnectEvent mockAuthenticatedEvent(Long memberId) {
+        SecurityUser securityUser = mock(SecurityUser.class);
+        when(securityUser.getId()).thenReturn(memberId);
+
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(securityUser, null, Collections.emptyList());
+
+        SessionDisconnectEvent event = mock(SessionDisconnectEvent.class);
+        when(event.getUser()).thenReturn(auth);
+        return event;
+    }
+}

--- a/src/test/java/com/back/global/websocket/BattleReconnectStoreTest.java
+++ b/src/test/java/com/back/global/websocket/BattleReconnectStoreTest.java
@@ -1,0 +1,83 @@
+package com.back.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * BattleReconnectStore Testcontainers 통합 테스트.
+ *
+ * <p>Spring 컨텍스트 없이 RedissonClient를 직접 생성하므로
+ * GracePeriodConsumer 소비 스레드의 간섭 없이 큐 동작만 검증한다.
+ *
+ * BattleReconnectStore 변경
+ * - GRACE_SECONDS = 15L 상수 → @Value("${battle.grace-period-seconds:15}") 필드로 변경
+ * - 배포 시 기본값 15초 적용, 별도 yml 설정 불필요
+ * grace period를 2초로 단축해 테스트 실행 시간을 최소화한다.
+ *
+ * 설계 포인트
+ * - Spring 컨텍스트 없이 Redisson.create() 직접 사용 → GracePeriodConsumer 소비 스레드 간섭 없음
+ * - ReflectionTestUtils.setField()로 grace period를 2초로 단축 → 테스트가 4초 안에 완료
+ * - flushdb()로 테스트 간 큐 상태 격리
+ */
+@Testcontainers
+class BattleReconnectStoreTest {
+
+    @Container
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    private RedissonClient redissonClient;
+    private BattleReconnectStore store;
+
+    @BeforeEach
+    void setUp() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + REDIS.getHost() + ":" + REDIS.getMappedPort(6379));
+        redissonClient = Redisson.create(config);
+
+        store = new BattleReconnectStore(redissonClient);
+        ReflectionTestUtils.setField(store, "gracePeriodSeconds", 2L);
+
+        redissonClient.getKeys().flushdb();
+    }
+
+    @AfterEach
+    void tearDown() {
+        redissonClient.shutdown();
+    }
+
+    @Test
+    @DisplayName("startGracePeriod 호출 후 2초가 지나면 BlockingQueue에서 memberId를 수신한다")
+    void startGracePeriod_2초후_BlockingQueue에서_수신된다() throws InterruptedException {
+        store.startGracePeriod(1L);
+
+        String received = store.getBlockingQueue().poll(4, TimeUnit.SECONDS);
+
+        assertThat(received).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("cancelGracePeriod 호출 시 만료 후에도 BlockingQueue에서 수신되지 않는다")
+    void cancelGracePeriod_만료전취소시_BlockingQueue에서_수신안된다() throws InterruptedException {
+        store.startGracePeriod(2L);
+        store.cancelGracePeriod(2L);
+
+        String received = store.getBlockingQueue().poll(4, TimeUnit.SECONDS);
+
+        assertThat(received).isNull();
+    }
+}

--- a/src/test/java/com/back/global/websocket/GracePeriodConsumerTest.java
+++ b/src/test/java/com/back/global/websocket/GracePeriodConsumerTest.java
@@ -1,0 +1,84 @@
+package com.back.global.websocket;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
+
+class GracePeriodConsumerTest {
+
+    private final BattleReconnectStore reconnectStore = mock(BattleReconnectStore.class);
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
+
+    private final GracePeriodConsumer sut =
+            new GracePeriodConsumer(reconnectStore, battleParticipantRepository, publisher);
+
+    private static final Long MEMBER_ID = 10L;
+    private static final Long ROOM_ID = 1L;
+
+    @Test
+    @DisplayName("grace period 만료 시 참여자가 ABANDONED이면 PARTICIPANT_LEFT를 브로드캐스트한다")
+    void handle_ABANDONED참여자_PARTICIPANT_LEFT발행() {
+        BattleRoom room = mock(BattleRoom.class);
+        when(room.getId()).thenReturn(ROOM_ID);
+
+        BattleParticipant participant = mock(BattleParticipant.class);
+        when(participant.getBattleRoom()).thenReturn(room);
+
+        when(battleParticipantRepository.findAbandonedParticipantByMemberId(
+                        MEMBER_ID, BattleParticipantStatus.ABANDONED, BattleRoomStatus.PLAYING))
+                .thenReturn(Optional.of(participant));
+
+        sut.handle(MEMBER_ID);
+
+        verify(publisher).publish(eq("/topic/room/" + ROOM_ID), any());
+    }
+
+    @Test
+    @DisplayName("grace period 만료 시 참여자가 이미 재접속했으면 PARTICIPANT_LEFT를 발행하지 않는다")
+    void handle_이미재접속한참여자_발행안함() {
+        when(battleParticipantRepository.findAbandonedParticipantByMemberId(
+                        MEMBER_ID, BattleParticipantStatus.ABANDONED, BattleRoomStatus.PLAYING))
+                .thenReturn(Optional.empty());
+
+        sut.handle(MEMBER_ID);
+
+        verify(publisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("PARTICIPANT_LEFT 발행 시 올바른 roomId와 타입이 포함된다")
+    void handle_발행메시지에_올바른roomId포함() {
+        BattleRoom room = mock(BattleRoom.class);
+        when(room.getId()).thenReturn(ROOM_ID);
+
+        BattleParticipant participant = mock(BattleParticipant.class);
+        when(participant.getBattleRoom()).thenReturn(room);
+
+        when(battleParticipantRepository.findAbandonedParticipantByMemberId(
+                        MEMBER_ID, BattleParticipantStatus.ABANDONED, BattleRoomStatus.PLAYING))
+                .thenReturn(Optional.of(participant));
+
+        sut.handle(MEMBER_ID);
+
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(java.util.Map.of("type", "PARTICIPANT_LEFT", "userId", MEMBER_ID)));
+    }
+}


### PR DESCRIPTION
### 배경

배틀 중 WebSocket 연결이 끊겼을 때, 백엔드는 새로고침인지 의도적 이탈인지 구분할 수 없다.
이를 해결하기 위해 **Grace Period(15초 유예 기간)** 를 도입했다.

- disconnect → DB: PLAYING → ABANDONED + Redis: `battle:reconnect:{memberId}` (TTL 15초)
- 15초 내 재접속 → 정상 복귀, 아무도 모름
- 15초 후 미복귀 → PARTICIPANT_LEFT 브로드캐스트

### 근본 문제: 폴링 스케줄러의 한계

Grace Period 만료를 감지하기 위해 **5초마다 스케줄러가 ABANDONED 참여자를 폴링**하는 방식을 사용했다.
이 폴링 방식이 아래 문제들을 연쇄적으로 만들었다.

**1) 최대 20초 지연**
- Grace Period 15초 + 스케줄러 폴링 최대 5초 = 최대 20초
- 배틀 중 상대방이 이탈했다는 사실을 실시간으로 알 수 없음

**2) left_sent 키의 복잡성**
- 스케줄러가 5초마다 실행되므로, 같은 ABANDONED 참여자를 여러 번 감지할 수 있음
- 이를 막기 위해 `battle:left_sent:{memberId}` (TTL 1시간) 키를 별도 관리해야 함
- 멀티 인스턴스 환경에서는 여러 인스턴스가 동시에 같은 참여자를 감지해 중복 발행 위험
- 재입장 시 `cancelGracePeriod()`에서 left_sent 키도 함께 삭제해야 하는 부담
- 2차 이탈 시 left_sent가 남아있으면 PARTICIPANT_LEFT가 영원히 안 나가는 버그 가능성

**3) 레이스 컨디션**
```
Grace Period 만료
  → 스케줄러: isGracePeriodActive() = false, isLeftNotified() = false 확인
  → joinRoom(): cancelGracePeriod() → participant.join() → PLAYING (커밋)
  → 스케줄러: PARTICIPANT_LEFT 발행 ← 이미 재입장한 유저에게!
```

---

### 폴링 방식의 문제

- 5초마다 스캔 → 최대 20초 지연 가능 (Grace Period 15초 + 스케줄러 폴링 최대 5초 = 최대 20초)
- left_sent 키로 중복 발행 방지 → 키 만료 타이밍에 따라 중복 발행 가능성
- 모든 인스턴스가 동시에 같은 유저를 처리하려는 경합 발생

### DelayedQueue 방식의 개선

- 정확히 15초 후 처리 (Redisson 내부 100ms 폴링)
- BlockingQueue의 take()가 exactly-once 보장 → left_sent 키 불필요
- DB 조회가 최후 안전망으로 타이밍 엣지케이스까지 커버