### PR TITLE
[feat] battleRoom에는 해당 room 참가자만 참여 가능하도록 함

### DIFF
--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -21,6 +21,8 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
 
     Optional<BattleParticipant> findByBattleRoomAndMember(BattleRoom battleRoom, Member member);
 
+    boolean existsByBattleRoomIdAndMemberId(Long battleRoomId, Long memberId);
+
     // 방별 참여자 수 조회 (N+1 방지용 - 전체 로드 없이 COUNT만 조회)
     long countByBattleRoom(BattleRoom battleRoom);
 

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -222,6 +222,10 @@ public class BattleRoomService {
                 .findByIdWithProblem(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
 
+        if (!battleParticipantRepository.existsByBattleRoomIdAndMemberId(roomId, memberId)) {
+            throw new ServiceException("403-1", "해당 방의 참여자가 아닙니다.");
+        }
+
         List<BattleParticipant> participants = battleParticipantRepository.findByBattleRoom(room);
         String myCode = battleCodeStore.get(roomId, memberId);
         return BattleRoomStateResponse.from(room, participants, myCode);

--- a/src/main/java/com/back/global/websocket/BattleRoomSubscribeInterceptor.java
+++ b/src/main/java/com/back/global/websocket/BattleRoomSubscribeInterceptor.java
@@ -1,0 +1,70 @@
+package com.back.global.websocket;
+
+import java.security.Principal;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.global.security.SecurityUser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * STOMP SUBSCRIBE 시 battleRoom 채널(/topic/room/{roomId}) 구독 권한을 검증하는 인터셉터.
+ *
+ * <p>참여자 전용 채널인 /topic/room/{roomId}는 해당 방의 BattleParticipant만 구독 가능.
+ * 관전자 채널(/topic/room/{roomId}/spectate)은 패턴에 걸리지 않으므로 그대로 통과.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BattleRoomSubscribeInterceptor implements ChannelInterceptor {
+
+    private static final Pattern BATTLE_ROOM_TOPIC = Pattern.compile("^/topic/room/(\\d+)$");
+
+    private final BattleParticipantRepository battleParticipantRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null || !StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        String destination = accessor.getDestination();
+        if (destination == null) {
+            return message;
+        }
+
+        Matcher matcher = BATTLE_ROOM_TOPIC.matcher(destination);
+        if (!matcher.matches()) {
+            return message;
+        }
+
+        Long roomId = Long.parseLong(matcher.group(1));
+        Principal principal = accessor.getUser();
+
+        if (!(principal instanceof UsernamePasswordAuthenticationToken auth)
+                || !(auth.getPrincipal() instanceof SecurityUser securityUser)) {
+            log.warn("WebSocket 구독 거부 - 인증 정보 없음 destination={}", destination);
+            return null;
+        }
+
+        if (!battleParticipantRepository.existsByBattleRoomIdAndMemberId(roomId, securityUser.getId())) {
+            log.warn("WebSocket 구독 거부 - 비참여자 memberId={} roomId={}", securityUser.getId(), roomId);
+            return null;
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/com/back/global/websocket/WebSocketConfig.java
+++ b/src/main/java/com/back/global/websocket/WebSocketConfig.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final WsTokenStore wsTokenStore;
+    private final BattleRoomSubscribeInterceptor battleRoomSubscribeInterceptor;
 
     /**
      * STOMP 메시지 인바운드 채널 인터셉터 등록.
@@ -51,47 +52,50 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
      */
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(new ChannelInterceptor() {
-            @Override
-            public Message<?> preSend(Message<?> message, MessageChannel channel) {
-                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                if (accessor == null) return message;
+        registration.interceptors(
+                new ChannelInterceptor() {
+                    @Override
+                    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                        StompHeaderAccessor accessor =
+                                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                        if (accessor == null) return message;
 
-                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-                    Principal principal = accessor.getUser();
+                        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                            Principal principal = accessor.getUser();
 
-                    if (principal instanceof UsernamePasswordAuthenticationToken cookieAuth
-                            && cookieAuth.getPrincipal() instanceof SecurityUser cookieUser) {
-                        // ① 쿠키 기반: Spring이 이미 Principal을 전파해둔 상태
-                        accessor.setUser(createWsAuthentication(cookieUser));
-                        log.info("WebSocket 연결 (쿠키 인증) - memberId={}", cookieUser.getId());
+                            if (principal instanceof UsernamePasswordAuthenticationToken cookieAuth
+                                    && cookieAuth.getPrincipal() instanceof SecurityUser cookieUser) {
+                                // ① 쿠키 기반: Spring이 이미 Principal을 전파해둔 상태
+                                accessor.setUser(createWsAuthentication(cookieUser));
+                                log.info("WebSocket 연결 (쿠키 인증) - memberId={}", cookieUser.getId());
 
-                    } else {
-                        // ② 1회용 토큰 기반: STOMP 헤더에서 토큰 추출 후 Redis 검증
-                        String token = accessor.getFirstNativeHeader("X-WS-Token");
+                            } else {
+                                // ② 1회용 토큰 기반: STOMP 헤더에서 토큰 추출 후 Redis 검증
+                                String token = accessor.getFirstNativeHeader("X-WS-Token");
 
-                        if (token == null) {
-                            // 쿠키도 없고 토큰도 없음 → 연결 거부
-                            log.warn("WebSocket 연결 거부 - 인증 정보 없음 (쿠키/토큰 모두 없음)");
-                            return null;
+                                if (token == null) {
+                                    // 쿠키도 없고 토큰도 없음 → 연결 거부
+                                    log.warn("WebSocket 연결 거부 - 인증 정보 없음 (쿠키/토큰 모두 없음)");
+                                    return null;
+                                }
+
+                                SecurityUser tokenUser = wsTokenStore.resolve(token);
+                                if (tokenUser == null) {
+                                    // 만료되었거나 이미 사용된 토큰 → 연결 거부
+                                    log.warn("WebSocket 연결 거부 - 유효하지 않거나 만료된 토큰");
+                                    return null;
+                                }
+
+                                // 검증 성공: SecurityUser를 STOMP Principal로 등록
+                                accessor.setUser(createWsAuthentication(tokenUser));
+                                log.info("WebSocket 연결 (토큰 인증) - memberId={}", tokenUser.getId());
+                            }
                         }
 
-                        SecurityUser tokenUser = wsTokenStore.resolve(token);
-                        if (tokenUser == null) {
-                            // 만료되었거나 이미 사용된 토큰 → 연결 거부
-                            log.warn("WebSocket 연결 거부 - 유효하지 않거나 만료된 토큰");
-                            return null;
-                        }
-
-                        // 검증 성공: SecurityUser를 STOMP Principal로 등록
-                        accessor.setUser(createWsAuthentication(tokenUser));
-                        log.info("WebSocket 연결 (토큰 인증) - memberId={}", tokenUser.getId());
+                        return message;
                     }
-                }
-
-                return message;
-            }
-        });
+                },
+                battleRoomSubscribeInterceptor);
     }
 
     private UsernamePasswordAuthenticationToken createWsAuthentication(SecurityUser securityUser) {

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceGetRoomStateTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceGetRoomStateTest.java
@@ -1,0 +1,115 @@
+package com.back.domain.battle.battleroom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.dto.BattleRoomStateResponse;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.websocket.BattleCodeStore;
+import com.back.global.websocket.BattleReconnectStore;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
+
+class BattleRoomServiceGetRoomStateTest {
+
+    private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final BattleCodeStore battleCodeStore = mock(BattleCodeStore.class);
+
+    private final BattleRoomService sut = new BattleRoomService(
+            battleRoomRepository,
+            battleParticipantRepository,
+            mock(ProblemRepository.class),
+            mock(MemberRepository.class),
+            mock(WebSocketMessagePublisher.class),
+            battleCodeStore,
+            mock(BattleReconnectStore.class),
+            mock(BattleResultService.class));
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long MEMBER_ID = 10L;
+
+    @Test
+    @DisplayName("참여자가 getRoomState 호출 시 방 상태와 본인 코드를 반환한다")
+    void getRoomState_참여자_정상반환() {
+        BattleRoom room = mockPlayingRoom();
+        when(battleParticipantRepository.existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+                .thenReturn(true);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of());
+        when(battleCodeStore.get(ROOM_ID, MEMBER_ID)).thenReturn("int main() {}");
+
+        BattleRoomStateResponse response = sut.getRoomState(ROOM_ID, MEMBER_ID);
+
+        assertThat(response.roomId()).isEqualTo(ROOM_ID);
+        assertThat(response.myCode()).isEqualTo("int main() {}");
+    }
+
+    @Test
+    @DisplayName("비참여자가 getRoomState 호출 시 403 예외가 발생한다")
+    void getRoomState_비참여자_403예외() {
+        mockPlayingRoom();
+        when(battleParticipantRepository.existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> sut.getRoomState(ROOM_ID, MEMBER_ID))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("해당 방의 참여자가 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("비참여자가 getRoomState 호출 시 participants 조회를 하지 않는다")
+    void getRoomState_비참여자_participants_조회안함() {
+        mockPlayingRoom();
+        when(battleParticipantRepository.existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> sut.getRoomState(ROOM_ID, MEMBER_ID)).isInstanceOf(ServiceException.class);
+
+        verify(battleParticipantRepository, never()).findByBattleRoom(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 방에 getRoomState 호출 시 예외가 발생한다")
+    void getRoomState_존재하지않는방_예외() {
+        when(battleRoomRepository.findByIdWithProblem(ROOM_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.getRoomState(ROOM_ID, MEMBER_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 방입니다.");
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private BattleRoom mockPlayingRoom() {
+        Problem problem = mock(Problem.class);
+        when(problem.getId()).thenReturn(100L);
+
+        BattleRoom room = mock(BattleRoom.class);
+        when(room.getId()).thenReturn(ROOM_ID);
+        when(room.getProblem()).thenReturn(problem);
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        when(battleRoomRepository.findByIdWithProblem(ROOM_ID)).thenReturn(Optional.of(room));
+        return room;
+    }
+
+    private static <T> T any() {
+        return org.mockito.ArgumentMatchers.any();
+    }
+}

--- a/src/test/java/com/back/global/websocket/BattleRoomSubscribeInterceptorTest.java
+++ b/src/test/java/com/back/global/websocket/BattleRoomSubscribeInterceptorTest.java
@@ -1,0 +1,118 @@
+package com.back.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.global.security.SecurityUser;
+
+class BattleRoomSubscribeInterceptorTest {
+
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final BattleRoomSubscribeInterceptor interceptor =
+            new BattleRoomSubscribeInterceptor(battleParticipantRepository);
+    private final MessageChannel channel = mock(MessageChannel.class);
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long MEMBER_ID = 10L;
+
+    @Test
+    @DisplayName("참여자가 /topic/room/{roomId} 구독 시 메시지가 통과된다")
+    void subscribe_참여자_통과() {
+        when(battleParticipantRepository.existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+                .thenReturn(true);
+        Message<?> message = subscribeMessage("/topic/room/" + ROOM_ID, authenticatedUser(MEMBER_ID));
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("비참여자가 /topic/room/{roomId} 구독 시 null을 반환해 구독을 차단한다")
+    void subscribe_비참여자_차단() {
+        when(battleParticipantRepository.existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+                .thenReturn(false);
+        Message<?> message = subscribeMessage("/topic/room/" + ROOM_ID, authenticatedUser(MEMBER_ID));
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("인증 정보 없이 /topic/room/{roomId} 구독 시 null을 반환해 구독을 차단한다")
+    void subscribe_인증없음_차단() {
+        Message<?> message = subscribeMessage("/topic/room/" + ROOM_ID, null);
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNull();
+        verify(battleParticipantRepository, never()).existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("/topic/room/{roomId}/spectate 구독 시 참여자 여부 확인 없이 통과된다")
+    void subscribe_spectate채널_통과() {
+        Message<?> message = subscribeMessage("/topic/room/" + ROOM_ID + "/spectate", authenticatedUser(MEMBER_ID));
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+        verify(battleParticipantRepository, never()).existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBE 아닌 커맨드는 참여자 확인 없이 통과된다")
+    void nonSubscribeCommand_통과() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+        accessor.setDestination("/app/room/" + ROOM_ID + "/code");
+        accessor.setSessionId("session1");
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+        verify(battleParticipantRepository, never()).existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("/topic/matching 같은 다른 채널 구독 시 참여자 확인 없이 통과된다")
+    void subscribe_다른채널_통과() {
+        Message<?> message = subscribeMessage("/topic/matching", authenticatedUser(MEMBER_ID));
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isNotNull();
+        verify(battleParticipantRepository, never()).existsByBattleRoomIdAndMemberId(ROOM_ID, MEMBER_ID);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private Message<?> subscribeMessage(String destination, UsernamePasswordAuthenticationToken principal) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        accessor.setSessionId("session1");
+        if (principal != null) {
+            accessor.setUser(principal);
+        }
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private UsernamePasswordAuthenticationToken authenticatedUser(Long memberId) {
+        SecurityUser securityUser = new SecurityUser(memberId, "user@test.com", "user", "ROLE_USER");
+        return new UsernamePasswordAuthenticationToken(securityUser, null, securityUser.getAuthorities());
+    }
+}

--- a/src/test/java/com/back/global/websocket/WebSocketConfigTest.java
+++ b/src/test/java/com/back/global/websocket/WebSocketConfigTest.java
@@ -17,7 +17,8 @@ class WebSocketConfigTest {
     @DisplayName("개인 matching 채널 라우팅을 위해 simple broker에 /queue prefix를 포함한다")
     @SuppressWarnings("unchecked")
     void configureMessageBroker_includesQueuePrefixForUserDestination() {
-        WebSocketConfig webSocketConfig = new WebSocketConfig(mock(WsTokenStore.class));
+        WebSocketConfig webSocketConfig =
+                new WebSocketConfig(mock(WsTokenStore.class), mock(BattleRoomSubscribeInterceptor.class));
         MessageBrokerRegistry registry =
                 new MessageBrokerRegistry(new ExecutorSubscribableChannel(), new ExecutorSubscribableChannel());
 


### PR DESCRIPTION
### 방에 참가한 사람들 외의 사람들이 방에 들어오지 못하도록 하기

```java
비참여자가 battleRoom URL 접근 시도
        │
        ▼
GET /api/v1/battle/rooms/{roomId}  ← 차단x (관전에서 사용)
GET /api/v1/battle/rooms/{roomId}/state  ← participant 체크 추가 (재입장 전용)
        │ (통과하면)
        ▼
WebSocket /topic/room/{roomId} 구독  ← BattleRoomSubscribeInterceptor에서 차단
```

### 차단 범위

| 엔드포인트/구독 | 처리 방향 |
| --- | --- |
| `GET /{roomId}` (getRoomInfo) | 그대로 공개 유지 (관전 화면이 사용) |
| `GET /{roomId}/state` (getRoomState) | participant 체크 추가 (재입장 전용) |
| WebSocket `/topic/room/{roomId}` | participant 체크 추가 (배틀 이벤트 채널) |
| WebSocket `/topic/room/{roomId}/spectate` | 그대로 공개 유지 (관전자용 코드 채널) |

### 구현

1. `getRoomState`에 participant 체크
2. WebSocket SUBSCRIBE 인터셉터에서 `/topic/room/{roomId}` 만 participant 체크

### 변경된 파일 요약

1. BattleParticipantRepository.java
    - existsByBattleRoomIdAndMemberId(Long, Long) 메서드 추가
    - Spring Data JPA가 자동으로 EXISTS 쿼리 생성 (객체 로딩 없이 효율적)
2. BattleRoomService.java — getRoomState()
    - GET /{roomId}/state 호출 시 participant 여부 확인
    - 비참여자면 403-1 예외
3. WebSocketConfig.java
- `BattleRoomSubscribeInterceptor`를 주입받아
`registration.interceptors(..., battleRoomSubscribeInterceptor)`로 등록
1. BattleRoomSubscribeInterceptor.java
    - SUBSCRIBE 로직만 담당하는 독립 `@Component`
    - BATTLE_ROOM_TOPIC 정규식 상수 추가: /topic/room/{숫자} 패턴만 체크
    - SUBSCRIBE 시 destination이 해당 패턴이면 participant 검증
    - /topic/room/123/spectate는 패턴에 안 걸려서 관전자 그대로 통과

### 프론트에 전달할 사항

`GET /api/v1/battle/rooms/{roomId}/state` — 비참여자 접근 시 이제 403 반환
이전엔 아무나 호출해도 됐는데, 이제 참여자만 200 반환하고 비참여자는 403 반환함
프론트에서 이 엔드포인트 호출하는 곳이 있으면 403 응답 처리가 필요한지 확인 부탁

WebSocket /topic/room/{roomId} 구독 거부는 STOMP 레벨에서 조용히 막히는 거라 프론트 동작에 별도 처리가 필요하진 않지만, 혹시 구독 실패 시 에러 핸들링 로직이 있다면 비참여자 접근 케이스도 커버되는지 확인하면 좋음

### 관련 테스트

`BattleRoomServiceGetRoomStateTest`

| 테스트 | 검증 내용 |
| --- | --- |
| 참여자 정상반환 | 방 상태 + 본인 코드 반환 |
| 비참여자 403 예외 | `ServiceException` 발생 |
| 비참여자 시 participants 조회 안 함 | 불필요한 DB 쿼리 차단 확인 |
| 존재하지 않는 방 | `IllegalArgumentException` 발생 |

`BattleRoomSubscribeInterceptorTest`

| 테스트 | 검증 내용 |
| --- | --- |
| 참여자 구독 | 메시지 통과 |
| 비참여자 구독 | null 반환 (차단) |
| 인증 없이 구독 | null 반환, DB 조회 안 함 |
| `/spectate` 채널 구독 | 참여자 확인 없이 통과 |
| SUBSCRIBE 외 커맨드 | 참여자 확인 없이 통과 |
| 다른 채널 구독 | 참여자 확인 없이 통과 |