### PR TITLE
[fix] Judge0 submit 배치 안정성 보강

### DIFF
--- a/src/main/java/com/back/global/judge/Judge0Client.java
+++ b/src/main/java/com/back/global/judge/Judge0Client.java
@@ -1,10 +1,12 @@
 package com.back.global.judge;
 
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class Judge0Client {
 
+    private static final int JUDGE0_BATCH_LIMIT = 20;
+
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
     private final String baseUrl;
@@ -38,8 +42,62 @@ public class Judge0Client {
      * Judge0는 snake_case 필드명(source_code, language_id 등)을 요구한다.
      */
     public List<String> submitBatch(List<Judge0SubmitRequest> submissions) {
+        if (submissions == null || submissions.isEmpty()) {
+            return List.of();
+        }
         log.debug("submitBatch called with {} submissions", submissions.size());
 
+        List<String> allTokens = new ArrayList<>(submissions.size());
+        for (int from = 0; from < submissions.size(); from += JUDGE0_BATCH_LIMIT) {
+            int to = Math.min(from + JUDGE0_BATCH_LIMIT, submissions.size());
+            List<Judge0SubmitRequest> chunk = submissions.subList(from, to);
+            allTokens.addAll(submitBatchChunkWithFallback(chunk));
+        }
+        return allTokens;
+    }
+
+    /**
+     * 토큰 목록으로 채점 결과를 조회한다.
+     */
+    public List<Judge0SubmitResponse> getBatchResults(List<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return List.of();
+        }
+
+        List<Judge0SubmitResponse> allResults = new ArrayList<>(tokens.size());
+        for (int from = 0; from < tokens.size(); from += JUDGE0_BATCH_LIMIT) {
+            int to = Math.min(from + JUDGE0_BATCH_LIMIT, tokens.size());
+            List<String> chunk = tokens.subList(from, to);
+            allResults.addAll(getBatchResultsChunkWithFallback(chunk));
+        }
+        return allResults;
+    }
+
+    /**
+     * Judge0 배치 호출이 실패하면 청크를 반으로 쪼개 재시도한다.
+     * 배포 환경별 request/body 제한 차이로 인한 일시적 4xx를 완화하기 위한 방어 로직.
+     */
+    private List<String> submitBatchChunkWithFallback(List<Judge0SubmitRequest> submissions) {
+        try {
+            return submitBatchChunk(submissions);
+        } catch (RuntimeException e) {
+            if (submissions.size() <= 1) {
+                return List.of(submitSingle(submissions.get(0)));
+            }
+            int mid = submissions.size() / 2;
+            log.warn("Judge0 batch submit failed for chunk size {}. Split and retry.", submissions.size(), e);
+            List<String> left = submitBatchChunkWithFallback(new ArrayList<>(submissions.subList(0, mid)));
+            List<String> right =
+                    submitBatchChunkWithFallback(new ArrayList<>(submissions.subList(mid, submissions.size())));
+
+            List<String> merged = new ArrayList<>(left.size() + right.size());
+            merged.addAll(left);
+            merged.addAll(right);
+            return merged;
+        }
+    }
+
+    private List<String> submitBatchChunk(List<Judge0SubmitRequest> submissions) {
         List<Map<String, Object>> submissionMaps = submissions.stream()
                 .map(s -> {
                     Map<String, Object> map = new LinkedHashMap<>();
@@ -74,6 +132,10 @@ public class Judge0Client {
 
             List<TokenResponse> tokenResponses =
                     objectMapper.readValue(response.body(), new TypeReference<List<TokenResponse>>() {});
+            if (tokenResponses.size() != submissions.size()) {
+                throw new RuntimeException("Judge0 batch submit mismatch: requested=" + submissions.size()
+                        + ", received=" + tokenResponses.size());
+            }
             return tokenResponses.stream().map(TokenResponse::token).toList();
 
         } catch (RuntimeException e) {
@@ -84,10 +146,49 @@ public class Judge0Client {
     }
 
     /**
-     * 토큰 목록으로 채점 결과를 조회한다.
+     * 단건 제출 폴백.
      */
-    public List<Judge0SubmitResponse> getBatchResults(List<String> tokens) {
-        String tokenParam = String.join(",", tokens);
+    private String submitSingle(Judge0SubmitRequest submission) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("source_code", submission.sourceCode());
+        body.put("language_id", submission.languageId());
+        body.put("stdin", submission.stdin() != null ? submission.stdin() : "");
+        if (submission.expectedOutput() != null) {
+            body.put("expected_output", submission.expectedOutput());
+        }
+
+        try {
+            String requestBodyJson = objectMapper.writeValueAsString(body);
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/submissions"))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBodyJson, StandardCharsets.UTF_8))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new RuntimeException(
+                        "Judge0 single submit failed: " + response.statusCode() + " " + response.body());
+            }
+
+            TokenResponse tokenResponse = objectMapper.readValue(response.body(), TokenResponse.class);
+            if (tokenResponse.token() == null || tokenResponse.token().isBlank()) {
+                throw new RuntimeException("Judge0 single submit returned empty token");
+            }
+            return tokenResponse.token();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Judge0 submitSingle error", e);
+        }
+    }
+
+    private List<Judge0SubmitResponse> getBatchResultsChunk(List<String> tokens) {
+        String tokenParam = tokens.stream()
+                .map(t -> URLEncoder.encode(t, StandardCharsets.UTF_8))
+                .reduce((a, b) -> a + "," + b)
+                .orElse("");
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(baseUrl + "/submissions/batch?tokens=" + tokenParam))
@@ -103,12 +204,67 @@ public class Judge0Client {
             }
 
             BatchResultResponse result = objectMapper.readValue(response.body(), BatchResultResponse.class);
+            if (result.submissions() == null || result.submissions().size() != tokens.size()) {
+                throw new RuntimeException("Judge0 batch result mismatch: requested=" + tokens.size() + ", received="
+                        + (result.submissions() == null
+                                ? 0
+                                : result.submissions().size()));
+            }
             return result.submissions();
 
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new RuntimeException("Judge0 getBatchResults error", e);
+        }
+    }
+
+    /**
+     * 결과 조회 실패 시에도 제출 순서를 유지한 채 분할 재시도한다.
+     */
+    private List<Judge0SubmitResponse> getBatchResultsChunkWithFallback(List<String> tokens) {
+        try {
+            return getBatchResultsChunk(tokens);
+        } catch (RuntimeException e) {
+            if (tokens.size() <= 1) {
+                return List.of(getResultByToken(tokens.get(0)));
+            }
+            int mid = tokens.size() / 2;
+            log.warn("Judge0 batch result fetch failed for chunk size {}. Split and retry.", tokens.size(), e);
+            List<Judge0SubmitResponse> left = getBatchResultsChunkWithFallback(new ArrayList<>(tokens.subList(0, mid)));
+            List<Judge0SubmitResponse> right =
+                    getBatchResultsChunkWithFallback(new ArrayList<>(tokens.subList(mid, tokens.size())));
+
+            List<Judge0SubmitResponse> merged = new ArrayList<>(left.size() + right.size());
+            merged.addAll(left);
+            merged.addAll(right);
+            return merged;
+        }
+    }
+
+    /**
+     * 단건 결과 조회 폴백.
+     */
+    private Judge0SubmitResponse getResultByToken(String token) {
+        String encodedToken = URLEncoder.encode(token, StandardCharsets.UTF_8);
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/submissions/" + encodedToken))
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new RuntimeException(
+                        "Judge0 single result failed: " + response.statusCode() + " " + response.body());
+            }
+
+            return objectMapper.readValue(response.body(), Judge0SubmitResponse.class);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Judge0 getResultByToken error", e);
         }
     }
 

--- a/src/main/java/com/back/global/judge/Judge0ExecutionService.java
+++ b/src/main/java/com/back/global/judge/Judge0ExecutionService.java
@@ -15,28 +15,54 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class Judge0ExecutionService {
 
-    private static final int MAX_POLL_ATTEMPTS = 10;
+    private static final int JUDGE0_BATCH_LIMIT = 20;
+    private static final int BASE_MAX_POLL_ATTEMPTS = 20;
+    private static final int EXTRA_ATTEMPTS_PER_EXTRA_CHUNK = 10;
+    private static final int EXTRA_ATTEMPTS_PER_10_CASES = 5;
     private static final int POLL_INTERVAL_MS = 1000;
 
     private final Judge0Client judge0Client;
 
     /**
      * Judge0에 배치 제출 후 폴링하여 결과 반환.
-     * 타임아웃(10초) 또는 오류 시 빈 리스트 반환.
+     * 타임아웃 또는 오류 시 빈 리스트 반환.
      */
     // TODO: 채점 폴링 10초 실패해서 빈 리스트를 반환하게되어서 WA로 된다면
     // 그건 나중에 점수 결산에서 빼야하는것 아닌가? (WA에서20초 추가되는거)
     public List<Judge0SubmitResponse> execute(List<Judge0SubmitRequest> batchRequests) {
         try {
             List<String> tokens = judge0Client.submitBatch(batchRequests);
-            for (int i = 0; i < MAX_POLL_ATTEMPTS; i++) {
-                List<Judge0SubmitResponse> results = judge0Client.getBatchResults(tokens);
-                if (results.stream().allMatch(Judge0SubmitResponse::isCompleted)) {
-                    return results;
+            if (tokens.isEmpty()) {
+                return List.of();
+            }
+
+            int chunkCount = Math.max(1, (tokens.size() + JUDGE0_BATCH_LIMIT - 1) / JUDGE0_BATCH_LIMIT);
+            int caseScaledAttempts = ((batchRequests.size() + 9) / 10) * EXTRA_ATTEMPTS_PER_10_CASES;
+            int maxPollAttempts =
+                    BASE_MAX_POLL_ATTEMPTS + (chunkCount - 1) * EXTRA_ATTEMPTS_PER_EXTRA_CHUNK + caseScaledAttempts;
+
+            List<Judge0SubmitResponse> lastResults = List.of();
+            for (int i = 0; i < maxPollAttempts; i++) {
+                try {
+                    List<Judge0SubmitResponse> results = judge0Client.getBatchResults(tokens);
+                    lastResults = results;
+                    if (!results.isEmpty() && results.stream().allMatch(Judge0SubmitResponse::isCompleted)) {
+                        return results;
+                    }
+                } catch (Exception pollException) {
+                    // 일시적 조회 실패(네트워크/4xx/5xx)가 있어도 즉시 JUDGE_ERROR로 끝내지 않고 재시도한다.
+                    log.warn("Judge0 polling attempt {}/{} failed", i + 1, maxPollAttempts, pollException);
                 }
                 Thread.sleep(POLL_INTERVAL_MS);
             }
-            log.warn("Judge0 polling timed out after {} attempts", MAX_POLL_ATTEMPTS);
+
+            // 타임아웃 직전 마지막 결과가 있으면 반환해 상위 계층에서 상태를 판단하게 한다.
+            if (!lastResults.isEmpty()) {
+                log.warn("Judge0 polling timed out after {} attempts with partial results", maxPollAttempts);
+                return lastResults;
+            }
+
+            log.warn("Judge0 polling timed out after {} attempts without results", maxPollAttempts);
             return List.of();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
## 배경
- submit 경로에서 테스트케이스 수가 많을 때 `JUDGE_ERROR (0/N)`가 발생하는 케이스 대응
- 환경에 따라 Judge0 batch 호출/조회가 불안정한 경우를 완화

## 변경 내용
- `Judge0Client`
  - 배치 크기 제한(20) 기반 분할 제출/조회
  - batch 실패 시 반분 재시도(fallback split)
  - 최종적으로 단건 submit/단건 result 조회 폴백 추가
  - batch 결과 개수 불일치 검증 추가
  - token query/path URL 인코딩 적용
- `Judge0ExecutionService`
  - 폴링 시도 횟수를 고정값에서 케이스 수/청크 수 기반으로 확장
  - 폴링 중 일시 실패 시 즉시 종료하지 않고 재시도
  - 타임아웃 직전 partial 결과가 있으면 반환

## 영향 파일
- `src/main/java/com/back/global/judge/Judge0Client.java`
- `src/main/java/com/back/global/judge/Judge0ExecutionService.java`

## 검증
- `./gradlew spotlessCheck`
- `./gradlew test --tests com.back.global.judge.JudgeServiceTest --tests com.back.global.judge.RunJudgeServiceTest`
