### PR TITLE
[feat] 마이페이지 티어 진행도 API 추가

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -8,7 +8,9 @@ import com.back.domain.member.member.dto.JoinRequest;
 import com.back.domain.member.member.dto.LoginRequest;
 import com.back.domain.member.member.dto.LoginTokens;
 import com.back.domain.member.member.dto.MyInfoResponse;
+import com.back.domain.member.member.dto.RatingProgressResponse;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberRatingProgressService;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.exception.ServiceException;
 import com.back.global.jwt.RefreshTokenService;
@@ -23,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("api/v1/members")
 public class MemberController {
     private final MemberService memberService;
+    private final MemberRatingProgressService memberRatingProgressService;
     private final BattleResultService battleResultService;
     private final RefreshTokenService refreshTokenService;
     private final Rq rq;
@@ -91,5 +94,15 @@ public class MemberController {
         }
 
         return memberService.getMyInfo(actor.getId());
+    }
+
+    @GetMapping("/me/rating-progress")
+    public RsData<RatingProgressResponse> getMyRatingProgress() {
+        Member actor = rq.getActor();
+        if (actor == null || actor.getId() == null) {
+            throw new ServiceException("MEMBER_401", "로그인이 필요합니다");
+        }
+
+        return memberRatingProgressService.getMyRatingProgress(actor.getId());
     }
 }

--- a/src/main/java/com/back/domain/member/member/dto/RatingProgressResponse.java
+++ b/src/main/java/com/back/domain/member/member/dto/RatingProgressResponse.java
@@ -1,0 +1,36 @@
+package com.back.domain.member.member.dto;
+
+import java.util.List;
+
+public record RatingProgressResponse(CurrentProgress current, NextTierProgress next) {
+
+    public record CurrentProgress(
+            String displayTier,
+            String tier,
+            int battleRating,
+            int hardBattleRating,
+            int activityPoint,
+            int battleMatchCount,
+            int firstSolvedProblemCount,
+            long solved1400Plus,
+            long solved1700Plus,
+            long solved2000Plus,
+            long solved2300Plus,
+            double recentTop2Ratio) {}
+
+    public record NextTierProgress(
+            String tier,
+            boolean eligibleNow,
+            String message,
+            Integer seatRank,
+            List<RequirementProgress> requirements) {}
+
+    public record RequirementProgress(
+            String key,
+            String label,
+            String comparison,
+            double current,
+            double required,
+            double remaining,
+            boolean satisfied) {}
+}

--- a/src/main/java/com/back/domain/member/member/service/MemberRatingProgressService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberRatingProgressService.java
@@ -1,0 +1,363 @@
+package com.back.domain.member.member.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.member.member.dto.RatingProgressResponse;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.rating.policy.TierPolicy;
+import com.back.domain.rating.profile.entity.MemberRatingProfile;
+import com.back.domain.rating.profile.entity.RatingTier;
+import com.back.domain.rating.profile.repository.MemberRatingProfileRepository;
+import com.back.domain.rating.solve.repository.MemberProblemFirstSolveRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.rsData.RsData;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRatingProgressService {
+
+    private static final int INITIAL_SKILL_RATING = 1000;
+    private static final int INITIAL_ACTIVITY_POINT = 0;
+    private static final int TOP2_WINDOW_SIZE = 20;
+    private static final String COMPARISON_AT_LEAST = "AT_LEAST";
+    private static final String COMPARISON_AT_MOST = "AT_MOST";
+    private static final String UNRANKED = "UNRANKED";
+
+    private final MemberRepository memberRepository;
+    private final MemberRatingProfileRepository memberRatingProfileRepository;
+    private final MemberProblemFirstSolveRepository memberProblemFirstSolveRepository;
+    private final BattleParticipantRepository battleParticipantRepository;
+
+    public RsData<RatingProgressResponse> getMyRatingProgress(Long memberId) {
+        if (memberId == null || memberId <= 0) {
+            throw new ServiceException("MEMBER_400", "유효한 회원 ID가 필요합니다");
+        }
+
+        Member member = memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new ServiceException("MEMBER_404", "존재하지 않는 회원입니다"));
+
+        MemberRatingProfile profile = memberRatingProfileRepository
+                .findByMemberId(memberId)
+                .orElseGet(() -> MemberRatingProfile.createDefault(member));
+
+        int battleMatchCount = nullToZero(profile.getBattleMatchCount());
+        int firstSolvedProblemCount = nullToZero(profile.getFirstSolvedProblemCount());
+        int battleRating = nullToDefault(profile.getBattleRating(), INITIAL_SKILL_RATING);
+        int hardBattleRating = nullToDefault(profile.getHardBattleRating(), INITIAL_SKILL_RATING);
+        int activityPoint = nullToDefault(profile.getFirstSolveScore(), INITIAL_ACTIVITY_POINT);
+        RatingTier currentTier = profile.getTier() == null ? RatingTier.BRONZE_5 : profile.getTier();
+        String displayTier = TierPolicy.resolveDisplayTier(currentTier, battleMatchCount, firstSolvedProblemCount);
+
+        long solved1400Plus =
+                memberProblemFirstSolveRepository.countByMemberIdAndProblemDifficultyRatingGreaterThanEqual(
+                        memberId, 1400);
+        long solved1700Plus =
+                memberProblemFirstSolveRepository.countByMemberIdAndProblemDifficultyRatingGreaterThanEqual(
+                        memberId, 1700);
+        long solved2000Plus =
+                memberProblemFirstSolveRepository.countByMemberIdAndProblemDifficultyRatingGreaterThanEqual(
+                        memberId, 2000);
+        long solved2300Plus =
+                memberProblemFirstSolveRepository.countByMemberIdAndProblemDifficultyRatingGreaterThanEqual(
+                        memberId, 2300);
+        double recentTop2Ratio = resolveRecentTop2Ratio(memberId);
+
+        RatingProgressResponse.CurrentProgress currentProgress = new RatingProgressResponse.CurrentProgress(
+                displayTier,
+                currentTier.name(),
+                battleRating,
+                hardBattleRating,
+                activityPoint,
+                battleMatchCount,
+                firstSolvedProblemCount,
+                solved1400Plus,
+                solved1700Plus,
+                solved2000Plus,
+                solved2300Plus,
+                recentTop2Ratio);
+
+        RatingProgressResponse.NextTierProgress nextProgress = resolveNextTierProgress(
+                memberId,
+                displayTier,
+                currentTier,
+                battleRating,
+                hardBattleRating,
+                activityPoint,
+                battleMatchCount,
+                firstSolvedProblemCount,
+                solved1400Plus,
+                solved1700Plus,
+                solved2000Plus,
+                solved2300Plus,
+                recentTop2Ratio);
+
+        return RsData.of("200", "내 레이팅 진행도 조회 성공", new RatingProgressResponse(currentProgress, nextProgress));
+    }
+
+    private RatingProgressResponse.NextTierProgress resolveNextTierProgress(
+            Long memberId,
+            String displayTier,
+            RatingTier currentTier,
+            int battleRating,
+            int hardBattleRating,
+            int activityPoint,
+            int battleMatchCount,
+            int firstSolvedProblemCount,
+            long solved1400Plus,
+            long solved1700Plus,
+            long solved2000Plus,
+            long solved2300Plus,
+            double recentTop2Ratio) {
+        RatingTier nextTier = resolveNextTier(displayTier, currentTier);
+        if (nextTier == null) {
+            return null;
+        }
+
+        if (UNRANKED.equals(displayTier)) {
+            boolean hasActivity = battleMatchCount > 0 || firstSolvedProblemCount > 0;
+            RatingProgressResponse.RequirementProgress activityRequirement =
+                    new RatingProgressResponse.RequirementProgress(
+                            "rankedActivity",
+                            "랭크 활동(배틀 1판 또는 first solve 1회)",
+                            COMPARISON_AT_LEAST,
+                            hasActivity ? 1.0d : 0.0d,
+                            1.0d,
+                            hasActivity ? 0.0d : 1.0d,
+                            hasActivity);
+
+            return new RatingProgressResponse.NextTierProgress(
+                    nextTier.name(),
+                    hasActivity,
+                    hasActivity ? "활동이 반영되어 다음 조회부터 BRONZE_5로 표시됩니다." : "배틀 1판 또는 first solve 1회를 완료하세요.",
+                    null,
+                    List.of(activityRequirement));
+        }
+
+        if (nextTier == RatingTier.GOD) {
+            Integer seatRank = resolveMasterSeatRank(memberId);
+            double currentRank = seatRank == null ? 9999.0d : seatRank.doubleValue();
+            boolean seatSatisfied = seatRank != null && seatRank <= 5;
+            RatingProgressResponse.RequirementProgress seatRequirement = new RatingProgressResponse.RequirementProgress(
+                    "godSeatRank",
+                    "MASTER_1 상위 5석(Hard SR 순위)",
+                    COMPARISON_AT_MOST,
+                    currentRank,
+                    5.0d,
+                    seatRank == null ? 9994.0d : Math.max(0.0d, seatRank - 5.0d),
+                    seatSatisfied);
+
+            return new RatingProgressResponse.NextTierProgress(
+                    nextTier.name(),
+                    seatSatisfied,
+                    "GOD은 MASTER_1 유저 중 Hard SR 상위 5명에게만 부여됩니다.",
+                    seatRank,
+                    List.of(seatRequirement));
+        }
+
+        List<RatingProgressResponse.RequirementProgress> requirements = new ArrayList<>();
+
+        Integer requiredSkillRating = resolveSkillThreshold(nextTier);
+        if (requiredSkillRating != null) {
+            requirements.add(
+                    buildAtLeastRequirement("battleRating", "SR (battleRating)", battleRating, requiredSkillRating));
+        }
+
+        Integer requiredHardSkillRating = resolveHardSkillThreshold(nextTier);
+        if (requiredHardSkillRating != null) {
+            requirements.add(
+                    buildAtLeastRequirement("hardBattleRating", "Hard SR", hardBattleRating, requiredHardSkillRating));
+        }
+
+        GateRequirement gateRequirement = resolveGateRequirement(nextTier);
+        if (gateRequirement.activityPoint != null) {
+            requirements.add(buildAtLeastRequirement(
+                    "activityPoint", "AP (firstSolveScore)", activityPoint, gateRequirement.activityPoint));
+        }
+        if (gateRequirement.solved1400Plus != null) {
+            requirements.add(buildAtLeastRequirement(
+                    "solved1400Plus", "1400+ first solve", solved1400Plus, gateRequirement.solved1400Plus));
+        }
+        if (gateRequirement.solved1700Plus != null) {
+            requirements.add(buildAtLeastRequirement(
+                    "solved1700Plus", "1700+ first solve", solved1700Plus, gateRequirement.solved1700Plus));
+        }
+        if (gateRequirement.solved2000Plus != null) {
+            requirements.add(buildAtLeastRequirement(
+                    "solved2000Plus", "2000+ first solve", solved2000Plus, gateRequirement.solved2000Plus));
+        }
+        if (gateRequirement.solved2300Plus != null) {
+            requirements.add(buildAtLeastRequirement(
+                    "solved2300Plus", "2300+ first solve", solved2300Plus, gateRequirement.solved2300Plus));
+        }
+        if (gateRequirement.recentTop2Ratio != null) {
+            requirements.add(buildAtLeastRequirement(
+                    "recentTop2Ratio", "최근 20판 Top2 비율", recentTop2Ratio, gateRequirement.recentTop2Ratio));
+        }
+
+        boolean eligibleNow = requirements.stream().allMatch(RatingProgressResponse.RequirementProgress::satisfied);
+        String message = eligibleNow ? "다음 정산 시 승급 가능한 상태입니다." : "남은 조건을 채우면 다음 티어로 승급할 수 있습니다.";
+
+        return new RatingProgressResponse.NextTierProgress(nextTier.name(), eligibleNow, message, null, requirements);
+    }
+
+    private RatingTier resolveNextTier(String displayTier, RatingTier currentTier) {
+        if (UNRANKED.equals(displayTier)) {
+            return RatingTier.BRONZE_5;
+        }
+
+        if (currentTier == null || currentTier == RatingTier.GOD) {
+            return null;
+        }
+
+        RatingTier[] tiers = RatingTier.values();
+        int nextOrdinal = currentTier.ordinal() + 1;
+        if (nextOrdinal >= tiers.length) {
+            return null;
+        }
+        return tiers[nextOrdinal];
+    }
+
+    private Integer resolveSkillThreshold(RatingTier tier) {
+        return switch (tier) {
+            case BRONZE_5 -> 900;
+            case BRONZE_4 -> 1060;
+            case BRONZE_3 -> 1120;
+            case BRONZE_2 -> 1180;
+            case BRONZE_1 -> 1240;
+            case SILVER_5 -> 1300;
+            case SILVER_4 -> 1360;
+            case SILVER_3 -> 1420;
+            case SILVER_2 -> 1480;
+            case SILVER_1 -> 1540;
+            case GOLD_5 -> 1600;
+            case GOLD_4 -> 1660;
+            case GOLD_3 -> 1720;
+            case GOLD_2 -> 1780;
+            case GOLD_1 -> 1840;
+            case PLATINUM_5 -> 1900;
+            case PLATINUM_4 -> 1960;
+            case PLATINUM_3 -> 2020;
+            case PLATINUM_2 -> 2080;
+            case PLATINUM_1 -> 2140;
+            case DIAMOND_5 -> 2200;
+            case DIAMOND_4 -> 2260;
+            case DIAMOND_3 -> 2320;
+            case DIAMOND_2 -> 2380;
+            case DIAMOND_1 -> 2440;
+            case MASTER_4 -> 2500;
+            case MASTER_3 -> 2575;
+            case MASTER_2 -> 2650;
+            case MASTER_1 -> 2725;
+            case GOD -> null;
+        };
+    }
+
+    private Integer resolveHardSkillThreshold(RatingTier tier) {
+        return switch (tier) {
+            case DIAMOND_5 -> 2200;
+            case DIAMOND_4 -> 2260;
+            case DIAMOND_3 -> 2320;
+            case DIAMOND_2 -> 2380;
+            case DIAMOND_1 -> 2440;
+            case MASTER_4 -> 2500;
+            case MASTER_3 -> 2575;
+            case MASTER_2 -> 2650;
+            case MASTER_1 -> 2725;
+            default -> null;
+        };
+    }
+
+    private GateRequirement resolveGateRequirement(RatingTier tier) {
+        if (tier.ordinal() <= RatingTier.BRONZE_1.ordinal()) {
+            return GateRequirement.none();
+        }
+        if (tier.ordinal() <= RatingTier.SILVER_1.ordinal()) {
+            return new GateRequirement(60, null, null, null, null, null);
+        }
+        if (tier.ordinal() <= RatingTier.GOLD_1.ordinal()) {
+            return new GateRequirement(220, 12L, null, null, null, null);
+        }
+        if (tier.ordinal() <= RatingTier.PLATINUM_1.ordinal()) {
+            return new GateRequirement(600, null, 20L, 6L, null, null);
+        }
+        if (tier.ordinal() <= RatingTier.DIAMOND_1.ordinal()) {
+            return new GateRequirement(1300, null, null, 30L, 8L, 0.55d);
+        }
+        if (tier.ordinal() <= RatingTier.MASTER_1.ordinal()) {
+            return new GateRequirement(2400, null, null, 60L, 18L, 0.65d);
+        }
+        return GateRequirement.none();
+    }
+
+    private Integer resolveMasterSeatRank(Long memberId) {
+        List<MemberRatingProfile> candidates =
+                memberRatingProfileRepository.findAllByTierInOrderByHardBattleRatingDescBattleRatingDescMemberIdAsc(
+                        List.of(RatingTier.GOD, RatingTier.MASTER_1));
+        if (candidates == null || candidates.isEmpty()) {
+            return null;
+        }
+
+        for (int i = 0; i < candidates.size(); i++) {
+            MemberRatingProfile profile = candidates.get(i);
+            if (profile == null || profile.getMember() == null) continue;
+            if (Objects.equals(profile.getMember().getId(), memberId)) {
+                return i + 1;
+            }
+        }
+        return null;
+    }
+
+    private double resolveRecentTop2Ratio(Long memberId) {
+        List<Integer> recentRanks = battleParticipantRepository.findRecentFinalRanksByMemberId(
+                memberId, PageRequest.of(0, TOP2_WINDOW_SIZE));
+        if (recentRanks == null || recentRanks.isEmpty()) {
+            return 0.0d;
+        }
+
+        long top2Count =
+                recentRanks.stream().filter(rank -> rank != null && rank <= 2).count();
+        return round((double) top2Count / recentRanks.size());
+    }
+
+    private RatingProgressResponse.RequirementProgress buildAtLeastRequirement(
+            String key, String label, double current, double required) {
+        boolean satisfied = current >= required;
+        double remaining = satisfied ? 0.0d : round(required - current);
+        return new RatingProgressResponse.RequirementProgress(
+                key, label, COMPARISON_AT_LEAST, round(current), round(required), remaining, satisfied);
+    }
+
+    private int nullToZero(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private int nullToDefault(Integer value, int defaultValue) {
+        return value == null ? defaultValue : value;
+    }
+
+    private double round(double value) {
+        return Math.round(value * 10000.0d) / 10000.0d;
+    }
+
+    private record GateRequirement(
+            Integer activityPoint,
+            Long solved1400Plus,
+            Long solved1700Plus,
+            Long solved2000Plus,
+            Long solved2300Plus,
+            Double recentTop2Ratio) {
+        private static GateRequirement none() {
+            return new GateRequirement(null, null, null, null, null, null);
+        }
+    }
+}

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerBattleResultsTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerBattleResultsTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.back.domain.battle.result.dto.MyBattleResultsResponse;
 import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberRatingProgressService;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.globalExceptionHandler.GlobalExceptionHandler;
 import com.back.global.jwt.RefreshTokenService;
@@ -26,6 +27,7 @@ import com.back.global.rq.Rq;
 class MemberControllerBattleResultsTest {
 
     private final MemberService memberService = mock(MemberService.class);
+    private final MemberRatingProgressService memberRatingProgressService = mock(MemberRatingProgressService.class);
     private final BattleResultService battleResultService = mock(BattleResultService.class);
     private final RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
     private final Rq rq = mock(Rq.class);
@@ -34,7 +36,8 @@ class MemberControllerBattleResultsTest {
 
     @BeforeEach
     void setUp() {
-        MemberController controller = new MemberController(memberService, battleResultService, refreshTokenService, rq);
+        MemberController controller = new MemberController(
+                memberService, memberRatingProgressService, battleResultService, refreshTokenService, rq);
 
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -121,6 +121,35 @@ class MemberControllerTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.tier").value("UNRANKED"))
                 .andExpect(jsonPath("$.data.role").value("USER"));
     }
+
+    @Test
+    @DisplayName("레이팅 진행도 조회 요청 시 현재/다음 티어 조건을 반환한다")
+    void getMyRatingProgress_success() throws Exception {
+        String loginBody = """
+                {
+                    "email": "%s",
+                    "password": "%s"
+                }
+                """.formatted(LOGIN_TEST_EMAIL, LOGIN_TEST_PASSWORD);
+
+        MvcResult loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody))
+                .andReturn();
+
+        String cookieHeader = loginResult.getResponse().getHeader("Set-Cookie");
+        String token = cookieHeader.split("accessToken=")[1].split(";")[0];
+
+        mockMvc.perform(get("/api/v1/members/me/rating-progress").cookie(new MockCookie("accessToken", token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("내 레이팅 진행도 조회 성공"))
+                .andExpect(jsonPath("$.data.current.displayTier").value("UNRANKED"))
+                .andExpect(jsonPath("$.data.current.tier").value("BRONZE_5"))
+                .andExpect(jsonPath("$.data.next.tier").value("BRONZE_5"))
+                .andExpect(jsonPath("$.data.next.eligibleNow").value(false))
+                .andExpect(jsonPath("$.data.next.requirements[0].key").value("rankedActivity"));
+    }
     // ============ 로그인 ============
     @Test
     @DisplayName("정상적인 로그인 요청 시 200 응답과 accessToken 쿠키를 반환한다")


### PR DESCRIPTION
## 작업 내용
- `GET /api/v1/members/me/rating-progress` API 추가
- `MemberController`에 진행도 조회 엔드포인트 연결
- `RatingProgressResponse` DTO 추가
- `MemberRatingProgressService` 추가
  - 현재 상태(SR/Hard SR/AP/난이도별 first solve/최근 Top2 비율) 계산
  - 다음 티어 및 요구조건 계산
  - `UNRANKED` 특수 처리
  - `GOD` 상위 5석(AT_MOST) 조건 처리

## 테스트
- `MemberControllerTest` 진행도 API 테스트 추가
- `MemberControllerBattleResultsTest` 생성자 변경 반영

## 비고
- 프론트 반영은 별도 레포(`NBE8-10-final-Team01-front`)에서 진행
