### PR TITLE
[feat] 배틀룸 참여자가 관전할 수 없도록 제한

### DIFF
--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -92,4 +92,19 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
             @Param("memberId") Long memberId,
             @Param("status") BattleParticipantStatus status,
             @Param("roomStatus") BattleRoomStatus roomStatus);
+
+    /**
+     * 관전 시도 시 해당 유저가 현재 배틀에 참여 중인지 확인하는 용도
+     * PLAYING(정상 참여 중) 또는 ABANDONED(네트워크 이탈) 상태이고 방이 PLAYING 중이면 참여 중으로 간주
+     */
+    @Query("""
+            select p from BattleParticipant p
+            join fetch p.battleRoom r
+            where p.member.id = :memberId
+              and p.status in (
+                  com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.PLAYING,
+                  com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.ABANDONED)
+              and r.status = com.back.domain.battle.battleroom.entity.BattleRoomStatus.PLAYING
+            """)
+    Optional<BattleParticipant> findActiveParticipantByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/back/domain/battle/result/controller/BattleResultController.java
+++ b/src/main/java/com/back/domain/battle/result/controller/BattleResultController.java
@@ -7,9 +7,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.back.domain.battle.result.dto.ActiveRoomResponse;
 import com.back.domain.battle.result.dto.BattleResultResponse;
 import com.back.domain.battle.result.dto.RoomListResponse;
 import com.back.domain.battle.result.service.BattleResultService;
+import com.back.global.rq.Rq;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class BattleResultController {
 
     private final BattleResultService battleResultService;
+    private final Rq rq;
 
     // 최종 결과 조회
     @GetMapping("/rooms/{roomId}/result")
@@ -30,5 +33,12 @@ public class BattleResultController {
     @GetMapping("/rooms")
     public List<RoomListResponse> getRoomList() {
         return battleResultService.getRoomList();
+    }
+
+    // 현재 유저가 참여 중인 배틀방 조회 (관전 시도 시 사전 확인용)
+    @GetMapping("/rooms/me/active")
+    public ActiveRoomResponse getActiveRoom() {
+        Long memberId = rq.getActor().getId();
+        return battleResultService.getActiveRoom(memberId);
     }
 }

--- a/src/main/java/com/back/domain/battle/result/dto/ActiveRoomResponse.java
+++ b/src/main/java/com/back/domain/battle/result/dto/ActiveRoomResponse.java
@@ -1,0 +1,3 @@
+package com.back.domain.battle.result.dto;
+
+public record ActiveRoomResponse(Long roomId) {}

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -21,6 +21,7 @@ import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepo
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.dto.ActiveRoomResponse;
 import com.back.domain.battle.result.dto.BattleResultResponse;
 import com.back.domain.battle.result.dto.BattleResultResponse.ParticipantResult;
 import com.back.domain.battle.result.dto.MyBattleResultsResponse;
@@ -194,6 +195,14 @@ public class BattleResultService {
                 room, participant.getMember(), SubmissionResult.WA, participant.getFinishTime());
 
         return elapsedSeconds + (waPenaltyCount * WA_PENALTY_SECONDS);
+    }
+
+    @Transactional(readOnly = true)
+    public ActiveRoomResponse getActiveRoom(Long memberId) {
+        return battleParticipantRepository
+                .findActiveParticipantByMemberId(memberId)
+                .map(p -> new ActiveRoomResponse(p.getBattleRoom().getId()))
+                .orElse(null);
     }
 
     /**

--- a/src/test/java/com/back/domain/battle/result/controller/BattleResultControllerActiveRoomTest.java
+++ b/src/test/java/com/back/domain/battle/result/controller/BattleResultControllerActiveRoomTest.java
@@ -1,0 +1,66 @@
+package com.back.domain.battle.result.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.back.domain.battle.result.dto.ActiveRoomResponse;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.entity.Member;
+import com.back.global.globalExceptionHandler.GlobalExceptionHandler;
+import com.back.global.rq.Rq;
+
+class BattleResultControllerActiveRoomTest {
+
+    private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final Rq rq = mock(Rq.class);
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        BattleResultController controller = new BattleResultController(battleResultService, rq);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("참여 중인 방이 있으면 roomId를 반환한다")
+    void getActiveRoom_whenExists() throws Exception {
+        // given
+        Member actor = Member.of(10L, "user@test.com", "user");
+
+        when(rq.getActor()).thenReturn(actor);
+        when(battleResultService.getActiveRoom(actor.getId())).thenReturn(new ActiveRoomResponse(42L));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/battle/rooms/me/active"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").value(42));
+    }
+
+    @Test
+    @DisplayName("참여 중인 방이 없으면 null을 반환한다")
+    void getActiveRoom_whenNotExists() throws Exception {
+        // given
+        Member actor = Member.of(10L, "user@test.com", "user");
+
+        when(rq.getActor()).thenReturn(actor);
+        when(battleResultService.getActiveRoom(actor.getId())).thenReturn(null);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/battle/rooms/me/active"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").doesNotExist());
+    }
+}

--- a/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepo
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.dto.ActiveRoomResponse;
 import com.back.domain.battle.result.dto.MyBattleResultsResponse;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.problem.entity.Problem;
@@ -116,5 +118,43 @@ class BattleResultServiceTest {
         assertThatThrownBy(() -> battleResultService.getMyBattleResults(1L, 0, 0))
                 .isInstanceOf(ServiceException.class)
                 .hasMessageContaining("size는 1 이상");
+    }
+
+    @Test
+    @DisplayName("참여 중인 방(PLAYING 또는 ABANDONED)이 있으면 roomId를 반환한다")
+    void getActiveRoom_whenExists() {
+        // given
+        Long memberId = 1L;
+
+        BattleParticipant participant = mock(BattleParticipant.class);
+        BattleRoom room = mock(BattleRoom.class);
+
+        when(participant.getBattleRoom()).thenReturn(room);
+        when(room.getId()).thenReturn(42L);
+        when(battleParticipantRepository.findActiveParticipantByMemberId(memberId))
+                .thenReturn(Optional.of(participant));
+
+        // when
+        ActiveRoomResponse response = battleResultService.getActiveRoom(memberId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.roomId()).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("참여 중인 방이 없으면 null을 반환한다")
+    void getActiveRoom_whenNotExists() {
+        // given
+        Long memberId = 1L;
+
+        when(battleParticipantRepository.findActiveParticipantByMemberId(memberId))
+                .thenReturn(Optional.empty());
+
+        // when
+        ActiveRoomResponse response = battleResultService.getActiveRoom(memberId);
+
+        // then
+        assertThat(response).isNull();
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #145
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #145

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
관전 시도 시 유저가 현재 배틀에 참여 중인지 확인하는 API를 추가했습니다.
참여 중인 방이 있으면 roomId를 반환하여 프론트에서 재입장/포기 여부를 물어볼 수 있습니다.
+ 테스트코드 추가

<p><code>GET /api/v1/battle/rooms/me/active</code></p>

상황 | 응답
-- | --
참여 중인 방 있음 | 200 { "roomId": 123 }
참여 중인 방 없음 | 200 null


<!-- notionvc: 2a7b19c8-8227-48bc-ad58-f078f50c82ba -->

---

## ✅ 주요 변경 사항
- `BattleParticipantRepository`: `findActiveParticipantByMemberId` 추가
    - participant 상태가 `PLAYING` 또는 `ABANDONED`이고 방이 `PLAYING`인 경우 조회
- `ActiveRoomResponse`: 응답 DTO 추가
- `BattleResultService`: `getActiveRoom()` 추가
- `BattleResultController`: `GET /rooms/me/active` 엔드포인트 추가
- 테스트코드 추가

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
| 파일 | 테스트 케이스 |
|---|---|
| BattleResultServiceTest | 참여 중인 방 있을 때 roomId 반환 |
| BattleResultServiceTest | 참여 중인 방 없을 때 null 반환 |
| BattleResultControllerActiveRoomTest | 참여 중인 방 있을 때 200 + roomId |
| BattleResultControllerActiveRoomTest | 참여 중인 방 없을 때 200 + null |

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
