### PR TITLE
[Refactor] 방 생성과 종료 개선

### DIFF
--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
@@ -36,7 +36,7 @@ public class BattleParticipant extends BaseEntity {
     private Long scoreDelta; // 이 판으로 변동된 점수
     private LocalDateTime finishTime; // 문제를 다 푼 시각
 
-    @jakarta.persistence.Column(name = "is_result_checked", nullable = false)
+    @Column(name = "is_result_checked", nullable = false, columnDefinition = "boolean default true")
     private boolean isResultChecked = true; // 결과 확인 여부 (settle 시 false, 결과 조회 시 true)
 
     public static BattleParticipant create(BattleRoom battleRoom, Member member) {

--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipant.java
@@ -36,6 +36,9 @@ public class BattleParticipant extends BaseEntity {
     private Long scoreDelta; // 이 판으로 변동된 점수
     private LocalDateTime finishTime; // 문제를 다 푼 시각
 
+    @jakarta.persistence.Column(name = "is_result_checked", nullable = false)
+    private boolean isResultChecked = true; // 결과 확인 여부 (settle 시 false, 결과 조회 시 true)
+
     public static BattleParticipant create(BattleRoom battleRoom, Member member) {
         BattleParticipant participant = new BattleParticipant();
         participant.battleRoom = battleRoom;
@@ -50,12 +53,16 @@ public class BattleParticipant extends BaseEntity {
     }
 
     public void complete(LocalDateTime finishTime) {
-        this.status = BattleParticipantStatus.EXIT;
+        this.status = BattleParticipantStatus.SOLVED;
         this.finishTime = finishTime;
     }
 
     public void abandon() {
         this.status = BattleParticipantStatus.ABANDONED;
+    }
+
+    public void timeout() {
+        this.status = BattleParticipantStatus.TIMEOUT;
     }
 
     public void quit() {
@@ -65,5 +72,13 @@ public class BattleParticipant extends BaseEntity {
     public void applyResult(int rank, long delta) {
         this.finalRank = rank;
         this.scoreDelta = delta;
+    }
+
+    public void markUnchecked() {
+        this.isResultChecked = false;
+    }
+
+    public void markChecked() {
+        this.isResultChecked = true;
     }
 }

--- a/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipantStatus.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/entity/BattleParticipantStatus.java
@@ -3,7 +3,8 @@ package com.back.domain.battle.battleparticipant.entity;
 public enum BattleParticipantStatus {
     READY,
     PLAYING,
-    EXIT,
-    ABANDONED,
-    QUIT
+    SOLVED, // AC 판정으로 정상 완료
+    ABANDONED, // 네트워크 이탈 (grace period 대상, 재입장 가능)
+    TIMEOUT, // 시간 종료까지 PLAYING이었지만 미완료
+    QUIT // 의도적 퇴장
 }

--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -110,6 +110,28 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
             """)
     Optional<BattleParticipant> findActiveParticipantByMemberId(@Param("memberId") Long memberId);
 
+    /**
+     * 미확인 배틀 결과 조회 (가장 최근 것 1건)
+     * settle() 후 isResultChecked=false로 설정되고, 유저가 결과를 확인하면 true로 전환된다.
+     */
+    @Query("""
+            select bp from BattleParticipant bp
+            join fetch bp.battleRoom br
+            join fetch br.problem p
+            where bp.member.id = :memberId
+              and bp.isResultChecked = false
+              and br.status = com.back.domain.battle.battleroom.entity.BattleRoomStatus.FINISHED
+            order by br.createdAt desc
+            """)
+    List<BattleParticipant> findUncheckedResultsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    /**
+     * roomId + memberId로 참여자 조회 (Member 엔티티 로드 없이 FK만으로 조회)
+     */
+    @Query("select bp from BattleParticipant bp where bp.battleRoom.id = :roomId and bp.member.id = :memberId")
+    Optional<BattleParticipant> findByBattleRoomIdAndMemberId(
+            @Param("roomId") Long roomId, @Param("memberId") Long memberId);
+
     @Query("""
             select bp.finalRank
             from BattleParticipant bp

--- a/src/main/java/com/back/domain/battle/battleroom/entity/BattleRoom.java
+++ b/src/main/java/com/back/domain/battle/battleroom/entity/BattleRoom.java
@@ -22,6 +22,14 @@ public class BattleRoom extends BaseEntity {
     @SequenceGenerator(name = "battle_room_seq_gen", sequenceName = "battle_room_id_seq", allocationSize = 50)
     private Long id;
 
+    /**
+     * 낙관적 락 — settle() 동시 진입 시 하나만 커밋 성공하도록 보장.
+     * idempotent 체크(if FINISHED return)가 대부분의 중복 호출을 차단하고,
+     * 낙관적 락은 두 트랜잭션이 동시에 체크를 통과한 극히 드문 race condition을 DB 레벨에서 차단한다.
+     */
+    @Version
+    private Long version;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_id")
     private Problem problem;

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -29,8 +29,10 @@ import com.back.domain.problem.problem.repository.ProblemRepository;
 import com.back.global.exception.ServiceException;
 import com.back.global.websocket.BattleCodeStore;
 import com.back.global.websocket.BattleReconnectStore;
+import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -46,6 +48,7 @@ public class BattleRoomService {
     private final WebSocketMessagePublisher publisher;
     private final BattleCodeStore battleCodeStore;
     private final BattleReconnectStore reconnectStore;
+    private final BattleTimerStore battleTimerStore;
     private final BattleResultService battleResultService;
 
     @Transactional
@@ -134,6 +137,11 @@ public class BattleRoomService {
                         } catch (Exception e) {
                             log.error("BATTLE_STARTED WebSocket 전송 실패 roomId={}", roomId, e);
                         }
+                        try {
+                            battleTimerStore.schedule(roomId);
+                        } catch (Exception e) {
+                            log.error("배틀 타이머 예약 실패 roomId={} - 스케줄러 안전망이 복구 예정", roomId, e);
+                        }
                     }
                 });
             }
@@ -197,7 +205,10 @@ public class BattleRoomService {
                 }
                 if (noActiveLeft) {
                     try {
+                        battleTimerStore.cancel(roomId);
                         battleResultService.settle(roomId);
+                    } catch (OptimisticLockException e) {
+                        log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", roomId);
                     } catch (Exception e) {
                         log.error("즉시 정산 실패 roomId={}", roomId, e);
                     }

--- a/src/main/java/com/back/domain/battle/result/controller/BattleResultController.java
+++ b/src/main/java/com/back/domain/battle/result/controller/BattleResultController.java
@@ -4,12 +4,14 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.battle.result.dto.ActiveRoomResponse;
 import com.back.domain.battle.result.dto.BattleResultResponse;
 import com.back.domain.battle.result.dto.RoomListResponse;
+import com.back.domain.battle.result.dto.UncheckedResultResponse;
 import com.back.domain.battle.result.service.BattleResultService;
 import com.back.global.rq.Rq;
 
@@ -40,5 +42,19 @@ public class BattleResultController {
     public ActiveRoomResponse getActiveRoom() {
         Long memberId = rq.getActor().getId();
         return battleResultService.getActiveRoom(memberId);
+    }
+
+    // 미확인 배틀 결과 조회 — 로그인/홈 진입 시 호출해 결과 화면으로 유도
+    @GetMapping("/result/unchecked")
+    public UncheckedResultResponse getUncheckedResult() {
+        Long memberId = rq.getActor().getId();
+        return battleResultService.getUncheckedResult(memberId);
+    }
+
+    // 결과 확인 처리 — 결과 화면 진입 시 호출
+    @PostMapping("/result/{roomId}/check")
+    public void checkResult(@PathVariable Long roomId) {
+        Long memberId = rq.getActor().getId();
+        battleResultService.checkResult(roomId, memberId);
     }
 }

--- a/src/main/java/com/back/domain/battle/result/dto/MyBattleResultsResponse.java
+++ b/src/main/java/com/back/domain/battle/result/dto/MyBattleResultsResponse.java
@@ -33,8 +33,8 @@ public record MyBattleResultsResponse(List<MyBattleResultItem> battleResults, Pa
          * BattleParticipant 엔티티를 전적 응답 아이템으로 변환
          *
          * solved:
-         * - 배틀에서 정답 처리 후 complete() 되면 EXIT 상태가 되므로
-         * - EXIT 이면 solved = true 로 본다.
+         * - 배틀에서 정답 처리 후 complete() 되면 SOLVED 상태가 되므로
+         * - SOLVED 이면 solved = true 로 본다.
          */
         public static MyBattleResultItem from(BattleParticipant participant) {
             return new MyBattleResultItem(
@@ -43,7 +43,7 @@ public record MyBattleResultsResponse(List<MyBattleResultItem> battleResults, Pa
                     participant.getBattleRoom().getProblem().getTitle(),
                     participant.getFinalRank(),
                     participant.getScoreDelta(),
-                    participant.getStatus() == BattleParticipantStatus.EXIT,
+                    participant.getStatus() == BattleParticipantStatus.SOLVED,
                     participant.getFinishTime(),
                     // 배틀이 생성된 시각을 "플레이한 시각" 기준값으로 사용
                     participant.getBattleRoom().getCreatedAt());

--- a/src/main/java/com/back/domain/battle/result/dto/UncheckedResultResponse.java
+++ b/src/main/java/com/back/domain/battle/result/dto/UncheckedResultResponse.java
@@ -1,0 +1,14 @@
+package com.back.domain.battle.result.dto;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+
+public record UncheckedResultResponse(Long roomId, int rank, long scoreDelta, String problemTitle) {
+
+    public static UncheckedResultResponse from(BattleParticipant p) {
+        return new UncheckedResultResponse(
+                p.getBattleRoom().getId(),
+                p.getFinalRank(),
+                p.getScoreDelta(),
+                p.getBattleRoom().getProblem().getTitle());
+    }
+}

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -27,6 +27,7 @@ import com.back.domain.battle.result.dto.BattleResultResponse;
 import com.back.domain.battle.result.dto.BattleResultResponse.ParticipantResult;
 import com.back.domain.battle.result.dto.MyBattleResultsResponse;
 import com.back.domain.battle.result.dto.RoomListResponse;
+import com.back.domain.battle.result.dto.UncheckedResultResponse;
 import com.back.domain.problem.submission.entity.Submission;
 import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
@@ -72,6 +73,12 @@ public class BattleResultService {
         // 2. 모든 참여자 조회
         List<BattleParticipant> participants = battleParticipantRepository.findByBattleRoom(room);
 
+        // 2-1. 시간 종료 시점까지 아직 PLAYING인 참여자를 TIMEOUT으로 명시적 전환
+        //      ABANDONED(네트워크 이탈)와 구분: TIMEOUT은 끝까지 도전했으나 시간 초과
+        participants.stream()
+                .filter(p -> p.getStatus() == BattleParticipantStatus.PLAYING)
+                .forEach(BattleParticipant::timeout);
+
         // 3. 각 참여자 score 미리 계산 (DB 쿼리를 정렬 전에 한 번씩만 실행)
         //    Comparator 안에서 calcScore() 호출 시 O(N log N) 횟수만큼 DB 조회가 발생하는 문제 방지
         Map<Long, Long> scoreMap =
@@ -92,7 +99,7 @@ public class BattleResultService {
         int rank = 1;
         int totalParticipants = sorted.size();
         for (BattleParticipant participant : sorted) {
-            boolean isAC = participant.getStatus() == BattleParticipantStatus.EXIT;
+            boolean isAC = participant.getStatus() == BattleParticipantStatus.SOLVED;
             long scoreDelta = 0L;
             if (isAC && rank <= SCORE_TABLE.length) {
                 scoreDelta = SCORE_TABLE[rank - 1];
@@ -123,21 +130,47 @@ public class BattleResultService {
                     participant.getMember(), room.getProblem(), participant.getFinishTime());
         }
 
-        // 6. BattleRoom 종료
+        // 6. 모든 참여자 결과 미확인 상태로 전환 (재접속 시 결과 화면 유도)
+        participants.forEach(BattleParticipant::markUnchecked);
+
+        // 7. BattleRoom 종료
         room.finish();
 
-        // 7. WebSocket 브로드캐스트 — 커밋 후 전송으로 프론트가 확정된 DB 상태를 읽도록 보장
+        // 8. WebSocket 브로드캐스트 — 커밋 후 전송으로 프론트가 확정된 DB 상태를 읽도록 보장
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 // 커밋 후이므로 예외를 전파해도 트랜잭션 롤백이 불가능하고,
                 // 클라이언트에게 500이 반환되어 DB는 성공했는데 실패로 인식하는 혼란을 유발함.
                 // WebSocket은 실시간 알림 역할이므로 전송 실패가 치명적이지 않아 예외를 삼키고 로그만 남김.
+
+                // 방 채널 브로드캐스트 (방 내 구독자 및 관전자)
                 try {
                     publisher.publish("/topic/room/" + roomId, Map.of("type", "BATTLE_FINISHED"));
                 } catch (Exception e) {
                     log.error("BATTLE_FINISHED WebSocket 전송 실패 roomId={}", roomId, e);
                 }
+
+                // 개인 채널 알림 — 방을 나간 참여자(AC 후 이탈)도 결과를 즉시 수신 가능
+                for (BattleParticipant p : sorted) {
+                    try {
+                        publisher.publish(
+                                "/topic/user/" + p.getMember().getId() + "/battle",
+                                Map.of(
+                                        "type",
+                                        "BATTLE_RESULT",
+                                        "roomId",
+                                        roomId,
+                                        "rank",
+                                        p.getFinalRank(),
+                                        "scoreDelta",
+                                        p.getScoreDelta()));
+                    } catch (Exception e) {
+                        log.error("개인 알림 전송 실패 memberId={}", p.getMember().getId(), e);
+                    }
+                }
+
+                // 방 종료 후 관전용 코드 Redis 정리
                 try {
                     battleCodeStore.deleteAllByRoom(roomId);
                 } catch (Exception e) {
@@ -208,7 +241,7 @@ public class BattleResultService {
      * 미통과 참여자: Long.MAX_VALUE
      */
     private long calcScore(BattleParticipant participant, BattleRoom room) {
-        if (participant.getStatus() != BattleParticipantStatus.EXIT) {
+        if (participant.getStatus() != BattleParticipantStatus.SOLVED) {
             return Long.MAX_VALUE;
         }
 
@@ -227,6 +260,28 @@ public class BattleResultService {
                 room, participant.getMember(), SubmissionResult.WA, participant.getFinishTime());
 
         return elapsedSeconds + (waPenaltyCount * WA_PENALTY_SECONDS);
+    }
+
+    /**
+     * 로그인 유저의 미확인 배틀 결과 조회 (가장 최근 1건).
+     * 브라우저를 닫고 재접속한 경우 이 API로 결과 화면으로 유도한다.
+     */
+    @Transactional(readOnly = true)
+    public UncheckedResultResponse getUncheckedResult(Long memberId) {
+        return battleParticipantRepository.findUncheckedResultsByMemberId(memberId, PageRequest.of(0, 1)).stream()
+                .findFirst()
+                .map(UncheckedResultResponse::from)
+                .orElse(null);
+    }
+
+    /**
+     * 결과 확인 처리 — 결과 화면 진입 시 호출.
+     */
+    @Transactional
+    public void checkResult(Long roomId, Long memberId) {
+        battleParticipantRepository
+                .findByBattleRoomIdAndMemberId(roomId, memberId)
+                .ifPresent(BattleParticipant::markChecked);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -32,6 +32,7 @@ import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
 import com.back.domain.rating.profile.service.RatingProfileService;
 import com.back.global.exception.ServiceException;
+import com.back.global.websocket.BattleCodeStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,7 @@ public class BattleResultService {
     private final SubmissionRepository submissionRepository;
     private final RatingProfileService ratingProfileService;
     private final WebSocketMessagePublisher publisher;
+    private final BattleCodeStore battleCodeStore;
 
     @Transactional
     public void settle(Long roomId) {
@@ -135,6 +137,11 @@ public class BattleResultService {
                     publisher.publish("/topic/room/" + roomId, Map.of("type", "BATTLE_FINISHED"));
                 } catch (Exception e) {
                     log.error("BATTLE_FINISHED WebSocket 전송 실패 roomId={}", roomId, e);
+                }
+                try {
+                    battleCodeStore.deleteAllByRoom(roomId);
+                } catch (Exception e) {
+                    log.error("배틀 코드 Redis 정리 실패 roomId={}", roomId, e);
                 }
             }
         });

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -24,8 +24,10 @@ import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.global.judge.dto.Judge0SubmitRequest;
 import com.back.global.judge.dto.Judge0SubmitResponse;
 import com.back.global.judge.event.JudgeRequestedEvent;
+import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,6 +42,7 @@ public class JudgeService {
     private final BattleRoomRepository battleRoomRepository;
     private final MemberRepository memberRepository;
     private final BattleResultService battleResultService;
+    private final BattleTimerStore battleTimerStore;
     private final WebSocketMessagePublisher publisher;
 
     /**
@@ -137,7 +140,7 @@ public class JudgeService {
                 .orElseThrow(() -> new IllegalStateException("Participant not found"));
 
         /*
-         * status: PLAYING에서 EXIT
+         * status: PLAYING에서 SOLVED
          * finishTime 기록
          */
         participant.complete(LocalDateTime.now());
@@ -145,7 +148,7 @@ public class JudgeService {
 
         List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
         long completedCount = allParticipants.stream()
-                .filter(p -> p.getStatus() == BattleParticipantStatus.EXIT)
+                .filter(p -> p.getStatus() == BattleParticipantStatus.SOLVED)
                 .count();
         // PARTICIPANT_DONE 브로드캐스트
         publisher.publish(
@@ -153,17 +156,18 @@ public class JudgeService {
                 Map.of("type", "PARTICIPANT_DONE", "userId", memberId, "rank", completedCount));
 
         /*
-         * 전원 EXIT 체크
+         * 전원 SOLVED 체크
          *     → 아직 남은 사람 있으면 종료
-         *     → 전원 완료면 battleResultService.settle() 호출
-         *         → 순위/점수 계산
-         *         → member.score 갱신
-         *         → room.finish() → status: FINISHED
-         *         → BATTLE_FINISHED 브로드캐스트
+         *     → 전원 완료면 타이머 취소 후 즉시 settle()
          */
-        boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.EXIT);
+        boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.SOLVED);
         if (allFinished) {
-            battleResultService.settle(roomId);
+            battleTimerStore.cancel(roomId);
+            try {
+                battleResultService.settle(roomId);
+            } catch (OptimisticLockException e) {
+                log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", roomId);
+            }
         }
     }
 

--- a/src/main/java/com/back/global/scheduler/BattleScheduler.java
+++ b/src/main/java/com/back/global/scheduler/BattleScheduler.java
@@ -11,6 +11,7 @@ import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
 import com.back.domain.battle.result.service.BattleResultService;
 
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,19 +24,24 @@ public class BattleScheduler {
     private final BattleResultService battleResultService;
 
     /**
-     * 10초마다 타이머가 만료된 PLAYING 방을 조회해 결과 정산.
-     * BattleResultService.settle() 내부에서 FINISHED 체크로 중복 정산 방지.
-     *
-     * <p>ABANDONED 참여자 감지는 GracePeriodConsumer(Redisson DelayedQueue)가 담당.
+     * 안전망: BattleTimerConsumer(Redisson DelayedQueue)가 주 트리거이며,
+     * 컨슈머 처리 실패 또는 서버 재시작으로 누락된 방을 60초마다 복구한다.
+     * settle() 내부의 FINISHED 체크로 중복 정산을 방지한다.
      */
-    @Scheduled(fixedDelay = 10_000)
+    @Scheduled(fixedDelay = 60_000)
     public void checkExpiredRooms() {
         List<BattleRoom> expiredRooms =
                 battleRoomRepository.findByStatusAndTimerEndBefore(BattleRoomStatus.PLAYING, LocalDateTime.now());
 
         for (BattleRoom room : expiredRooms) {
             log.info("타이머 만료 감지 - roomId: {}, timerEnd: {}", room.getId(), room.getTimerEnd());
-            battleResultService.settle(room.getId());
+            try {
+                battleResultService.settle(room.getId());
+            } catch (OptimisticLockException e) {
+                log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", room.getId());
+            } catch (Exception e) {
+                log.error("settle 실패 roomId={}", room.getId(), e);
+            }
         }
     }
 }

--- a/src/main/java/com/back/global/websocket/BattleCodeStore.java
+++ b/src/main/java/com/back/global/websocket/BattleCodeStore.java
@@ -8,11 +8,13 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Redis에 코드를 저장/조회/삭제하는 컴포넌트
- * Key:   "battle:code:{roomId}:{memberId}"   예) "battle:code:1:42"
+ * Redis Hash에 코드를 저장/조회/삭제하는 컴포넌트
+ * Key:   "battle:code:{roomId}"              예) "battle:code:1"
+ * Field: "{memberId}"                         예) "42"
  * Value: 유저가 작성 중인 코드 문자열
  * TTL:   40분 (배틀 시간 30분 + 여유분)
- * TTL을 설정해두면 배틀이 끝난 후 별도로 삭제 안 해도 Redis에서 자동으로 삭제됨
+ *
+ * Hash 구조를 사용하면 방 종료 시 DEL 명령 1번으로 모든 참가자 코드를 일괄 삭제 가능
  */
 @Component
 @RequiredArgsConstructor
@@ -20,19 +22,26 @@ public class BattleCodeStore {
 
     private final StringRedisTemplate redisTemplate;
 
-    private static final String KEY_FORMAT = "battle:code:%d:%d"; // roomId:memberId
+    private static final String KEY_FORMAT = "battle:code:%d"; // roomId
     private static final Duration TTL = Duration.ofMinutes(40);
 
     public void save(Long roomId, Long memberId, String code) {
-        redisTemplate.opsForValue().set(KEY_FORMAT.formatted(roomId, memberId), code, TTL);
+        String key = KEY_FORMAT.formatted(roomId);
+        redisTemplate.opsForHash().put(key, memberId.toString(), code);
+        redisTemplate.expire(key, TTL);
     }
 
     public String get(Long roomId, Long memberId) {
-        String value = redisTemplate.opsForValue().get(KEY_FORMAT.formatted(roomId, memberId));
-        return value != null ? value : "";
+        Object value = redisTemplate.opsForHash().get(KEY_FORMAT.formatted(roomId), memberId.toString());
+        return value != null ? value.toString() : "";
     }
 
     public void delete(Long roomId, Long memberId) {
-        redisTemplate.delete(KEY_FORMAT.formatted(roomId, memberId));
+        redisTemplate.opsForHash().delete(KEY_FORMAT.formatted(roomId), memberId.toString());
+    }
+
+    /** 방 종료 시 해당 방의 모든 참가자 코드를 일괄 삭제 */
+    public void deleteAllByRoom(Long roomId) {
+        redisTemplate.delete(KEY_FORMAT.formatted(roomId));
     }
 }

--- a/src/main/java/com/back/global/websocket/BattleTimerConsumer.java
+++ b/src/main/java/com/back/global/websocket/BattleTimerConsumer.java
@@ -1,0 +1,81 @@
+package com.back.global.websocket;
+
+import org.redisson.RedissonShutdownException;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.back.domain.battle.result.service.BattleResultService;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 배틀 종료 타이머 만료 메시지를 소비하는 백그라운드 컨슈머.
+ *
+ * GracePeriodConsumer와 동일한 구조:
+ * Redisson DelayedQueue에 등록된 roomId가 30분 후 BlockingQueue로 이동하면
+ * 이 컨슈머가 꺼내서 settle()을 호출한다.
+ *
+ * 처리 실패 시 복구 전략:
+ * settle() 예외가 발생해도 BattleScheduler(60초 주기 안전망)가 만료된 방을 재감지해 복구한다.
+ * 따라서 여기서는 예외를 삼키고 로그만 남긴다.
+ *
+ * 멀티 컨슈머 확장:
+ * 현재는 단일 가상 스레드로 처리한다.
+ * 서비스 규모가 커져 동시에 다수의 방이 만료되는 경우 아래처럼 복수 컨슈머로 확장할 수 있다:
+ *
+ * for (int i = 0; i < N; i++) {
+ *     Thread.ofVirtual().name("battle-timer-consumer-" + i).start(this::consume);
+ * }
+ *
+ * RBlockingQueue는 Redis BLPOP 기반으로 각 아이템을 정확히 하나의 컨슈머만 처리하므로 안전하다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BattleTimerConsumer {
+
+    private final BattleTimerStore battleTimerStore;
+    private final BattleResultService battleResultService;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void startConsuming() {
+        Thread.ofVirtual().name("battle-timer-consumer").start(this::consume);
+    }
+
+    private void consume() {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                String item = battleTimerStore.getBlockingQueue().take();
+                Long roomId = Long.parseLong(item);
+                handle(roomId);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.info("BattleTimerConsumer 종료");
+                break;
+            } catch (RedissonShutdownException e) {
+                log.info("Redisson 종료 감지 - BattleTimerConsumer 중단");
+                break;
+            } catch (Exception e) {
+                log.error("BattleTimerConsumer 처리 중 오류", e);
+            }
+        }
+    }
+
+    // package-private for testing
+    void handle(Long roomId) {
+        try {
+            log.info("배틀 타이머 만료 - settle 호출 roomId={}", roomId);
+            battleResultService.settle(roomId);
+        } catch (OptimisticLockException e) {
+            // 동시에 settle()이 두 번 진입한 경우 두 번째 트랜잭션이 여기서 차단됨.
+            // 첫 번째가 이미 정산을 완료했으므로 정상 흐름 — 로그만 남기고 무시.
+            log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", roomId);
+        } catch (Exception e) {
+            // settle() 실패 시 BattleScheduler(60초 주기 안전망)가 복구 예정
+            log.error("settle 실패 - 스케줄러 안전망이 복구 예정 roomId={}", roomId, e);
+        }
+    }
+}

--- a/src/main/java/com/back/global/websocket/BattleTimerStore.java
+++ b/src/main/java/com/back/global/websocket/BattleTimerStore.java
@@ -1,0 +1,69 @@
+package com.back.global.websocket;
+
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RBlockingQueue;
+import org.redisson.api.RDelayedQueue;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 배틀 종료 타이머를 Redisson DelayedQueue로 관리.
+ *
+ * Key 설계:
+ * battle:timer:queue  ZSET → List  — Redisson DelayedQueue 내부 저장소
+ *
+ * BattleReconnectStore(grace period)와 동일한 패턴:
+ * - BattleReconnectStore : memberId → 15초 후 PARTICIPANT_LEFT
+ * - BattleTimerStore     : roomId  → 30분 후 settle()
+ *
+ * 기존 BattleScheduler(폴링)와의 역할 분담:
+ * - BattleTimerStore  : 배틀 시작 시점에 정확한 종료 시각을 예약 (주 트리거)
+ * - BattleScheduler   : 서버 재시작 또는 컨슈머 처리 실패 시 복구용 안전망 (60초 주기)
+ */
+@Component
+@RequiredArgsConstructor
+public class BattleTimerStore {
+
+    private final RedissonClient redissonClient;
+
+    @Value("${battle.duration-minutes:30}")
+    private long battleDurationMinutes;
+
+    private static final String TIMER_QUEUE = "battle:timer:queue";
+
+    private RBlockingQueue<String> blockingQueue() {
+        return redissonClient.getBlockingQueue(TIMER_QUEUE);
+    }
+
+    private RDelayedQueue<String> delayedQueue() {
+        return redissonClient.getDelayedQueue(blockingQueue());
+    }
+
+    /**
+     * 배틀 시작 시 호출. 30분 후 settle()이 실행되도록 roomId를 큐에 등록한다.
+     * BattleRoomService.joinRoom() afterCommit에서 호출 — DB 커밋 후 예약으로 원자성 보장.
+     */
+    public void schedule(Long roomId) {
+        delayedQueue().offer(roomId.toString(), battleDurationMinutes, TimeUnit.MINUTES);
+    }
+
+    /**
+     * 전원 AC 조기종료 또는 모든 참여자 퇴장 시 호출.
+     * ZSET·List 양쪽 모두 제거 시도 — 이미 컨슈머가 꺼낸 경우 remove()는 no-op.
+     */
+    public void cancel(Long roomId) {
+        delayedQueue().remove(roomId.toString());
+        blockingQueue().remove(roomId.toString());
+    }
+
+    /**
+     * BattleTimerConsumer가 만료된 roomId를 꺼내는 큐.
+     */
+    public RBlockingQueue<String> getBlockingQueue() {
+        return blockingQueue();
+    }
+}

--- a/src/main/java/com/back/global/websocket/BattleWebSocketHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleWebSocketHandler.java
@@ -1,5 +1,6 @@
 package com.back.global.websocket;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -13,7 +14,9 @@ import com.back.global.websocket.dto.CodeUpdateMessage;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class BattleWebSocketHandler {
@@ -34,9 +37,28 @@ public class BattleWebSocketHandler {
             CodeUpdateMessage message,
             @AuthenticationPrincipal SecurityUser securityUser) {
 
-        publisher.publish(
-                "/topic/room/" + roomId + "/spectate",
-                Map.of("type", "CODE_UPDATE", "userId", securityUser.getId(), "code", message.code()));
+        if (securityUser == null) {
+            log.warn("handleCodeUpdate - securityUser is null roomId={}", roomId);
+            return;
+        }
+        if (securityUser.getId() == null) {
+            log.warn("handleCodeUpdate - securityUser.getId() is null roomId={}", roomId);
+            return;
+        }
+        if (message == null) {
+            log.warn("handleCodeUpdate - message is null roomId={}", roomId);
+            return;
+        }
+        if (message.code() == null) {
+            log.warn("handleCodeUpdate - message.code() is null roomId={} memberId={}", roomId, securityUser.getId());
+            return;
+        }
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("type", "CODE_UPDATE");
+        payload.put("userId", securityUser.getId());
+        payload.put("code", message.code());
+        publisher.publish("/topic/room/" + roomId + "/spectate", payload);
 
         // 재입장 및 관전자 동기화를 위해 Redis에 임시 저장
         battleCodeStore.save(roomId, securityUser.getId(), message.code());
@@ -52,10 +74,21 @@ public class BattleWebSocketHandler {
     @MessageMapping("/room/{roomId}/code/sync")
     public void handleSyncRequest(@DestinationVariable Long roomId, CodeSyncRequest request) {
 
+        if (request == null) {
+            log.warn("handleSyncRequest - request is null roomId={}", roomId);
+            return;
+        }
+        if (request.targetUserId() == null) {
+            log.warn("handleSyncRequest - targetUserId is null roomId={}", roomId);
+            return;
+        }
+
         String code = battleCodeStore.get(roomId, request.targetUserId());
 
-        publisher.publish(
-                "/topic/room/" + roomId + "/spectate",
-                Map.of("type", "CODE_SYNC", "userId", request.targetUserId(), "code", code));
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("type", "CODE_SYNC");
+        payload.put("userId", request.targetUserId());
+        payload.put("code", code);
+        publisher.publish("/topic/room/" + roomId + "/spectate", payload);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceExitRoomTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceExitRoomTest.java
@@ -33,6 +33,7 @@ import com.back.domain.problem.problem.repository.ProblemRepository;
 import com.back.global.exception.ServiceException;
 import com.back.global.websocket.BattleCodeStore;
 import com.back.global.websocket.BattleReconnectStore;
+import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 class BattleRoomServiceExitRoomTest {
@@ -44,6 +45,7 @@ class BattleRoomServiceExitRoomTest {
     private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
     private final BattleCodeStore battleCodeStore = mock(BattleCodeStore.class);
     private final BattleReconnectStore reconnectStore = mock(BattleReconnectStore.class);
+    private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
     private final BattleResultService battleResultService = mock(BattleResultService.class);
 
     private final BattleRoomService sut = new BattleRoomService(
@@ -54,6 +56,7 @@ class BattleRoomServiceExitRoomTest {
             publisher,
             battleCodeStore,
             reconnectStore,
+            battleTimerStore,
             battleResultService);
 
     private static final Long ROOM_ID = 1L;
@@ -99,7 +102,7 @@ class BattleRoomServiceExitRoomTest {
         BattleParticipant participant = playingParticipant(room, member);
 
         BattleParticipant exitedOther = mock(BattleParticipant.class);
-        when(exitedOther.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(exitedOther.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
 
         given_room_member_participant(room, member, participant, List.of(participant, exitedOther));
 

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceGetRoomStateTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceGetRoomStateTest.java
@@ -25,6 +25,7 @@ import com.back.domain.problem.problem.repository.ProblemRepository;
 import com.back.global.exception.ServiceException;
 import com.back.global.websocket.BattleCodeStore;
 import com.back.global.websocket.BattleReconnectStore;
+import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 class BattleRoomServiceGetRoomStateTest {
@@ -41,6 +42,7 @@ class BattleRoomServiceGetRoomStateTest {
             mock(WebSocketMessagePublisher.class),
             battleCodeStore,
             mock(BattleReconnectStore.class),
+            mock(BattleTimerStore.class),
             mock(BattleResultService.class));
 
     private static final Long ROOM_ID = 1L;

--- a/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
@@ -28,6 +28,7 @@ import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
 import com.back.domain.rating.profile.service.RatingProfileService;
 import com.back.global.exception.ServiceException;
+import com.back.global.websocket.BattleCodeStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 class BattleResultServiceTest {
@@ -39,7 +40,12 @@ class BattleResultServiceTest {
     private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
 
     private final BattleResultService battleResultService = new BattleResultService(
-            battleRoomRepository, battleParticipantRepository, submissionRepository, ratingProfileService, publisher);
+            battleRoomRepository,
+            battleParticipantRepository,
+            submissionRepository,
+            ratingProfileService,
+            publisher,
+            mock(BattleCodeStore.class));
 
     @Test
     @DisplayName("내 전적 조회 성공 시 battleResults와 pageInfo를 반환한다")
@@ -59,7 +65,7 @@ class BattleResultServiceTest {
         when(participant.getBattleRoom()).thenReturn(room);
         when(participant.getFinalRank()).thenReturn(2);
         when(participant.getScoreDelta()).thenReturn(70L);
-        when(participant.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(participant.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
         when(participant.getFinishTime()).thenReturn(finishTime);
 
         when(room.getId()).thenReturn(101L);

--- a/src/test/java/com/back/global/judge/JudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/JudgeServiceTest.java
@@ -32,6 +32,7 @@ import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.global.judge.dto.Judge0SubmitResponse;
 import com.back.global.judge.dto.Judge0SubmitResponse.Status;
 import com.back.global.judge.event.JudgeRequestedEvent;
+import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 class JudgeServiceTest {
@@ -42,6 +43,7 @@ class JudgeServiceTest {
     private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
     private final MemberRepository memberRepository = mock(MemberRepository.class);
     private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
     private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
 
     private final JudgeService judgeService = new JudgeService(
@@ -51,6 +53,7 @@ class JudgeServiceTest {
             battleRoomRepository,
             memberRepository,
             battleResultService,
+            battleTimerStore,
             publisher);
 
     private static final Long SUBMISSION_ID = 1L;
@@ -112,7 +115,7 @@ class JudgeServiceTest {
         stubJudge0(response(3, "3\n"));
 
         BattleParticipant exitParticipant = mock(BattleParticipant.class);
-        when(exitParticipant.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(exitParticipant.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
         stubHandleAc(List.of(exitParticipant));
 
         judgeService.onJudgeRequested(event(List.of(tc)));
@@ -202,7 +205,7 @@ class JudgeServiceTest {
         stubJudge0(response(3, "3\n"));
 
         BattleParticipant exitParticipant = mock(BattleParticipant.class);
-        when(exitParticipant.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(exitParticipant.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
         stubHandleAc(List.of(exitParticipant));
 
         judgeService.onJudgeRequested(event(List.of(tc)));
@@ -231,8 +234,8 @@ class JudgeServiceTest {
 
         BattleParticipant p1 = mock(BattleParticipant.class);
         BattleParticipant p2 = mock(BattleParticipant.class);
-        when(p1.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
-        when(p2.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(p1.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(p2.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
         stubHandleAc(List.of(p1, p2));
 
         judgeService.onJudgeRequested(event(List.of(tc)));
@@ -248,7 +251,7 @@ class JudgeServiceTest {
 
         BattleParticipant p1 = mock(BattleParticipant.class);
         BattleParticipant p2 = mock(BattleParticipant.class);
-        when(p1.getStatus()).thenReturn(BattleParticipantStatus.EXIT);
+        when(p1.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
         when(p2.getStatus()).thenReturn(BattleParticipantStatus.PLAYING);
         stubHandleAc(List.of(p1, p2));
 


### PR DESCRIPTION
### 현재 Redis 인프라 현황

| 패턴 | 현재 용도 | 관련 클래스 |
| --- | --- | --- |
| Redisson DelayedQueue | Grace period (15초 유예) | `BattleReconnectStore`, `GracePeriodConsumer` |
| Redis Pub/Sub | WebSocket 멀티 인스턴스 브로드캐스트 | `WebSocketMessagePublisher`, `WebSocketMessageSubscriber` |
| StringRedisTemplate TTL | 토큰, 코드 저장 | `WsTokenStore`, `BattleCodeStore` |

### 개선된 아키텍처

핵심 아이디어
`BattleTimer`도 `DelayedQueue`로 `battle:grace:queue`와 완전히 동일한 패턴으로 `battle:timer:queue`를 추가

기존: `GracePeriodConsumer` → `battle:grace:queue` (15초) → `PARTICIPANT_LEFT`
신규: `BattleTimerConsumer` → `battle:timer:queue` (30분) → `settle()`
(새로운 인프라 없이 동일한 패턴을 사용)

### 흐름 비교

```java
현재:
배틀 시작
  └─ (아무것도 안 함)

10초마다 폴링 스케줄러
  └─ DB 조회 (timerEnd < now AND status=PLAYING)
     └─ settle()

=====================================================================

개선 후:
배틀 시작
  └─ BattleTimerQueue.schedule(roomId, 30분)  ← DelayedQueue에 예약 (battle:timer:queue ← offer(roomId, 30분))

30분 후 자동으로
  └─ BattleTimerConsumer.handle(roomId) (BattleTimerConsumer)
     └─ settle()

모든 참가자 AC (조기종료):
마지막 AC
  └─ BattleTimerQueue.cancel(roomId)  ← DelayedQueue에서 제거 (battle:timer:queue.cancel(roomId))
     └─ settle()
```

`BattleScheduler`: 10초 폴링 → 60초 안전망으로 역할 축소

---

### `settle()` 동시성: idempotent + 낙관적 락

 RLock 대신 낙관적 락을 선택.
RLock은 Redis 장애 시 settle() 전체가 실패하는 리스크가 있고, 이미 DB 체크(if FINISHED return)가 있어 Redis 추가 의존도를 높일 이유가 없었음.

```java
settle() 호출
      │
      ├─ [1차] idempotent 체크
      │   if (FINISHED) return  ← 대부분의 중복 호출 여기서 차단
      │   불필요한 DB 쿼리 실행 없음
      │
      ├─ 점수 계산, 상태 전환...
      │
      └─ [2차] @Version 낙관적 락
          commit 시 version 불일치 → OptimisticLockException → 롤백
          호출자에서 "이미 정산 완료" info 로그 처리
```

|  | RLock | 낙관적 락 (선택) |
| --- | --- | --- |
| Redis 장애 시 | settle() 전체 실패 | 영향 없음 |
| leaseTime 설정 | 필수 (크래시 대비) | 불필요 |
| 기존 idempotent 체크와 관계 | 중복 | 상호 보완 |

---

### 상태값 정비

```java
Before: READY | PLAYING | EXIT | ABANDONED | QUIT
After:  READY | PLAYING | SOLVED | ABANDONED | TIMEOUT | QUIT
```

| 상태 | 의미 |
| --- | --- |
| SOLVED | AC 판정으로 정상 완료 (기존 EXIT) |
| ABANDONED | 네트워크 이탈 — grace period 대상, 재입장 가능 (기존 의미 유지) |
| TIMEOUT | 시간 종료까지 PLAYING이었으나 미완료 (신규) |

EXIT → SOLVED는 이름이 의미를 반영 못했기 때문에 바꿨음

TIMEOUT을 ABANDONED와 분리한 이유는 두 상태의 원인이 다르기 때문

- ABANDONED: 네트워크 이탈 (본인 의지와 무관)
- TIMEOUT: 끝까지 도전했으나 시간 초과

---

### 종료 알림: 기존 Pub/Sub 확장

`WebSocketMessagePublisher.publish()`가 이미 Redis Pub/Sub을 타고 브로드캐스트
(경로만 추가하면 됨, )

```java
// settle() afterCommit에서

// 1. 방 채널 (기존) — 방 내 구독자, 관전자
publisher.publish("/topic/room/" + roomId, Map.of("type", "BATTLE_FINISHED"));

// 2. 개인 채널 (신규) — 방을 나간 참여자도 수신 가능
for (BattleParticipant p : sorted) {
    publisher.publish(
        "/topic/user/" + p.getMember().getId() + "/battle",
        Map.of("type", "BATTLE_RESULT", "roomId", roomId,
               "rank", p.getFinalRank(), "scoreDelta", p.getScoreDelta()));
}

// 3. 관전용 코드 Redis 정리
battleCodeStore.deleteAllByRoom(roomId);
```

개인 채널은 기존 WebSocketMessagePublisher가 Redis Pub/Sub을 타고 멀티 인스턴스 브로드캐스트하는 인프라를 그대로 활용. 새로운 인프라 추가
없음.

### 미접속자 결과 알림: `isResultChecked`

Redis Pub/Sub은 fire-and-forget이라 브라우저를 닫고 재접속한 유저는 BATTLE_RESULT를 수신 못함. 이를 DB 저장으로 보완했음

```java
settle() → 모든 참여자 isResultChecked = false

재접속 시 → GET /api/v1/battle/result/unchecked
            → 미확인 결과 있으면 결과 화면으로 이동
            → POST /api/v1/battle/result/{roomId}/check
            → isResultChecked = true
```

| 경우 | 처리 |
| --- | --- |
| 배틀 중 접속 | `/topic/room/{id}` WebSocket으로 즉시 수신 |
| AC 후 방 나간 상태 | `/topic/user/{id}/battle` 개인 채널로 즉시 수신 |
| 브라우저 닫고 재접속 | `isResultChecked` 체크 후 결과 화면 유도 |

---

### 최종 구조

```java
배틀 시작 (전원 READY → PLAYING)
  ├─ DB: room.status = PLAYING, timerEnd 설정
  ├─ Redis: battle:timer:queue ← offer(roomId, 30분)
  └─ WS (STOMP): BATTLE_STARTED 브로드캐스트

진행 중 (AC 발생)
  ├─ participant.status: PLAYING → SOLVED
  └─ WS: PARTICIPANT_DONE 브로드캐스트

종료 트리거 (둘 중 하나)
  ├─ [전원 SOLVED] battle:timer:queue.cancel() → settle()
  ├─ [전원 퇴장]   battle:timer:queue.cancel() → settle()
  └─ [30분 만료]   BattleTimerConsumer → settle()
                   BattleScheduler (60초 안전망)

settle()
  ├─ [1차] idempotent 체크 (if FINISHED return)
  ├─ PLAYING → TIMEOUT (명시적으로 처리해줌)
  ├─ 점수·순위 정산
  ├─ Rating(Elo) 정산
  ├─ isResultChecked = false
  ├─ room.status = FINISHED (idempotent)
  ├─ [2차] @Version 낙관적 락 (커밋 시 race condition 차단)
  └─ afterCommit
       ├─ WS /topic/room/{id}: BATTLE_FINISHED
       ├─ WS /topic/user/{id}/battle: BATTLE_RESULT × N명
       └─ Redis: battle:code:{roomId} 삭제
```