### PR TITLE
[refactor] matching Redis key 규칙과 저장소 스켈레톤 추가

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/store/MatchingStoreProperties.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchingStoreProperties.java
@@ -1,0 +1,31 @@
+package com.back.domain.matching.queue.store;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * matching 상태 저장소 선택 설정을 묶는다.
+ *
+ * 이번 단계에서는 설정 구조만 먼저 도입하고,
+ * 실제 구현체 전환은 다음 하위 이슈에서 연결한다.
+ */
+@ConfigurationProperties(prefix = "matching.store")
+public class MatchingStoreProperties {
+
+    /**
+     * 기본값은 기존 InMemory 저장소를 유지한다.
+     */
+    private StoreType type = StoreType.MEMORY;
+
+    public StoreType getType() {
+        return type;
+    }
+
+    public void setType(StoreType type) {
+        this.type = type;
+    }
+
+    public enum StoreType {
+        MEMORY,
+        REDIS
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/store/MatchingStorePropertiesConfig.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchingStorePropertiesConfig.java
@@ -1,0 +1,14 @@
+package com.back.domain.matching.queue.store;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * matching 저장소 설정 바인딩만 먼저 연다.
+ *
+ * 이번 단계에서는 구현체 스위칭까지 연결하지 않고,
+ * 설정 키와 바인딩 구조만 안전하게 고정한다.
+ */
+@Configuration
+@EnableConfigurationProperties(MatchingStoreProperties.class)
+public class MatchingStorePropertiesConfig {}

--- a/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisKeys.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisKeys.java
@@ -1,0 +1,74 @@
+package com.back.domain.matching.queue.store.redis;
+
+import java.util.Objects;
+
+import com.back.domain.matching.queue.model.QueueKey;
+
+/**
+ * matching Redis key 규칙을 한 곳에 모아 둔다.
+ *
+ * 이후 하위 이슈에서 Redis 저장소 구현이 늘어나더라도
+ * key 네이밍 규칙은 이 유틸만 기준으로 사용한다.
+ */
+public final class MatchingRedisKeys {
+
+    private static final String PREFIX = "matching";
+    private static final String QUEUE_PREFIX = PREFIX + ":queue";
+    private static final String USER_QUEUE_PREFIX = PREFIX + ":user:queue";
+    private static final String USER_MATCH_PREFIX = PREFIX + ":user:match";
+    private static final String MATCH_PREFIX = PREFIX + ":match";
+    private static final String MATCH_DEADLINE_KEY = MATCH_PREFIX + ":deadline";
+    private static final String MATCH_SEQUENCE_KEY = MATCH_PREFIX + ":seq";
+
+    private MatchingRedisKeys() {}
+
+    /**
+     * queue 대기열은 category + difficulty 조합으로 구분한다.
+     */
+    public static String queue(QueueKey queueKey) {
+        Objects.requireNonNull(queueKey, "queueKey must not be null");
+        Objects.requireNonNull(queueKey.category(), "queueKey.category must not be null");
+        Objects.requireNonNull(queueKey.difficulty(), "queueKey.difficulty must not be null");
+        return QUEUE_PREFIX + ":" + queueKey.category() + ":"
+                + queueKey.difficulty().name();
+    }
+
+    /**
+     * user -> queue 연결은 사용자별 단일 key 로 고정한다.
+     */
+    public static String userQueue(Long userId) {
+        return USER_QUEUE_PREFIX + ":" + requireId(userId, "userId");
+    }
+
+    /**
+     * user -> match 연결도 사용자별 단일 key 로 고정한다.
+     */
+    public static String userMatch(Long userId) {
+        return USER_MATCH_PREFIX + ":" + requireId(userId, "userId");
+    }
+
+    /**
+     * match session 본문은 matchId 로 조회한다.
+     */
+    public static String match(Long matchId) {
+        return MATCH_PREFIX + ":" + requireId(matchId, "matchId");
+    }
+
+    /**
+     * deadline index 는 단일 sorted set key 로 유지한다.
+     */
+    public static String matchDeadline() {
+        return MATCH_DEADLINE_KEY;
+    }
+
+    /**
+     * match sequence 도 단일 증가 key 로 유지한다.
+     */
+    public static String matchSequence() {
+        return MATCH_SEQUENCE_KEY;
+    }
+
+    private static Long requireId(Long id, String fieldName) {
+        return Objects.requireNonNull(id, fieldName + " must not be null");
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializer.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializer.java
@@ -62,6 +62,11 @@ public class MatchingRedisSerializer {
     }
 
     private <T> T readValue(String value, Class<T> targetType, String targetName) {
+        // Redis 값이 비어 있는 경우는 호출부가 missing 으로 처리해야 하므로 즉시 실패시킨다.
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(targetName + " JSON 값이 비어 있습니다.");
+        }
+
         try {
             return objectMapper.readValue(value, targetType);
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializer.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializer.java
@@ -1,0 +1,113 @@
+package com.back.domain.matching.queue.store.redis;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import com.back.domain.matching.queue.model.MatchSession;
+import com.back.domain.matching.queue.model.MatchSessionStatus;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.ReadyDecision;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * matching 상태를 Redis 문자열 값으로 저장할 때 사용할 직렬화 규칙을 모은다.
+ *
+ * 이번 단계에서는 StringRedisTemplate + JSON 저장 방식을 기준으로 고정한다.
+ */
+public class MatchingRedisSerializer {
+
+    private final ObjectMapper objectMapper;
+
+    public MatchingRedisSerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * match session 본문은 JSON 문자열 하나로 저장한다.
+     */
+    public String writeMatchSession(MatchSession matchSession) {
+        return writeValue(MatchSessionDocument.from(matchSession), "match session");
+    }
+
+    /**
+     * queue key 도 필요 시 문자열 값으로 저장할 수 있게 같은 규칙을 사용한다.
+     */
+    public String writeQueueKey(QueueKey queueKey) {
+        return writeValue(queueKey, "queue key");
+    }
+
+    /**
+     * Redis 에서 꺼낸 JSON 을 MatchSession 으로 복원한다.
+     */
+    public MatchSession readMatchSession(String value) {
+        MatchSessionDocument document = readValue(value, MatchSessionDocument.class, "match session");
+        return document.toModel();
+    }
+
+    /**
+     * Redis 에서 꺼낸 JSON 을 QueueKey 로 복원한다.
+     */
+    public QueueKey readQueueKey(String value) {
+        return readValue(value, QueueKey.class, "queue key");
+    }
+
+    private String writeValue(Object value, String targetName) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(targetName + " JSON 직렬화에 실패했습니다.", e);
+        }
+    }
+
+    private <T> T readValue(String value, Class<T> targetType, String targetName) {
+        try {
+            return objectMapper.readValue(value, targetType);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(targetName + " JSON 역직렬화에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * MatchSession 의 계산 메서드가 JSON 에 섞이지 않도록
+     * Redis 저장 전용 스냅샷 구조를 별도로 둔다.
+     */
+    private record MatchSessionDocument(
+            Long matchId,
+            QueueKey queueKey,
+            List<Long> participantIds,
+            Map<Long, String> participantNicknames,
+            Map<Long, ReadyDecision> participantDecisions,
+            MatchSessionStatus status,
+            Long roomId,
+            LocalDateTime deadline,
+            LocalDateTime createdAt) {
+
+        private static MatchSessionDocument from(MatchSession matchSession) {
+            return new MatchSessionDocument(
+                    matchSession.matchId(),
+                    matchSession.queueKey(),
+                    matchSession.participantIds(),
+                    matchSession.participantNicknames(),
+                    matchSession.participantDecisions(),
+                    matchSession.status(),
+                    matchSession.roomId(),
+                    matchSession.deadline(),
+                    matchSession.createdAt());
+        }
+
+        private MatchSession toModel() {
+            return new MatchSession(
+                    matchId,
+                    queueKey,
+                    participantIds,
+                    participantNicknames,
+                    participantDecisions,
+                    status,
+                    roomId,
+                    deadline,
+                    createdAt);
+        }
+    }
+}

--- a/src/main/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStore.java
@@ -1,0 +1,147 @@
+package com.back.domain.matching.queue.store.redis;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
+import com.back.domain.matching.queue.model.MatchSession;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.domain.matching.queue.store.MatchStateStore;
+import com.back.domain.matching.queue.store.MatchingStoreProperties;
+
+/**
+ * Redis 기반 matching 저장소 스켈레톤이다.
+ *
+ * 이번 단계에서는 key 규칙, 직렬화 방식, 의존성 구조만 먼저 고정하고
+ * 실제 queue / ready-check 상태 전이는 다음 하위 이슈에서 채운다.
+ *
+ * 아직 런타임 빈으로 연결하지 않았기 때문에 기존 동작에는 영향이 없다.
+ */
+public class RedisMatchStateStore implements MatchStateStore {
+
+    private final StringRedisTemplate redisTemplate;
+    private final MatchingRedisSerializer serializer;
+    private final MatchingStoreProperties storeProperties;
+
+    public RedisMatchStateStore(
+            StringRedisTemplate redisTemplate,
+            MatchingRedisSerializer serializer,
+            MatchingStoreProperties storeProperties) {
+        this.redisTemplate = redisTemplate;
+        this.serializer = serializer;
+        this.storeProperties = storeProperties;
+    }
+
+    @Override
+    public int enqueue(Long userId, String nickname, QueueKey queueKey) {
+        throw unsupported("enqueue");
+    }
+
+    @Override
+    public CancelResult cancel(Long userId) {
+        throw unsupported("cancel");
+    }
+
+    @Override
+    public List<WaitingUser> pollMatchCandidates(QueueKey queueKey, int count) {
+        throw unsupported("pollMatchCandidates");
+    }
+
+    @Override
+    public void rollbackPolledUsers(QueueKey queueKey, List<WaitingUser> users) {
+        throw unsupported("rollbackPolledUsers");
+    }
+
+    @Override
+    public MatchSession markAcceptPending(QueueKey queueKey, List<WaitingUser> matchedUsers, LocalDateTime deadline) {
+        throw unsupported("markAcceptPending");
+    }
+
+    @Override
+    public MatchSession accept(Long matchId, Long userId) {
+        throw unsupported("accept");
+    }
+
+    @Override
+    public MatchSession decline(Long matchId, Long userId) {
+        throw unsupported("decline");
+    }
+
+    @Override
+    public RoomCreationAttempt tryBeginRoomCreation(Long matchId) {
+        throw unsupported("tryBeginRoomCreation");
+    }
+
+    @Override
+    public MatchSession markRoomReady(Long matchId, Long roomId) {
+        throw unsupported("markRoomReady");
+    }
+
+    @Override
+    public MatchSession expire(Long matchId) {
+        throw unsupported("expire");
+    }
+
+    @Override
+    public MatchSession cancelMatch(Long matchId) {
+        throw unsupported("cancelMatch");
+    }
+
+    @Override
+    public int getWaitingCount(QueueKey queueKey) {
+        throw unsupported("getWaitingCount");
+    }
+
+    @Override
+    public QueueStateV2Response getQueueStateV2(Long userId) {
+        throw unsupported("getQueueStateV2");
+    }
+
+    @Override
+    public MatchSession findMatchSessionByUserId(Long userId) {
+        throw unsupported("findMatchSessionByUserId");
+    }
+
+    @Override
+    public List<Long> findExpiredAcceptPendingMatchIds(LocalDateTime now) {
+        throw unsupported("findExpiredAcceptPendingMatchIds");
+    }
+
+    @Override
+    public void clearTerminalMatch(Long matchId) {
+        throw unsupported("clearTerminalMatch");
+    }
+
+    @Override
+    public void clearMatchedRoom(Long userId, Long roomId) {
+        throw unsupported("clearMatchedRoom");
+    }
+
+    /**
+     * 다음 하위 이슈에서 실제 전환을 시작할 때 바로 사용할 기본 의존성 접근점이다.
+     */
+    StringRedisTemplate redisTemplate() {
+        return redisTemplate;
+    }
+
+    /**
+     * 직렬화 방식은 StringRedisTemplate + JSON 조합으로 고정한다.
+     */
+    MatchingRedisSerializer serializer() {
+        return serializer;
+    }
+
+    /**
+     * 설정 구조는 미리 받아 두되, 이번 단계에서는 동작 분기에 연결하지 않는다.
+     */
+    MatchingStoreProperties storeProperties() {
+        return storeProperties;
+    }
+
+    private UnsupportedOperationException unsupported(String methodName) {
+        return new UnsupportedOperationException("RedisMatchStateStore." + methodName + " 는 다음 하위 이슈에서 구현합니다.");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,7 @@ logging:
     org.springframework.transaction.interceptor: DEBUG
     com.back: DEBUG
     org.springframework.security: DEBUG
+
+matching:
+  store:
+    type: memory

--- a/src/test/java/com/back/domain/matching/queue/store/MatchingStorePropertiesTest.java
+++ b/src/test/java/com/back/domain/matching/queue/store/MatchingStorePropertiesTest.java
@@ -1,0 +1,33 @@
+package com.back.domain.matching.queue.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class MatchingStorePropertiesTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner().withUserConfiguration(MatchingStorePropertiesConfig.class);
+
+    @Test
+    @DisplayName("matching.store.type 기본값은 memory 로 바인딩된다")
+    void defaultTypeIsMemory() {
+        contextRunner.run(context -> {
+            MatchingStoreProperties properties = context.getBean(MatchingStoreProperties.class);
+
+            assertThat(properties.getType()).isEqualTo(MatchingStoreProperties.StoreType.MEMORY);
+        });
+    }
+
+    @Test
+    @DisplayName("matching.store.type 설정값을 redis 로 바인딩할 수 있다")
+    void bindsExplicitRedisType() {
+        contextRunner.withPropertyValues("matching.store.type=redis").run(context -> {
+            MatchingStoreProperties properties = context.getBean(MatchingStoreProperties.class);
+
+            assertThat(properties.getType()).isEqualTo(MatchingStoreProperties.StoreType.REDIS);
+        });
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/store/redis/MatchingRedisKeysTest.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/MatchingRedisKeysTest.java
@@ -1,0 +1,30 @@
+package com.back.domain.matching.queue.store.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.QueueKey;
+
+class MatchingRedisKeysTest {
+
+    @Test
+    @DisplayName("queue key 는 category 와 difficulty 조합으로 생성된다")
+    void buildsQueueKey() {
+        QueueKey queueKey = new QueueKey("array", Difficulty.EASY);
+
+        assertThat(MatchingRedisKeys.queue(queueKey)).isEqualTo("matching:queue:ARRAY:EASY");
+    }
+
+    @Test
+    @DisplayName("user 와 match 관련 key 는 단일 규칙으로 생성된다")
+    void buildsUserAndMatchKeys() {
+        assertThat(MatchingRedisKeys.userQueue(7L)).isEqualTo("matching:user:queue:7");
+        assertThat(MatchingRedisKeys.userMatch(7L)).isEqualTo("matching:user:match:7");
+        assertThat(MatchingRedisKeys.match(11L)).isEqualTo("matching:match:11");
+        assertThat(MatchingRedisKeys.matchDeadline()).isEqualTo("matching:match:deadline");
+        assertThat(MatchingRedisKeys.matchSequence()).isEqualTo("matching:match:seq");
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializerTest.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializerTest.java
@@ -1,0 +1,73 @@
+package com.back.domain.matching.queue.store.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.MatchSession;
+import com.back.domain.matching.queue.model.MatchSessionStatus;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.ReadyDecision;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+class MatchingRedisSerializerTest {
+
+    private final MatchingRedisSerializer serializer =
+            new MatchingRedisSerializer(JsonMapper.builder().findAndAddModules().build());
+
+    @Test
+    @DisplayName("QueueKey 는 JSON 으로 직렬화 후 다시 복원할 수 있다")
+    void serializesQueueKeyRoundTrip() {
+        QueueKey queueKey = new QueueKey("graph", Difficulty.HARD);
+
+        String payload = serializer.writeQueueKey(queueKey);
+        QueueKey restored = serializer.readQueueKey(payload);
+
+        assertThat(restored).isEqualTo(queueKey);
+    }
+
+    @Test
+    @DisplayName("MatchSession 은 JSON 으로 직렬화 후 다시 복원할 수 있다")
+    void serializesMatchSessionRoundTrip() {
+        MatchSession session = new MatchSession(
+                15L,
+                new QueueKey("dp", Difficulty.MEDIUM),
+                List.of(1L, 2L, 3L, 4L),
+                participantNicknames(),
+                participantDecisions(),
+                MatchSessionStatus.ACCEPT_PENDING,
+                null,
+                LocalDateTime.of(2026, 4, 6, 12, 30, 0),
+                LocalDateTime.of(2026, 4, 6, 12, 0, 0));
+
+        String payload = serializer.writeMatchSession(session);
+        MatchSession restored = serializer.readMatchSession(payload);
+
+        assertThat(restored).isEqualTo(session);
+    }
+
+    private Map<Long, String> participantNicknames() {
+        Map<Long, String> nicknames = new LinkedHashMap<>();
+        nicknames.put(1L, "m1");
+        nicknames.put(2L, "m2");
+        nicknames.put(3L, "m3");
+        nicknames.put(4L, "m4");
+        return nicknames;
+    }
+
+    private Map<Long, ReadyDecision> participantDecisions() {
+        Map<Long, ReadyDecision> decisions = new LinkedHashMap<>();
+        decisions.put(1L, ReadyDecision.ACCEPTED);
+        decisions.put(2L, ReadyDecision.PENDING);
+        decisions.put(3L, ReadyDecision.PENDING);
+        decisions.put(4L, ReadyDecision.PENDING);
+        return decisions;
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializerTest.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializerTest.java
@@ -1,6 +1,7 @@
 package com.back.domain.matching.queue.store.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
@@ -51,6 +52,22 @@ class MatchingRedisSerializerTest {
         MatchSession restored = serializer.readMatchSession(payload);
 
         assertThat(restored).isEqualTo(session);
+    }
+
+    @Test
+    @DisplayName("비어 있는 MatchSession JSON 은 명시적인 예외로 거부한다")
+    void rejectsBlankMatchSessionJson() {
+        assertThatThrownBy(() -> serializer.readMatchSession(" "))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("match session JSON 값이 비어 있습니다.");
+    }
+
+    @Test
+    @DisplayName("없는 QueueKey JSON 은 명시적인 예외로 거부한다")
+    void rejectsNullQueueKeyJson() {
+        assertThatThrownBy(() -> serializer.readQueueKey(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("queue key JSON 값이 비어 있습니다.");
     }
 
     private Map<Long, String> participantNicknames() {


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #147 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #147 

---

<html>
<body>
<h1>[refactor] matching Redis key 규칙과 저장소 전환 기반 설계</h1>

<h3>개요</h3>
<p>이번 PR은 현재 인메모리 기반으로 동작하는 matching 상태 저장소를 이후 Redis 기반으로 옮길 수 있도록, <strong>설정 구조</strong>, <strong>Redis key 네이밍 규칙</strong>, <strong>직렬화 규약</strong>, <strong>Redis 저장소 스켈레톤</strong>을 먼저 고정하는 작업입니다.</p>
<p>핵심은 이번 단계에서 바로 Redis 저장소를 런타임에 연결하는 것이 아니라, <strong>다음 하위 이슈에서 안전하게 실제 전환을 진행할 수 있도록 기반 설계를 먼저 코드로 고정</strong>하는 데 있습니다. 그래서 기존 인메모리 동작은 그대로 유지하고, Redis 전환에 필요한 key 구조와 serialization contract를 테스트와 함께 먼저 정의했습니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) matching 저장소 선택 설정 구조 추가</h3>
<p><code>MatchingStoreProperties</code>를 새로 추가해 matching 상태 저장소 종류를 설정으로 분리할 수 있는 구조를 만들었습니다.</p>

<pre><code class="language-java">@ConfigurationProperties(prefix = "matching.store")
public class MatchingStoreProperties {

    private StoreType type = StoreType.MEMORY;

    public enum StoreType {
        MEMORY,
        REDIS
    }
}
</code></pre>

<p>의미는 아래와 같습니다.</p>
<ul>
<li><code>MEMORY</code> : 현재 사용 중인 기존 인메모리 저장소</li>
<li><code>REDIS</code> : 다음 하위 이슈에서 실제 구현 연결 예정인 Redis 저장소</li>
</ul>

<p>즉, 저장소 전환 기준을 코드가 아니라 설정 키로 분리할 준비를 먼저 해둔 것입니다.</p>

<h3>2) 설정 바인딩 전용 config 추가</h3>
<p><code>MatchingStorePropertiesConfig</code>를 추가해 위 설정 클래스가 정상적으로 Spring context에 바인딩되도록 했습니다.</p>

<pre><code class="language-java">@Configuration
@EnableConfigurationProperties(MatchingStoreProperties.class)
public class MatchingStorePropertiesConfig {}
</code></pre>

<p>이번 단계에서는 구현체 스위칭까지 붙이지 않고, <strong>설정 키와 바인딩 구조를 먼저 안정적으로 고정</strong>하는 것이 목적입니다.</p>

<h3>3) <code>application.yml</code>에 기본 저장소 타입 추가</h3>
<p>애플리케이션 기본 설정에 matching 저장소 타입을 명시했습니다.</p>

<pre><code class="language-yml">matching:
  store:
    type: memory
</code></pre>

<p>즉, 이번 PR을 적용해도 기본 동작은 그대로 인메모리 저장소를 사용합니다. Redis 관련 코드를 추가했지만, 현재 런타임 동작은 바뀌지 않도록 기본값을 <code>memory</code>로 유지했습니다.</p>

<h3>4) Redis key 네이밍 규칙을 <code>MatchingRedisKeys</code>로 중앙화</h3>
<p>Redis 저장 구조에서 가장 먼저 중요한 것은 key 규칙이기 때문에, 이를 <code>MatchingRedisKeys</code> 유틸로 분리해 한 곳에서 관리하도록 했습니다.</p>

<pre><code class="language-java">private static final String PREFIX = "matching";
private static final String QUEUE_PREFIX = PREFIX + ":queue";
private static final String USER_QUEUE_PREFIX = PREFIX + ":user:queue";
private static final String USER_MATCH_PREFIX = PREFIX + ":user:match";
private static final String MATCH_PREFIX = PREFIX + ":match";
private static final String MATCH_DEADLINE_KEY = MATCH_PREFIX + ":deadline";
private static final String MATCH_SEQUENCE_KEY = MATCH_PREFIX + ":seq";
</code></pre>

<p>실제 key 규칙은 아래처럼 정리됩니다.</p>

<ul>
<li><code>matching:queue:{CATEGORY}:{DIFFICULTY}</code> : queue 대기열</li>
<li><code>matching:user:queue:{userId}</code> : user -&gt; queue 연결</li>
<li><code>matching:user:match:{userId}</code> : user -&gt; match 연결</li>
<li><code>matching:match:{matchId}</code> : match session 본문</li>
<li><code>matching:match:deadline</code> : deadline 인덱스용 단일 sorted set key</li>
<li><code>matching:match:seq</code> : matchId 발급용 단일 증가 key</li>
</ul>

<p>즉, 이후 Redis 구현이 늘어나더라도 key naming 규칙은 이 유틸만 기준으로 사용하게 됩니다.</p>

<h3>5) queue / user / match / deadline / sequence 의 Redis 책임을 미리 분리</h3>
<p>이번 key 설계에서 중요한 포인트는 Redis에 저장할 책임을 처음부터 분리했다는 점입니다.</p>

<ul>
<li>queue 대기열은 <code>category + difficulty</code> 기준 key</li>
<li>사용자별 현재 queue 연결은 별도 key</li>
<li>사용자별 현재 match 연결도 별도 key</li>
<li>match session 본문은 matchId 기준 key</li>
<li>deadline sweep은 단일 index key</li>
<li>match sequence는 별도 증가 key</li>
</ul>

<p>즉, 단순히 모든 상태를 한 JSON에 넣는 방식이 아니라, 현재 인메모리 저장소가 관리하는 책임을 Redis 구조로 어떻게 분해할지 먼저 설계해둔 것입니다.</p>

<h3>6) <code>MatchingRedisSerializer</code> 추가</h3>
<p>Redis 저장 형식은 이번 단계에서 <strong>StringRedisTemplate + JSON 문자열 저장</strong> 방식으로 고정했습니다.</p>

<pre><code class="language-java">public class MatchingRedisSerializer {

    public String writeMatchSession(MatchSession matchSession) { ... }
    public String writeQueueKey(QueueKey queueKey) { ... }

    public MatchSession readMatchSession(String value) { ... }
    public QueueKey readQueueKey(String value) { ... }
}
</code></pre>

<p>즉, Redis에는 matching 상태를 문자열(JSON)로 저장하고, 애플리케이션에서는 이를 다시 모델로 복원하는 방식을 기준으로 삼습니다.</p>

<h3>7) <code>MatchSession</code>은 전용 document 구조로 직렬화</h3>
<p><code>MatchSession</code>은 record이지만 ready-check 계산 메서드와 상태 보조 메서드를 함께 가지고 있기 때문에, Redis 직렬화 시에는 저장 전용 구조를 따로 두는 편이 더 안전합니다. 그래서 <code>MatchingRedisSerializer</code> 내부에 <code>MatchSessionDocument</code>를 별도로 정의했습니다.</p>

<pre><code class="language-java">private record MatchSessionDocument(
        Long matchId,
        QueueKey queueKey,
        List&lt;Long&gt; participantIds,
        Map&lt;Long, String&gt; participantNicknames,
        Map&lt;Long, ReadyDecision&gt; participantDecisions,
        MatchSessionStatus status,
        Long roomId,
        LocalDateTime deadline,
        LocalDateTime createdAt) {
    ...
}
</code></pre>

<p>의도는 아래와 같습니다.</p>
<ul>
<li>Redis에 저장할 데이터 스냅샷을 명확히 분리</li>
<li>모델의 계산 메서드가 JSON 구조에 섞이지 않도록 방지</li>
<li>역직렬화 시에도 동일한 필드 집합으로 다시 <code>MatchSession</code>을 복원</li>
</ul>

<h3>8) <code>QueueKey</code>도 같은 JSON 규칙으로 저장 가능하도록 정리</h3>
<p>Redis에서 queue 관련 보조 값을 저장할 때도 동일한 serializer 규칙을 사용하도록 <code>QueueKey</code> 직렬화/역직렬화 메서드를 함께 추가했습니다.</p>

<pre><code class="language-java">public String writeQueueKey(QueueKey queueKey)
public QueueKey readQueueKey(String value)
</code></pre>

<p>즉, queue 관련 key/value 저장 방식도 match session과 동일한 JSON 규칙 안에서 관리됩니다.</p>

<h3>9) <code>RedisMatchStateStore</code> 스켈레톤 추가</h3>
<p>실제 Redis 기반 저장소 클래스를 새로 추가했지만, 이번 단계에서는 아직 런타임 빈으로 연결하지 않고 스켈레톤만 마련했습니다.</p>

<pre><code class="language-java">public class RedisMatchStateStore implements MatchStateStore {
    private final StringRedisTemplate redisTemplate;
    private final MatchingRedisSerializer serializer;
    private final MatchingStoreProperties storeProperties;

    ...
}
</code></pre>

<p>즉, 다음 하위 이슈에서 실제 Redis 로직을 채워 넣을 자리를 먼저 만들고, 의존성 구조를 확정한 것입니다.</p>

<h3>10) <code>MatchStateStore</code> 전체 계약을 Redis 구현체도 그대로 따르게 설계</h3>
<p><code>RedisMatchStateStore</code>는 현재 사용 중인 <code>MatchStateStore</code> 인터페이스를 그대로 구현합니다.</p>
<p>따라서 이후 Redis 전환 시에도 서비스 계층은 아래와 같은 동일 계약을 기준으로 동작할 수 있습니다.</p>

<ul>
<li><code>enqueue</code></li>
<li><code>cancel</code></li>
<li><code>pollMatchCandidates</code></li>
<li><code>markAcceptPending</code></li>
<li><code>accept</code></li>
<li><code>decline</code></li>
<li><code>tryBeginRoomCreation</code></li>
<li><code>markRoomReady</code></li>
<li><code>expire</code></li>
<li><code>cancelMatch</code></li>
<li><code>getQueueStateV2</code></li>
<li><code>findMatchSessionByUserId</code></li>
<li><code>findExpiredAcceptPendingMatchIds</code></li>
<li><code>clearTerminalMatch</code></li>
<li><code>clearMatchedRoom</code></li>
</ul>

<p>즉, 저장소 구현만 바뀌고 서비스 로직은 최대한 유지하는 방향으로 전환 경계를 준비한 것입니다.</p>

<h3>11) 현재 단계에서는 모든 동작 메서드를 명시적으로 미구현 처리</h3>
<p>이번 PR이 실제 Redis 전환이 아니라 기반 설계 단계인 만큼, <code>RedisMatchStateStore</code>의 동작 메서드는 모두 명시적으로 <code>UnsupportedOperationException</code>을 던지도록 두었습니다.</p>

<pre><code class="language-java">private UnsupportedOperationException unsupported(String methodName) {
    return new UnsupportedOperationException(
            "RedisMatchStateStore." + methodName + " 는 다음 하위 이슈에서 구현합니다.");
}
</code></pre>

<p>이렇게 한 이유는 아래와 같습니다.</p>
<ul>
<li>반쯤 구현된 상태로 런타임에 잘못 연결되는 것을 방지</li>
<li>현재 PR의 범위가 “설계/기반 작업”임을 코드로 명확히 표현</li>
<li>다음 이슈에서 어떤 메서드부터 채워야 하는지 바로 드러나게 함</li>
</ul>

<h3>12) 런타임 전환은 아직 연결하지 않음</h3>
<p>이번 PR에서 특히 중요한 점은, Redis 저장소 클래스를 추가했지만 <strong>실제 애플리케이션이 이 구현체를 사용하도록 스위칭하지는 않았다</strong>는 점입니다.</p>
<p>즉, 아래 작업은 아직 이번 PR 범위가 아닙니다.</p>

<ul>
<li>조건부 bean 등록</li>
<li><code>matching.store.type</code>에 따른 실제 구현체 선택</li>
<li><code>ReadyCheckService</code>나 기존 matching 서비스의 Redis 저장소 연결</li>
<li>Redis 기반 queue / session 조작 로직 구현</li>
</ul>

<p>이번 단계는 말 그대로 <strong>전환 기반을 먼저 안전하게 고정하는 refactor</strong>입니다.</p>

<h3>13) 테스트 추가</h3>
<p>설계 기반 작업이기 때문에, 이번 PR에서는 “동작 구현” 대신 “규칙 고정”을 검증하는 테스트를 추가했습니다.</p>

<p><code>MatchingStorePropertiesTest</code></p>
<ul>
<li><code>matching.store.type</code> 기본값이 <code>memory</code>로 바인딩되는지 확인</li>
<li>설정값을 <code>redis</code>로 바인딩할 수 있는지 확인</li>
</ul>

<p><code>MatchingRedisKeysTest</code></p>
<ul>
<li>queue key가 <code>matching:queue:ARRAY:EASY</code> 형식으로 생성되는지 확인</li>
<li>userQueue, userMatch, match, deadline, sequence key 규칙이 고정된 문자열 형태로 생성되는지 확인</li>
</ul>

<p><code>MatchingRedisSerializerTest</code></p>
<ul>
<li><code>QueueKey</code>가 JSON으로 직렬화/역직렬화 round-trip 가능한지 확인</li>
<li><code>MatchSession</code>이 JSON으로 직렬화/역직렬화 round-trip 가능한지 확인</li>
</ul>

<p>즉, 다음 Redis 구현 이슈에서 바뀌면 안 되는 규칙들을 이번 PR에서 테스트로 먼저 고정해둔 것입니다.</p>

<hr>

<h2>현재 단계의 범위</h2>
<pre><code class="language-text">1. matching.store.type 설정 구조 추가
2. Redis key 규칙 중앙화
3. MatchSession / QueueKey JSON 직렬화 규칙 추가
4. RedisMatchStateStore 스켈레톤 추가
5. 규칙 검증 테스트 추가
6. 런타임 구현체 전환은 아직 하지 않음
</code></pre>

<h2>정리된 효과</h2>
<ul>
<li>matching 상태의 Redis 전환에 필요한 key 구조와 직렬화 규칙이 코드와 테스트로 먼저 고정됩니다.</li>
<li>다음 하위 이슈에서 Redis 저장소 실제 구현을 채울 때 기준점이 명확해집니다.</li>
<li>현재 인메모리 동작에는 영향을 주지 않으면서 전환 준비를 단계적으로 진행할 수 있습니다.</li>
<li>설정 구조, 저장 형식, key naming 규칙을 미리 분리해 이후 변경 비용을 줄입니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li><code>matching.store.type</code> 기본값이 <code>memory</code>이고, <code>redis</code> 값도 정상 바인딩되는지 확인</li>
<li>Redis key 규칙이 queue / userQueue / userMatch / match / deadline / sequence 기준으로 일관되게 생성되는지 확인</li>
<li><code>MatchSession</code>과 <code>QueueKey</code>가 JSON round-trip 직렬화 가능한지 확인</li>
<li><code>RedisMatchStateStore</code>가 아직 런타임에 연결되지 않아 기존 인메모리 동작에 영향이 없는지 확인</li>
</ol>
</body>
</html>

