### PR TITLE
[refactor] queue 상태를 Redis 기반 hybrid store로 전환

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/model/WaitingUser.java
+++ b/src/main/java/com/back/domain/matching/queue/model/WaitingUser.java
@@ -42,10 +42,17 @@ public class WaitingUser {
      * joinedAt은 객체가 생성되는 현재 시각으로 자동 저장한다.
      */
     public WaitingUser(Long userId, String nickname, QueueKey queueKey) {
+        this(userId, nickname, queueKey, LocalDateTime.now());
+    }
+
+    /**
+     * Redis 직렬화 복원처럼 joinedAt을 유지해야 하는 경우에만 사용한다.
+     */
+    public WaitingUser(Long userId, String nickname, QueueKey queueKey, LocalDateTime joinedAt) {
         this.userId = userId;
         this.nickname = nickname;
         this.queueKey = queueKey;
-        this.joinedAt = LocalDateTime.now();
+        this.joinedAt = joinedAt;
     }
 
     // 대기 중인 사용자의 ID 반환

--- a/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializer.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializer.java
@@ -4,10 +4,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.stereotype.Component;
+
 import com.back.domain.matching.queue.model.MatchSession;
 import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.ReadyDecision;
+import com.back.domain.matching.queue.model.WaitingUser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -16,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * 이번 단계에서는 StringRedisTemplate + JSON 저장 방식을 기준으로 고정한다.
  */
+@Component
 public class MatchingRedisSerializer {
 
     private final ObjectMapper objectMapper;
@@ -39,6 +43,13 @@ public class MatchingRedisSerializer {
     }
 
     /**
+     * queue list와 userQueue index에는 같은 WaitingUser JSON 문자열을 저장한다.
+     */
+    public String writeWaitingUser(WaitingUser waitingUser) {
+        return writeValue(WaitingUserDocument.from(waitingUser), "waiting user");
+    }
+
+    /**
      * Redis 에서 꺼낸 JSON 을 MatchSession 으로 복원한다.
      */
     public MatchSession readMatchSession(String value) {
@@ -51,6 +62,14 @@ public class MatchingRedisSerializer {
      */
     public QueueKey readQueueKey(String value) {
         return readValue(value, QueueKey.class, "queue key");
+    }
+
+    /**
+     * queue list와 userQueue index는 같은 복원 규칙을 사용한다.
+     */
+    public WaitingUser readWaitingUser(String value) {
+        WaitingUserDocument document = readValue(value, WaitingUserDocument.class, "waiting user");
+        return document.toModel();
     }
 
     private String writeValue(Object value, String targetName) {
@@ -113,6 +132,24 @@ public class MatchingRedisSerializer {
                     roomId,
                     deadline,
                     createdAt);
+        }
+    }
+
+    /**
+     * WaitingUser도 joinedAt을 유지해야 rollback과 디버깅 시점이 흐려지지 않는다.
+     */
+    private record WaitingUserDocument(Long userId, String nickname, QueueKey queueKey, LocalDateTime joinedAt) {
+
+        private static WaitingUserDocument from(WaitingUser waitingUser) {
+            return new WaitingUserDocument(
+                    waitingUser.getUserId(),
+                    waitingUser.getNickname(),
+                    waitingUser.getQueueKey(),
+                    waitingUser.getJoinedAt());
+        }
+
+        private WaitingUser toModel() {
+            return new WaitingUser(userId, nickname, queueKey, joinedAt);
         }
     }
 }

--- a/src/main/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStore.java
@@ -1,123 +1,284 @@
 package com.back.domain.matching.queue.store.redis;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
 
 import com.back.domain.matching.queue.dto.QueueStateV2Response;
 import com.back.domain.matching.queue.model.MatchSession;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
 import com.back.domain.matching.queue.store.MatchStateStore;
 import com.back.domain.matching.queue.store.MatchingStoreProperties;
+import com.back.global.exception.ServiceException;
 
 /**
- * Redis 기반 matching 저장소 스켈레톤이다.
+ * Redis 기반 matching 저장소다.
  *
- * 이번 단계에서는 key 규칙, 직렬화 방식, 의존성 구조만 먼저 고정하고
- * 실제 queue / ready-check 상태 전이는 다음 하위 이슈에서 채운다.
+ * 이번 단계에서는 SEARCHING 구간의 queue 상태만 Redis로 옮기고,
+ * ready-check 세션 본문과 상태 전이는 기존 인메모리 구현에 위임한다.
  *
- * 아직 런타임 빈으로 연결하지 않았기 때문에 기존 동작에는 영향이 없다.
+ * 즉 queue는 Redis, ready-check는 memory인 하이브리드 저장소이며
+ * 다음 하위 이슈에서 ready-check 전이도 Redis로 옮길 수 있게 경계를 먼저 만든다.
  */
+@Primary
+@Component
+@ConditionalOnProperty(prefix = "matching.store", name = "type", havingValue = "redis")
 public class RedisMatchStateStore implements MatchStateStore {
+
+    private static final int REQUIRED_MATCH_SIZE = 4;
+
+    private static final RedisScript<Long> ENQUEUE_SCRIPT = longScript("""
+            if redis.call('EXISTS', KEYS[1]) == 1 then
+                return -1
+            end
+            redis.call('SET', KEYS[1], ARGV[1])
+            redis.call('RPUSH', KEYS[2], ARGV[1])
+            return redis.call('LLEN', KEYS[2])
+            """);
+
+    private static final RedisScript<Long> QUEUE_CONTAINS_SCRIPT = longScript("""
+            local pos = redis.call('LPOS', KEYS[1], ARGV[1])
+            if pos then
+                return 1
+            end
+            return 0
+            """);
+
+    private static final RedisScript<List> POLL_SCRIPT = listScript("""
+            local count = tonumber(ARGV[1])
+            if redis.call('LLEN', KEYS[1]) < count then
+                return {}
+            end
+
+            local result = {}
+            for i = 1, count do
+                result[i] = redis.call('LPOP', KEYS[1])
+            end
+
+            if redis.call('LLEN', KEYS[1]) == 0 then
+                redis.call('DEL', KEYS[1])
+            end
+
+            return result
+            """);
+
+    private static final RedisScript<List> CANCEL_SCRIPT = listScript("""
+            local removed = redis.call('LREM', KEYS[2], 1, ARGV[1])
+            redis.call('DEL', KEYS[1])
+            local size = redis.call('LLEN', KEYS[2])
+            if size == 0 then
+                redis.call('DEL', KEYS[2])
+            end
+            return {removed, size}
+            """);
+
+    private static final RedisScript<Long> ROLLBACK_SCRIPT = longScript("""
+            for i = #ARGV, 1, -1 do
+                redis.call('LPUSH', KEYS[1], ARGV[i])
+            end
+
+            for i = 2, #KEYS do
+                redis.call('SET', KEYS[i], ARGV[i - 1])
+            end
+
+            return redis.call('LLEN', KEYS[1])
+            """);
 
     private final StringRedisTemplate redisTemplate;
     private final MatchingRedisSerializer serializer;
     private final MatchingStoreProperties storeProperties;
+    private final InMemoryMatchStateStore delegate;
 
     public RedisMatchStateStore(
             StringRedisTemplate redisTemplate,
             MatchingRedisSerializer serializer,
-            MatchingStoreProperties storeProperties) {
+            MatchingStoreProperties storeProperties,
+            InMemoryMatchStateStore delegate) {
         this.redisTemplate = redisTemplate;
         this.serializer = serializer;
         this.storeProperties = storeProperties;
+        this.delegate = delegate;
     }
 
     @Override
     public int enqueue(Long userId, String nickname, QueueKey queueKey) {
-        throw unsupported("enqueue");
+        ensureJoinEligibility(userId);
+
+        if (findActiveQueuePayload(userId) != null) {
+            throw new ServiceException("409-1", "이미 매칭 대기열에 참가 중인 사용자입니다.");
+        }
+
+        WaitingUser waitingUser = new WaitingUser(userId, nickname, queueKey);
+        String payload = serializer.writeWaitingUser(waitingUser);
+
+        Long currentSize = redisTemplate.execute(
+                ENQUEUE_SCRIPT,
+                List.of(MatchingRedisKeys.userQueue(userId), MatchingRedisKeys.queue(queueKey)),
+                payload);
+
+        if (currentSize == null) {
+            throw new IllegalStateException("Redis queue enqueue 결과를 확인할 수 없습니다.");
+        }
+
+        if (currentSize == -1L) {
+            throw new ServiceException("409-1", "이미 매칭 대기열에 참가 중인 사용자입니다.");
+        }
+
+        return currentSize.intValue();
     }
 
     @Override
     public CancelResult cancel(Long userId) {
-        throw unsupported("cancel");
+        String userQueueKey = MatchingRedisKeys.userQueue(userId);
+        String payload = redisTemplate.opsForValue().get(userQueueKey);
+
+        if (payload == null) {
+            throw new IllegalStateException("현재 매칭 대기열에 참가 중이 아닙니다.");
+        }
+
+        WaitingUser waitingUser = serializer.readWaitingUser(payload);
+        QueueKey queueKey = waitingUser.getQueueKey();
+
+        List<Long> cancelResult = executeNumberListScript(
+                CANCEL_SCRIPT, List.of(userQueueKey, MatchingRedisKeys.queue(queueKey)), payload);
+
+        long removedCount = numberAt(cancelResult, 0);
+        int waitingCount = (int) numberAt(cancelResult, 1);
+
+        if (removedCount == 0L) {
+            throw new IllegalStateException("대기열에서 사용자를 제거하지 못했습니다.");
+        }
+
+        return new CancelResult(queueKey, waitingCount);
     }
 
     @Override
     public List<WaitingUser> pollMatchCandidates(QueueKey queueKey, int count) {
-        throw unsupported("pollMatchCandidates");
+        List<String> payloads =
+                executeStringListScript(POLL_SCRIPT, List.of(MatchingRedisKeys.queue(queueKey)), String.valueOf(count));
+
+        if (payloads.isEmpty()) {
+            return null;
+        }
+
+        return payloads.stream().map(serializer::readWaitingUser).toList();
     }
 
     @Override
     public void rollbackPolledUsers(QueueKey queueKey, List<WaitingUser> users) {
-        throw unsupported("rollbackPolledUsers");
+        if (users == null || users.isEmpty()) {
+            return;
+        }
+
+        List<String> keys = new ArrayList<>();
+        keys.add(MatchingRedisKeys.queue(queueKey));
+
+        List<String> payloads = new ArrayList<>();
+
+        // queue 복구와 userQueue 복구를 같은 payload 기준으로 함께 되돌린다.
+        for (WaitingUser user : users) {
+            keys.add(MatchingRedisKeys.userQueue(user.getUserId()));
+            payloads.add(serializer.writeWaitingUser(user));
+        }
+
+        redisTemplate.execute(ROLLBACK_SCRIPT, keys, payloads.toArray());
     }
 
     @Override
     public MatchSession markAcceptPending(QueueKey queueKey, List<WaitingUser> matchedUsers, LocalDateTime deadline) {
-        throw unsupported("markAcceptPending");
+        if (matchedUsers != null && !matchedUsers.isEmpty()) {
+            // queue에서 handoff 된 사용자는 SEARCHING 사용자로 보이지 않게 userQueue key를 먼저 정리한다.
+            redisTemplate.delete(matchedUsers.stream()
+                    .map(WaitingUser::getUserId)
+                    .map(MatchingRedisKeys::userQueue)
+                    .toList());
+        }
+
+        return delegate.markAcceptPending(queueKey, matchedUsers, deadline);
     }
 
     @Override
     public MatchSession accept(Long matchId, Long userId) {
-        throw unsupported("accept");
+        return delegate.accept(matchId, userId);
     }
 
     @Override
     public MatchSession decline(Long matchId, Long userId) {
-        throw unsupported("decline");
+        return delegate.decline(matchId, userId);
     }
 
     @Override
     public RoomCreationAttempt tryBeginRoomCreation(Long matchId) {
-        throw unsupported("tryBeginRoomCreation");
+        return delegate.tryBeginRoomCreation(matchId);
     }
 
     @Override
     public MatchSession markRoomReady(Long matchId, Long roomId) {
-        throw unsupported("markRoomReady");
+        return delegate.markRoomReady(matchId, roomId);
     }
 
     @Override
     public MatchSession expire(Long matchId) {
-        throw unsupported("expire");
+        return delegate.expire(matchId);
     }
 
     @Override
     public MatchSession cancelMatch(Long matchId) {
-        throw unsupported("cancelMatch");
+        return delegate.cancelMatch(matchId);
     }
 
     @Override
     public int getWaitingCount(QueueKey queueKey) {
-        throw unsupported("getWaitingCount");
+        Long waitingCount = redisTemplate.opsForList().size(MatchingRedisKeys.queue(queueKey));
+        return waitingCount == null ? 0 : waitingCount.intValue();
     }
 
     @Override
     public QueueStateV2Response getQueueStateV2(Long userId) {
-        throw unsupported("getQueueStateV2");
+        String payload = findActiveQueuePayload(userId);
+
+        if (payload == null) {
+            return new QueueStateV2Response(false, null, null, 0, REQUIRED_MATCH_SIZE);
+        }
+
+        WaitingUser waitingUser = serializer.readWaitingUser(payload);
+        QueueKey queueKey = waitingUser.getQueueKey();
+
+        return new QueueStateV2Response(
+                true,
+                queueKey.category(),
+                queueKey.difficulty().name(),
+                getWaitingCount(queueKey),
+                REQUIRED_MATCH_SIZE);
     }
 
     @Override
     public MatchSession findMatchSessionByUserId(Long userId) {
-        throw unsupported("findMatchSessionByUserId");
+        return delegate.findMatchSessionByUserId(userId);
     }
 
     @Override
     public List<Long> findExpiredAcceptPendingMatchIds(LocalDateTime now) {
-        throw unsupported("findExpiredAcceptPendingMatchIds");
+        return delegate.findExpiredAcceptPendingMatchIds(now);
     }
 
     @Override
     public void clearTerminalMatch(Long matchId) {
-        throw unsupported("clearTerminalMatch");
+        delegate.clearTerminalMatch(matchId);
     }
 
     @Override
     public void clearMatchedRoom(Long userId, Long roomId) {
-        throw unsupported("clearMatchedRoom");
+        delegate.clearMatchedRoom(userId, roomId);
     }
 
     /**
@@ -135,13 +296,87 @@ public class RedisMatchStateStore implements MatchStateStore {
     }
 
     /**
-     * 설정 구조는 미리 받아 두되, 이번 단계에서는 동작 분기에 연결하지 않는다.
+     * 설정 구조는 미리 받아 두되, 이번 단계에서는 동작 분기에만 사용한다.
      */
     MatchingStoreProperties storeProperties() {
         return storeProperties;
     }
 
-    private UnsupportedOperationException unsupported(String methodName) {
-        return new UnsupportedOperationException("RedisMatchStateStore." + methodName + " 는 다음 하위 이슈에서 구현합니다.");
+    private void ensureJoinEligibility(Long userId) {
+        MatchSession matchSession = delegate.findMatchSessionByUserId(userId);
+
+        if (matchSession != null) {
+            throw new ServiceException("409-1", "이미 진행 중인 매칭이 있습니다.");
+        }
+    }
+
+    private String findActiveQueuePayload(Long userId) {
+        String userQueueKey = MatchingRedisKeys.userQueue(userId);
+        String payload = redisTemplate.opsForValue().get(userQueueKey);
+
+        if (payload == null) {
+            return null;
+        }
+
+        WaitingUser waitingUser = serializer.readWaitingUser(payload);
+        String queueKey = MatchingRedisKeys.queue(waitingUser.getQueueKey());
+
+        // userQueue만 남고 실제 queue list에는 없으면 stale 데이터로 보고 현재 사용자 기준으로 정리한다.
+        Long contains = redisTemplate.execute(QUEUE_CONTAINS_SCRIPT, List.of(queueKey), payload);
+
+        if (contains == null || contains == 0L) {
+            redisTemplate.delete(userQueueKey);
+            return null;
+        }
+
+        return payload;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Long> executeNumberListScript(RedisScript<List> script, List<String> keys, String... args) {
+        List<Object> raw = (List<Object>) redisTemplate.execute(script, keys, (Object[]) args);
+
+        if (raw == null) {
+            return List.of();
+        }
+
+        return raw.stream().map(this::asLong).toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> executeStringListScript(RedisScript<List> script, List<String> keys, String... args) {
+        List<Object> raw = (List<Object>) redisTemplate.execute(script, keys, (Object[]) args);
+
+        if (raw == null) {
+            return List.of();
+        }
+
+        return raw.stream().map(String::valueOf).toList();
+    }
+
+    private long numberAt(List<Long> values, int index) {
+        return values.size() > index ? values.get(index) : 0L;
+    }
+
+    private Long asLong(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+
+        throw new IllegalStateException("Redis 스크립트 결과를 숫자로 변환하지 못했습니다.");
+    }
+
+    private static RedisScript<Long> longScript(String scriptText) {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setScriptText(scriptText);
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    private static RedisScript<List> listScript(String scriptText) {
+        DefaultRedisScript<List> script = new DefaultRedisScript<>();
+        script.setScriptText(scriptText);
+        script.setResultType(List.class);
+        return script;
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,3 +22,7 @@ spring:
 
 judge0:
   url: http://${JUDGE0_EC2_IP}:2358
+
+matching:
+  store:
+    type: redis

--- a/src/test/java/com/back/domain/matching/queue/service/RedisQueueReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/RedisQueueReadyCheckServiceTest.java
@@ -1,0 +1,167 @@
+package com.back.domain.matching.queue.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.back.domain.battle.battleroom.service.BattleRoomService;
+import com.back.domain.matching.queue.adapter.QueueProblemPicker;
+import com.back.domain.matching.queue.dto.MatchStateV2Response;
+import com.back.domain.matching.queue.dto.MatchStatus;
+import com.back.domain.matching.queue.dto.QueueJoinRequest;
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
+import com.back.domain.matching.queue.dto.QueueStatusResponse;
+import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
+import com.back.domain.matching.queue.store.MatchingStoreProperties;
+import com.back.domain.matching.queue.store.redis.FakeStringRedisTemplate;
+import com.back.domain.matching.queue.store.redis.MatchingRedisSerializer;
+import com.back.domain.matching.queue.store.redis.RedisMatchStateStore;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+class RedisQueueReadyCheckServiceTest {
+
+    private final BattleRoomService battleRoomService = mock(BattleRoomService.class);
+    private final QueueProblemPicker queueProblemPicker = mock(QueueProblemPicker.class);
+    private final MatchingEventPublisher matchingEventPublisher = mock(MatchingEventPublisher.class);
+
+    private FakeStringRedisTemplate redisTemplate;
+    private MatchingRedisSerializer serializer;
+    private ReadyCheckService readyCheckService;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate = new FakeStringRedisTemplate();
+        serializer = new MatchingRedisSerializer(
+                JsonMapper.builder().findAndAddModules().build());
+        readyCheckService = new ReadyCheckService(
+                battleRoomService,
+                queueProblemPicker,
+                new RedisMatchStateStore(
+                        redisTemplate, serializer, matchingStoreProperties(), new InMemoryMatchStateStore()),
+                matchingEventPublisher);
+    }
+
+    @Test
+    @DisplayName("Redis queue 경로에서도 queue/me 는 SEARCHING 동안 waitingCount와 requiredCount를 반환한다")
+    void getMyQueueStateV2_returnsSearchingInfo() {
+        QueueStatusResponse response = joinUser(1L);
+
+        QueueStateV2Response queueState = readyCheckService.getMyQueueStateV2(1L);
+
+        assertThat(response.getWaitingCount()).isEqualTo(1);
+        assertThat(queueState.inQueue()).isTrue();
+        assertThat(queueState.category()).isEqualTo("ARRAY");
+        assertThat(queueState.difficulty()).isEqualTo("EASY");
+        assertThat(queueState.waitingCount()).isEqualTo(1);
+        assertThat(queueState.requiredCount()).isEqualTo(4);
+        verify(matchingEventPublisher).publishQueueStateChanged(any(QueueKey.class), eq(1));
+    }
+
+    @Test
+    @DisplayName("Redis queue 경로에서도 cancel 후 감소한 waitingCount를 queue topic 이벤트로 발행한다")
+    void cancelQueueV2_publishesQueueStateChanged() {
+        joinUser(1L);
+        joinUser(2L);
+
+        QueueStatusResponse response = readyCheckService.cancelQueueV2(2L);
+
+        assertThat(response.getWaitingCount()).isEqualTo(1);
+        verify(matchingEventPublisher, times(2)).publishQueueStateChanged(any(QueueKey.class), eq(1));
+        verify(matchingEventPublisher, times(1)).publishQueueStateChanged(any(QueueKey.class), eq(2));
+    }
+
+    @Test
+    @DisplayName("Redis queue 경로에서도 4번째 join 시 matched 4명에게 READY_CHECK_STARTED를 발행한다")
+    void joinQueueV2_publishesReadyCheckStarted_whenFourthUserJoins() {
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+
+        readyCheckService.joinQueueV2(4L, "m4", createRequest("Array", Difficulty.EASY));
+
+        MatchStateV2Response matchState = readyCheckService.getMyMatchStateV2(1L);
+        ArgumentCaptor<Long> userIdCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<MatchStateV2Response> responseCaptor = ArgumentCaptor.forClass(MatchStateV2Response.class);
+
+        assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isFalse();
+        assertThat(matchState.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+
+        verify(matchingEventPublisher, times(4))
+                .publishReadyCheckStarted(userIdCaptor.capture(), responseCaptor.capture());
+
+        assertThat(userIdCaptor.getAllValues()).containsExactlyInAnyOrder(1L, 2L, 3L, 4L);
+        assertThat(responseCaptor.getAllValues()).allSatisfy(response -> {
+            assertThat(response.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+            assertThat(response.readyCheck()).isNotNull();
+            assertThat(response.readyCheck().acceptedCount()).isEqualTo(0);
+            assertThat(response.readyCheck().requiredCount()).isEqualTo(4);
+        });
+    }
+
+    @Test
+    @DisplayName("Redis queue 경로에서도 ready-check 세션 생성 실패 시 rollback 후 queue waitingCount 복구 이벤트를 발행한다")
+    void joinQueueV2_publishesRecoveredQueueEvent_whenMarkAcceptPendingFails() {
+        ExplodingRedisMatchStateStore failingStore =
+                new ExplodingRedisMatchStateStore(redisTemplate, serializer, matchingStoreProperties());
+        MatchingEventPublisher failingPublisher = mock(MatchingEventPublisher.class);
+        ReadyCheckService failingService =
+                new ReadyCheckService(battleRoomService, queueProblemPicker, failingStore, failingPublisher);
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+
+        failingService.joinQueueV2(1L, "m1", createRequest("Array", Difficulty.EASY));
+        failingService.joinQueueV2(2L, "m2", createRequest("Array", Difficulty.EASY));
+        failingService.joinQueueV2(3L, "m3", createRequest("Array", Difficulty.EASY));
+
+        assertThatThrownBy(() -> failingService.joinQueueV2(4L, "m4", createRequest("Array", Difficulty.EASY)))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("mark failed");
+
+        assertThat(failingStore.getWaitingCount(queueKey)).isEqualTo(4);
+        verify(failingPublisher).publishQueueStateChanged(queueKey, 4);
+    }
+
+    private MatchingStoreProperties matchingStoreProperties() {
+        MatchingStoreProperties properties = new MatchingStoreProperties();
+        properties.setType(MatchingStoreProperties.StoreType.REDIS);
+        return properties;
+    }
+
+    private QueueJoinRequest createRequest(String category, Difficulty difficulty) {
+        return new QueueJoinRequest(category, difficulty);
+    }
+
+    private QueueStatusResponse joinUser(Long userId) {
+        return readyCheckService.joinQueueV2(userId, "m" + userId, createRequest("Array", Difficulty.EASY));
+    }
+
+    private static final class ExplodingRedisMatchStateStore extends RedisMatchStateStore {
+
+        private ExplodingRedisMatchStateStore(
+                FakeStringRedisTemplate redisTemplate,
+                MatchingRedisSerializer serializer,
+                MatchingStoreProperties properties) {
+            super(redisTemplate, serializer, properties, new InMemoryMatchStateStore());
+        }
+
+        @Override
+        public com.back.domain.matching.queue.model.MatchSession markAcceptPending(
+                QueueKey queueKey, List<WaitingUser> matchedUsers, LocalDateTime deadline) {
+            throw new RuntimeException("mark failed");
+        }
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/store/redis/FakeStringRedisTemplate.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/FakeStringRedisTemplate.java
@@ -1,0 +1,179 @@
+package com.back.domain.matching.queue.store.redis;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+/**
+ * Redis queue 전환 로직을 빠르게 검증하기 위한 테스트 전용 템플릿이다.
+ *
+ * 이번 단계에서는 StringRedisTemplate이 사용하는 최소 기능만 흉내 내고,
+ * Lua script는 store가 기대하는 결과만 메모리 자료구조로 재현한다.
+ */
+public class FakeStringRedisTemplate extends StringRedisTemplate {
+
+    private final Map<String, String> values = new HashMap<>();
+    private final Map<String, LinkedList<String>> lists = new HashMap<>();
+    private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    private final ListOperations<String, String> listOperations = mock(ListOperations.class);
+
+    public FakeStringRedisTemplate() {
+        when(valueOperations.get(anyString())).thenAnswer(invocation -> values.get(invocation.getArgument(0)));
+        when(listOperations.size(anyString()))
+                .thenAnswer(invocation -> (long) list(invocation.getArgument(0)).size());
+        when(listOperations.index(anyString(), anyLong())).thenAnswer(invocation -> {
+            LinkedList<String> queue = list(invocation.getArgument(0));
+            long index = invocation.getArgument(1);
+            return index >= 0 && index < queue.size() ? queue.get((int) index) : null;
+        });
+        doAnswer(invocation -> {
+                    values.put(invocation.getArgument(0), invocation.getArgument(1));
+                    return null;
+                })
+                .when(valueOperations)
+                .set(anyString(), anyString());
+    }
+
+    @Override
+    public ValueOperations<String, String> opsForValue() {
+        return valueOperations;
+    }
+
+    @Override
+    public ListOperations<String, String> opsForList() {
+        return listOperations;
+    }
+
+    @Override
+    public Boolean delete(String key) {
+        boolean removed = values.remove(key) != null;
+        removed = lists.remove(key) != null || removed;
+        return removed;
+    }
+
+    @Override
+    public Long delete(Collection<String> keys) {
+        long removedCount = 0L;
+
+        for (String key : keys) {
+            if (Boolean.TRUE.equals(delete(key))) {
+                removedCount++;
+            }
+        }
+
+        return removedCount;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T execute(RedisScript<T> script, List<String> keys, Object... args) {
+        Class<T> resultType = script.getResultType();
+
+        if (Long.class.equals(resultType) && keys.size() == 2 && args.length == 1) {
+            return (T) handleEnqueue(keys, args);
+        }
+
+        if (Long.class.equals(resultType) && keys.size() == 1 && args.length == 1) {
+            return (T) handleQueueContains(keys, args);
+        }
+
+        if (List.class.equals(resultType) && keys.size() == 1 && args.length == 1) {
+            return (T) handlePoll(keys, args);
+        }
+
+        if (List.class.equals(resultType) && keys.size() == 2 && args.length == 1) {
+            return (T) handleCancel(keys, args);
+        }
+
+        if (Long.class.equals(resultType) && keys.size() >= 2 && args.length >= 1) {
+            return (T) handleRollback(keys, args);
+        }
+
+        throw new UnsupportedOperationException("테스트 템플릿이 처리하지 않는 Redis script 호출입니다.");
+    }
+
+    private Long handleEnqueue(List<String> keys, Object[] args) {
+        String userQueueKey = keys.get(0);
+        String queueKey = keys.get(1);
+        String payload = String.valueOf(args[0]);
+
+        if (values.containsKey(userQueueKey)) {
+            return -1L;
+        }
+
+        values.put(userQueueKey, payload);
+        list(queueKey).addLast(payload);
+        return (long) list(queueKey).size();
+    }
+
+    private Long handleQueueContains(List<String> keys, Object[] args) {
+        return list(keys.get(0)).contains(String.valueOf(args[0])) ? 1L : 0L;
+    }
+
+    private List<String> handlePoll(List<String> keys, Object[] args) {
+        LinkedList<String> queue = list(keys.get(0));
+        int count = Integer.parseInt(String.valueOf(args[0]));
+
+        if (queue.size() < count) {
+            return List.of();
+        }
+
+        List<String> result = new LinkedList<>();
+        for (int i = 0; i < count; i++) {
+            result.add(queue.removeFirst());
+        }
+
+        if (queue.isEmpty()) {
+            lists.remove(keys.get(0));
+        }
+
+        return result;
+    }
+
+    private List<Long> handleCancel(List<String> keys, Object[] args) {
+        String userQueueKey = keys.get(0);
+        String queueKey = keys.get(1);
+        String payload = String.valueOf(args[0]);
+
+        LinkedList<String> queue = list(queueKey);
+        long removed = queue.removeFirstOccurrence(payload) ? 1L : 0L;
+        values.remove(userQueueKey);
+
+        if (queue.isEmpty()) {
+            lists.remove(queueKey);
+        }
+
+        return List.of(removed, (long) queue.size());
+    }
+
+    private Long handleRollback(List<String> keys, Object[] args) {
+        LinkedList<String> queue = list(keys.get(0));
+
+        for (int i = args.length - 1; i >= 0; i--) {
+            queue.addFirst(String.valueOf(args[i]));
+        }
+
+        for (int i = 1; i < keys.size(); i++) {
+            values.put(keys.get(i), String.valueOf(args[i - 1]));
+        }
+
+        return (long) queue.size();
+    }
+
+    private LinkedList<String> list(String key) {
+        return lists.computeIfAbsent(key, ignored -> new LinkedList<>());
+    }
+}

--- a/src/test/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializerTest.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializerTest.java
@@ -16,6 +16,7 @@ import com.back.domain.matching.queue.model.MatchSession;
 import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.ReadyDecision;
+import com.back.domain.matching.queue.model.WaitingUser;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
 class MatchingRedisSerializerTest {
@@ -52,6 +53,21 @@ class MatchingRedisSerializerTest {
         MatchSession restored = serializer.readMatchSession(payload);
 
         assertThat(restored).isEqualTo(session);
+    }
+
+    @Test
+    @DisplayName("WaitingUser 는 JSON 으로 직렬화 후 joinedAt까지 유지한 채 복원할 수 있다")
+    void serializesWaitingUserRoundTrip() {
+        WaitingUser waitingUser = new WaitingUser(
+                1L, "m1", new QueueKey("array", Difficulty.EASY), LocalDateTime.of(2026, 4, 6, 12, 10, 0));
+
+        String payload = serializer.writeWaitingUser(waitingUser);
+        WaitingUser restored = serializer.readWaitingUser(payload);
+
+        assertThat(restored.getUserId()).isEqualTo(waitingUser.getUserId());
+        assertThat(restored.getNickname()).isEqualTo(waitingUser.getNickname());
+        assertThat(restored.getQueueKey()).isEqualTo(waitingUser.getQueueKey());
+        assertThat(restored.getJoinedAt()).isEqualTo(waitingUser.getJoinedAt());
     }
 
     @Test

--- a/src/test/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStoreTest.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStoreTest.java
@@ -1,0 +1,168 @@
+package com.back.domain.matching.queue.store.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.matching.queue.dto.QueueStateV2Response;
+import com.back.domain.matching.queue.model.Difficulty;
+import com.back.domain.matching.queue.model.MatchSession;
+import com.back.domain.matching.queue.model.MatchSessionStatus;
+import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.WaitingUser;
+import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
+import com.back.domain.matching.queue.store.MatchStateStore;
+import com.back.domain.matching.queue.store.MatchingStoreProperties;
+import com.back.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+class RedisMatchStateStoreTest {
+
+    private FakeStringRedisTemplate redisTemplate;
+    private MatchingRedisSerializer serializer;
+    private RedisMatchStateStore store;
+    private InMemoryMatchStateStore delegate;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate = new FakeStringRedisTemplate();
+        serializer = new MatchingRedisSerializer(
+                JsonMapper.builder().findAndAddModules().build());
+        delegate = new InMemoryMatchStateStore();
+
+        MatchingStoreProperties properties = new MatchingStoreProperties();
+        properties.setType(MatchingStoreProperties.StoreType.REDIS);
+
+        store = new RedisMatchStateStore(redisTemplate, serializer, properties, delegate);
+    }
+
+    @Test
+    @DisplayName("enqueue 는 WaitingUser payload 를 Redis queue 와 userQueue index 에 함께 저장한다")
+    void enqueue_storesWaitingUserPayloadInRedis() {
+        QueueKey queueKey = queueKey();
+
+        int currentSize = store.enqueue(1L, "m1", queueKey);
+
+        String userQueuePayload = redisTemplate.opsForValue().get(MatchingRedisKeys.userQueue(1L));
+        String queuePayload = redisTemplate.opsForList().index(MatchingRedisKeys.queue(queueKey), 0);
+
+        assertThat(currentSize).isEqualTo(1);
+        assertThat(userQueuePayload).isNotNull();
+        assertThat(queuePayload).isEqualTo(userQueuePayload);
+        assertThat(serializer.readWaitingUser(userQueuePayload).getQueueKey()).isEqualTo(queueKey);
+    }
+
+    @Test
+    @DisplayName("중복 enqueue 는 기존과 같은 예외로 차단한다")
+    void enqueue_rejectsDuplicateUser() {
+        QueueKey queueKey = queueKey();
+        store.enqueue(1L, "m1", queueKey);
+
+        assertThatThrownBy(() -> store.enqueue(1L, "m1", queueKey))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("이미 매칭 대기열에 참가 중인 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("cancel 은 Redis queue 와 userQueue index 를 함께 정리하고 waitingCount 를 반환한다")
+    void cancel_removesRedisQueueState() {
+        QueueKey queueKey = queueKey();
+        store.enqueue(1L, "m1", queueKey);
+        store.enqueue(2L, "m2", queueKey);
+
+        MatchStateStore.CancelResult cancelResult = store.cancel(2L);
+
+        assertThat(cancelResult.queueKey()).isEqualTo(queueKey);
+        assertThat(cancelResult.waitingCount()).isEqualTo(1);
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userQueue(2L)))
+                .isNull();
+        assertThat(store.getWaitingCount(queueKey)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("queue/me 는 Redis 기준 SEARCHING snapshot 을 반환한다")
+    void getQueueStateV2_readsSearchingInfoFromRedis() {
+        store.enqueue(1L, "m1", queueKey());
+
+        QueueStateV2Response response = store.getQueueStateV2(1L);
+
+        assertThat(response.inQueue()).isTrue();
+        assertThat(response.category()).isEqualTo("ARRAY");
+        assertThat(response.difficulty()).isEqualTo("EASY");
+        assertThat(response.waitingCount()).isEqualTo(1);
+        assertThat(response.requiredCount()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("인원이 부족하면 pollMatchCandidates 는 null 을 반환한다")
+    void pollMatchCandidates_returnsNullWhenQueueIsShort() {
+        QueueKey queueKey = queueKey();
+        store.enqueue(1L, "m1", queueKey);
+        store.enqueue(2L, "m2", queueKey);
+        store.enqueue(3L, "m3", queueKey);
+
+        List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
+
+        assertThat(matchedUsers).isNull();
+    }
+
+    @Test
+    @DisplayName("pollMatchCandidates 는 Redis queue 에서 FIFO 순서로 4명을 꺼낸다")
+    void pollMatchCandidates_returnsFifoUsers() {
+        QueueKey queueKey = queueKey();
+        enqueueUsers(queueKey, 4);
+
+        List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
+
+        assertThat(matchedUsers).extracting(WaitingUser::getUserId).containsExactly(1L, 2L, 3L, 4L);
+        assertThat(store.getWaitingCount(queueKey)).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("rollbackPolledUsers 는 queue 순서와 userQueue index 를 함께 복구한다")
+    void rollbackPolledUsers_restoresQueueOrderAndUserQueue() {
+        QueueKey queueKey = queueKey();
+        enqueueUsers(queueKey, 4);
+        List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
+
+        store.rollbackPolledUsers(queueKey, matchedUsers);
+
+        List<WaitingUser> restoredUsers = store.pollMatchCandidates(queueKey, 4);
+
+        assertThat(restoredUsers).extracting(WaitingUser::getUserId).containsExactly(1L, 2L, 3L, 4L);
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userQueue(1L)))
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("markAcceptPending 은 userQueue Redis key 를 정리하고 ready-check 본문은 인메모리 delegate 에 저장한다")
+    void markAcceptPending_handsOffToInMemoryDelegate() {
+        QueueKey queueKey = queueKey();
+        enqueueUsers(queueKey, 4);
+        List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
+
+        MatchSession matchSession =
+                store.markAcceptPending(queueKey, matchedUsers, LocalDateTime.of(2026, 4, 6, 12, 30, 0));
+
+        assertThat(matchSession.status()).isEqualTo(MatchSessionStatus.ACCEPT_PENDING);
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userQueue(1L)))
+                .isNull();
+        assertThat(delegate.findMatchSessionByUserId(1L)).isNotNull();
+    }
+
+    private QueueKey queueKey() {
+        return new QueueKey("Array", Difficulty.EASY);
+    }
+
+    private void enqueueUsers(QueueKey queueKey, int count) {
+        for (long userId = 1L; userId <= count; userId++) {
+            store.enqueue(userId, "m" + userId, queueKey);
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #148 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #148 

---
<html>
<body>
<h1>[refactor] matching queue 상태를 Redis 기반 hybrid store로 전환</h1>

<h3>개요</h3>
<p>이번 PR은 현재 인메모리 기반으로 관리하던 matching 상태 중에서 <strong>SEARCHING 구간의 queue 상태</strong>를 Redis로 옮기고, <strong>ready-check 세션 본문과 이후 상태 전이</strong>는 기존 인메모리 저장소에 그대로 위임하는 hybrid 구조로 전환한 작업입니다.</p>
<p>즉, 이번 단계에서 Redis로 옮긴 범위는 아래와 같습니다.</p>
<ul>
<li>queue 대기열 자체</li>
<li>user -&gt; queue 연결</li>
<li>queue 기반 waitingCount / queue/me 조회</li>
<li>4인 poll 및 rollback</li>
</ul>

<p>반면 아래 ready-check 상태 전이는 아직 기존 인메모리 저장소를 그대로 사용합니다.</p>
<ul>
<li><code>markAcceptPending</code> 이후 match session 본문</li>
<li><code>accept</code>, <code>decline</code></li>
<li><code>tryBeginRoomCreation</code>, <code>markRoomReady</code></li>
<li><code>expire</code>, <code>cancelMatch</code></li>
<li><code>findMatchSessionByUserId</code>, <code>clearTerminalMatch</code>, <code>clearMatchedRoom</code></li>
</ul>

<p>즉, 이번 PR의 핵심은 <strong>queue/searching 구간만 Redis로 먼저 이전하고, ready-check 이후는 메모리 delegate로 넘기는 하이브리드 저장소 경계</strong>를 실제 동작하는 코드로 만든 것입니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) dev 환경에서 matching store 기본값을 Redis로 전환</h3>
<p>기존 설정 구조는 이미 <code>matching.store.type</code>를 지원하고 있었고, 이번 PR에서는 <code>application-dev.yml</code>에서 dev 환경 기본값을 Redis로 바꿨습니다.</p>

<pre><code class="language-yml">matching:
  store:
    type: redis
</code></pre>

<p>즉, dev 프로필에서는 이제 <code>RedisMatchStateStore</code>가 실제 matching 저장소로 선택됩니다.</p>

<h3>2) <code>RedisMatchStateStore</code>를 실제 런타임 빈으로 연결</h3>
<p>이전 단계의 Redis 저장소는 스켈레톤 수준이었지만, 이번 PR에서는 실제 런타임 빈으로 동작하도록 조건부 등록을 붙였습니다.</p>

<pre><code class="language-java">@Primary
@Component
@ConditionalOnProperty(prefix = "matching.store", name = "type", havingValue = "redis")
public class RedisMatchStateStore implements MatchStateStore
</code></pre>

<p>의미는 아래와 같습니다.</p>
<ul>
<li><code>matching.store.type=redis</code>일 때만 활성화</li>
<li><code>MatchStateStore</code> 주입 시 Redis 구현체를 우선 사용</li>
<li>기존 인메모리 저장소는 ready-check delegate 용으로 계속 남김</li>
</ul>

<p>즉, 이 PR부터는 “Redis 설계 파일만 있는 상태”가 아니라 실제 서비스가 Redis queue 경로를 사용하게 됩니다.</p>

<h3>3) queue/searching 상태를 Redis로 저장하는 하이브리드 구조 도입</h3>
<p><code>RedisMatchStateStore</code>는 내부적으로 아래 4가지 의존성을 가집니다.</p>

<pre><code class="language-java">private final StringRedisTemplate redisTemplate;
private final MatchingRedisSerializer serializer;
private final MatchingStoreProperties storeProperties;
private final InMemoryMatchStateStore delegate;
</code></pre>

<p>책임 분리는 아래와 같습니다.</p>
<ul>
<li><code>redisTemplate</code> : queue, userQueue index, poll/rollback/cancel 등 Redis 조작</li>
<li><code>serializer</code> : WaitingUser / MatchSession / QueueKey JSON 직렬화 규칙</li>
<li><code>storeProperties</code> : 저장소 타입 설정 유지</li>
<li><code>delegate</code> : 아직 Redis로 옮기지 않은 ready-check 세션 본문 및 상태 전이 처리</li>
</ul>

<p>즉, queue는 Redis, ready-check는 memory인 hybrid store가 이번 PR의 핵심 구조입니다.</p>

<h3>4) Redis enqueue를 Lua script 기반으로 구현</h3>
<p>queue 참가 시에는 단순히 두 번의 Redis 호출을 따로 날리는 것이 아니라, <strong>중복 참가 검사 + userQueue index 저장 + queue push + size 반환</strong>을 한 번에 처리하는 Lua script를 사용했습니다.</p>

<pre><code class="language-lua">if redis.call('EXISTS', KEYS[1]) == 1 then
    return -1
end
redis.call('SET', KEYS[1], ARGV[1])
redis.call('RPUSH', KEYS[2], ARGV[1])
return redis.call('LLEN', KEYS[2])
</code></pre>

<p>여기서 key 의미는 아래와 같습니다.</p>
<ul>
<li><code>KEYS[1]</code> : <code>matching:user:queue:{userId}</code></li>
<li><code>KEYS[2]</code> : <code>matching:queue:{category}:{difficulty}</code></li>
<li><code>ARGV[1]</code> : 직렬화된 <code>WaitingUser</code> payload</li>
</ul>

<p>즉, join 시에는 Redis 안에서 아래 작업을 원자적으로 수행합니다.</p>
<ul>
<li>이미 userQueue key가 있는지 확인</li>
<li>없으면 userQueue key 저장</li>
<li>queue list 뒤쪽에 payload push</li>
<li>현재 queue size 반환</li>
</ul>

<h3>5) duplicate join 예외를 Redis 경로에서도 동일하게 유지</h3>
<p>Redis 경로에서도 기존과 동일하게 중복 queue 참가를 <code>409-1</code> 예외로 막습니다.</p>

<pre><code class="language-java">if (currentSize == -1L) {
    throw new ServiceException("409-1", "이미 매칭 대기열에 참가 중인 사용자입니다.");
}
</code></pre>

<p>또한 enqueue 전에 <code>ensureJoinEligibility(userId)</code>를 호출해, 이미 active match session에 연결된 사용자는 기존 정책대로 재join을 막습니다.</p>

<pre><code class="language-java">private void ensureJoinEligibility(Long userId) {
    MatchSession matchSession = delegate.findMatchSessionByUserId(userId);

    if (matchSession != null) {
        throw new ServiceException("409-1", "이미 진행 중인 매칭이 있습니다.");
    }
}
</code></pre>

<p>즉, Redis queue로 바뀌어도 “이미 SEARCHING 중인 사용자”와 “이미 active match session이 있는 사용자” 모두 재참가 차단 정책을 유지합니다.</p>

<h3>6) <code>WaitingUser</code>를 Redis 저장용으로 확장</h3>
<p>기존 <code>WaitingUser</code>는 기본 생성 시점의 <code>joinedAt</code>을 내부에서 <code>LocalDateTime.now()</code>로만 만들 수 있었습니다. 이번 PR에서는 Redis 직렬화 복원 시 원래 시각을 유지할 수 있도록 생성자를 확장했습니다.</p>

<pre><code class="language-java">public WaitingUser(Long userId, String nickname, QueueKey queueKey) {
    this(userId, nickname, queueKey, LocalDateTime.now());
}

public WaitingUser(Long userId, String nickname, QueueKey queueKey, LocalDateTime joinedAt) {
    this.userId = userId;
    this.nickname = nickname;
    this.queueKey = queueKey;
    this.joinedAt = joinedAt;
}
</code></pre>

<p>즉, Redis에서 복원된 queue 사용자도 기존 joinedAt 정보를 잃지 않도록 만들었습니다.</p>

<h3>7) <code>MatchingRedisSerializer</code>에 <code>WaitingUser</code> 직렬화 규칙 추가</h3>
<p>기존 serializer는 <code>QueueKey</code>와 <code>MatchSession</code>만 다루고 있었지만, 이번 단계부터 queue 상태가 Redis로 이동하므로 <code>WaitingUser</code> 직렬화/역직렬화도 추가했습니다.</p>

<pre><code class="language-java">public String writeWaitingUser(WaitingUser waitingUser)
public WaitingUser readWaitingUser(String value)
</code></pre>

<p>내부적으로는 저장 전용 document를 두어 joinedAt까지 유지한 채 복원할 수 있게 했습니다.</p>

<pre><code class="language-java">private record WaitingUserDocument(
        Long userId,
        String nickname,
        QueueKey queueKey,
        LocalDateTime joinedAt
) { ... }
</code></pre>

<p>즉, Redis queue list와 userQueue index에는 동일한 <code>WaitingUser JSON</code> 문자열을 저장합니다.</p>

<h3>8) queue 상태 조회도 Redis 기준으로 전환</h3>
<p><code>getQueueStateV2()</code>는 이제 Redis의 <code>userQueue</code> key와 queue list를 기준으로 SEARCHING snapshot을 만듭니다.</p>

<pre><code class="language-java">String payload = findActiveQueuePayload(userId);

if (payload == null) {
    return new QueueStateV2Response(false, null, null, 0, REQUIRED_MATCH_SIZE);
}

WaitingUser waitingUser = serializer.readWaitingUser(payload);
QueueKey queueKey = waitingUser.getQueueKey();

return new QueueStateV2Response(
        true,
        queueKey.category(),
        queueKey.difficulty().name(),
        getWaitingCount(queueKey),
        REQUIRED_MATCH_SIZE);
</code></pre>

<p>즉, queue/me 응답은 더 이상 인메모리 Deque가 아니라 Redis에 저장된 queue 상태를 읽어 반환합니다.</p>

<h3>9) stale userQueue index 정리 로직 추가</h3>
<p>Redis 환경에서는 <code>matching:user:queue:{userId}</code> key는 남아 있지만 실제 queue list에는 payload가 없는 stale 상태가 생길 수 있습니다. 이를 방지하기 위해 <code>findActiveQueuePayload()</code>에서 queue list에 실제 payload가 있는지 검증한 뒤, 없으면 현재 사용자 기준 stale 데이터를 정리합니다.</p>

<pre><code class="language-java">Long contains = redisTemplate.execute(QUEUE_CONTAINS_SCRIPT, List.of(queueKey), payload);

if (contains == null || contains == 0L) {
    redisTemplate.delete(userQueueKey);
    return null;
}
</code></pre>

<p>즉, userQueue index만 남아 있는 깨진 상태는 queue 조회 시 자동으로 회복됩니다.</p>

<h3>10) cancel도 Redis queue와 userQueue index를 함께 정리</h3>
<p>cancel은 Redis Lua script로 아래 작업을 한 번에 처리합니다.</p>

<pre><code class="language-lua">local removed = redis.call('LREM', KEYS[2], 1, ARGV[1])
redis.call('DEL', KEYS[1])
local size = redis.call('LLEN', KEYS[2])
if size == 0 then
    redis.call('DEL', KEYS[2])
end
return {removed, size}
</code></pre>

<p>즉, cancel 시에는 아래가 같이 처리됩니다.</p>
<ul>
<li>queue list에서 해당 WaitingUser payload 제거</li>
<li>userQueue index 삭제</li>
<li>queue가 비었으면 queue key 자체 삭제</li>
<li>남은 waitingCount 반환</li>
</ul>

<p>따라서 기존 인메모리 cancel과 같은 의미를 Redis 기준으로 유지합니다.</p>

<h3>11) 4인 poll도 Redis FIFO queue 기준으로 전환</h3>
<p><code>pollMatchCandidates()</code>는 Redis list에서 FIFO 순서로 4명을 꺼내도록 구현했습니다.</p>

<pre><code class="language-lua">local count = tonumber(ARGV[1])
if redis.call('LLEN', KEYS[1]) < count then
    return {}
end

local result = {}
for i = 1, count do
    result[i] = redis.call('LPOP', KEYS[1])
end

if redis.call('LLEN', KEYS[1]) == 0 then
    redis.call('DEL', KEYS[1])
end

return result
</code></pre>

<p>즉, queue 인원이 부족하면 빈 결과를 반환하고, 충분하면 앞에서부터 4명을 꺼낸 뒤 queue가 비면 key 자체를 정리합니다.</p>

<h3>12) rollback도 Redis queue와 userQueue index를 함께 복구</h3>
<p>ready-check 세션 생성 도중 실패했을 때는 poll했던 4명을 queue 앞쪽으로 되돌리고, 각 사용자의 userQueue index도 같이 복구해야 합니다. 이를 위해 rollback도 Lua script로 구현했습니다.</p>

<pre><code class="language-lua">for i = #ARGV, 1, -1 do
    redis.call('LPUSH', KEYS[1], ARGV[i])
end

for i = 2, #KEYS do
    redis.call('SET', KEYS[i], ARGV[i - 1])
end

return redis.call('LLEN', KEYS[1])
</code></pre>

<p>즉, rollback 시에는:</p>
<ul>
<li>queue는 원래 FIFO 순서가 유지되도록 역순 <code>LPUSH</code></li>
<li>각 사용자의 <code>matching:user:queue:{userId}</code> key도 함께 복구</li>
</ul>

<p>즉, Redis queue 경로에서도 실패 rollback의 의미를 그대로 유지합니다.</p>

<h3>13) 4명 handoff 이후에는 ready-check 세션 본문을 인메모리 delegate에 저장</h3>
<p>이번 PR은 queue/searching 상태만 Redis로 옮긴 단계이므로, 4명이 poll된 뒤 ready-check 세션을 만드는 시점에는 기존 인메모리 저장소로 handoff 합니다.</p>

<pre><code class="language-java">@Override
public MatchSession markAcceptPending(QueueKey queueKey, List&lt;WaitingUser&gt; matchedUsers, LocalDateTime deadline) {
    if (matchedUsers != null && !matchedUsers.isEmpty()) {
        redisTemplate.delete(matchedUsers.stream()
                .map(WaitingUser::getUserId)
                .map(MatchingRedisKeys::userQueue)
                .toList());
    }

    return delegate.markAcceptPending(queueKey, matchedUsers, deadline);
}
</code></pre>

<p>즉, 이 시점에 하는 일은 아래와 같습니다.</p>
<ul>
<li>SEARCHING 사용자로 보이지 않도록 userQueue Redis key 삭제</li>
<li>ready-check 세션 본문은 기존 <code>InMemoryMatchStateStore</code>에 저장</li>
</ul>

<p>따라서 현재 구조는 정확히 <strong>queue는 Redis, match session은 memory</strong>입니다.</p>

<h3>14) ready-check 이후 상태 전이는 기존 delegate 그대로 사용</h3>
<p>아래 메서드들은 이번 PR에서 Redis로 옮기지 않고 기존 인메모리 delegate를 그대로 사용합니다.</p>

<pre><code class="language-java">accept(...)
decline(...)
tryBeginRoomCreation(...)
markRoomReady(...)
expire(...)
cancelMatch(...)
findMatchSessionByUserId(...)
findExpiredAcceptPendingMatchIds(...)
clearTerminalMatch(...)
clearMatchedRoom(...)
</code></pre>

<p>즉, ready-check 본문과 이후 상태 전이는 다음 하위 이슈에서 Redis로 넘길 예정이고, 이번 단계에서는 queue 경로만 먼저 옮겨 서비스 동작을 안정적으로 유지하도록 했습니다.</p>

<h3>15) Redis serializer는 Spring bean으로 등록</h3>
<p><code>MatchingRedisSerializer</code>에는 이번 단계부터 <code>@Component</code>를 붙여 실제 저장소 bean에서 주입받아 사용할 수 있도록 했습니다.</p>

<pre><code class="language-java">@Component
public class MatchingRedisSerializer { ... }
</code></pre>

<p>즉, 이제 serializer는 테스트 유틸이 아니라 실제 Redis 저장소 런타임 구성 요소가 됩니다.</p>

<h3>16) Redis queue 경로 전용 테스트 더블 추가</h3>
<p>Redis queue 전환 로직을 빠르게 검증하기 위해 <code>FakeStringRedisTemplate</code>를 새로 추가했습니다.</p>
<p>이 테스트 더블은 실제 Redis 전체를 흉내 내는 것이 아니라, 이번 단계에서 store가 사용하는 최소 기능만 메모리 자료구조로 재현합니다.</p>

<ul>
<li><code>opsForValue().get/set</code></li>
<li><code>opsForList().size/index</code></li>
<li><code>delete</code></li>
<li>현재 store가 호출하는 Lua script 패턴별 <code>execute(...)</code></li>
</ul>

<p>즉, Redis queue 전환 로직을 빠르게 단위 테스트할 수 있는 최소 환경을 마련한 것입니다.</p>

<h3>17) 테스트 추가</h3>

<p><code>RedisMatchStateStoreTest</code></p>
<ul>
<li>enqueue 시 <code>WaitingUser</code> payload가 Redis queue와 userQueue index에 함께 저장되는지 확인</li>
<li>중복 enqueue가 기존과 같은 예외로 차단되는지 확인</li>
<li>cancel이 Redis queue와 userQueue index를 함께 정리하는지 확인</li>
<li>queue/me가 Redis 기준 SEARCHING snapshot을 반환하는지 확인</li>
<li>인원 부족 시 poll이 null을 반환하는지 확인</li>
<li>poll이 FIFO 순서로 4명을 꺼내는지 확인</li>
<li>rollback이 queue 순서와 userQueue index를 함께 복구하는지 확인</li>
<li>markAcceptPending이 userQueue Redis key를 지우고 인메모리 delegate로 handoff하는지 확인</li>
</ul>

<p><code>RedisQueueReadyCheckServiceTest</code></p>
<ul>
<li>Redis queue 경로에서도 queue/me가 waitingCount / requiredCount를 정상 반환하는지 확인</li>
<li>Redis queue 경로에서도 cancel 후 queue topic 이벤트가 정상 발행되는지 확인</li>
<li>Redis queue 경로에서도 4번째 join 시 READY_CHECK_STARTED handoff 이벤트가 정상 발행되는지 확인</li>
<li>Redis queue 경로에서도 markAcceptPending 실패 시 rollback 후 queue 상태 복구 이벤트가 발행되는지 확인</li>
</ul>

<p><code>MatchingRedisSerializerTest</code></p>
<ul>
<li><code>WaitingUser</code>가 joinedAt까지 유지한 채 JSON round-trip 가능한지 확인</li>
</ul>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">POST /api/v2/queue/join
  ↓
RedisMatchStateStore.enqueue()
  ↓
1. active match session 있으면 차단
2. userQueue key 중복 검사
3. WaitingUser JSON 저장
4. queue list 뒤에 push
5. waitingCount 반환

GET /api/v2/queue/me
  ↓
userQueue key 조회
  ↓
payload 복원
  ↓
실제 queue list 에 payload 존재하는지 확인
  ├─ 있으면 SEARCHING snapshot 반환
  └─ 없으면 stale userQueue 정리 후 inQueue=false

4명 모임
  ↓
Redis queue 에서 FIFO poll
  ↓
Redis userQueue key 삭제
  ↓
delegate(InMemoryMatchStateStore).markAcceptPending(...)
  ↓
이후 ready-check 상태 전이는 기존 memory 경로 사용
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>SEARCHING queue 상태를 실제 Redis 기반 저장소로 먼저 이전할 수 있습니다.</li>
<li>기존 서비스 계층은 유지하면서 queue와 ready-check를 단계적으로 분리 전환할 수 있습니다.</li>
<li>duplicate join, cancel, poll, rollback, queue/me 의미를 Redis에서도 기존과 동일하게 유지합니다.</li>
<li>ready-check 이후 상태 전이는 아직 안전하게 인메모리 delegate를 사용해 전환 리스크를 줄입니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li>dev 환경에서 <code>matching.store.type=redis</code>일 때 실제로 RedisMatchStateStore가 선택되는지 확인</li>
<li>queue join / cancel / queue/me / poll / rollback이 Redis 기준으로 정상 동작하는지 확인</li>
<li>4인 handoff 이후에는 SEARCHING Redis key가 정리되고, ready-check 세션은 기존 인메모리 delegate에 저장되는지 확인</li>
<li>stale userQueue index가 남아도 queue 조회 시 자동으로 정리되는지 확인</li>
<li>기존 READY_CHECK_STARTED / queue 상태 이벤트 흐름이 Redis queue 경로에서도 그대로 유지되는지 확인</li>
</ol>
</body>
</html>

