### PR TITLE
[refactor] matching ready-check 상태 전이를 Redis로 전환

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -24,10 +24,8 @@ public class QueueProblemPicker {
         if (queueKey == null) {
             throw new IllegalArgumentException("queueKey는 필수입니다.");
         }
-
-        return 1L;
-        //        return problemPickService.pickProblemId(
-        //                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+        return problemPickService.pickProblemId(
+                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
     }
 
     private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {

--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -25,8 +25,9 @@ public class QueueProblemPicker {
             throw new IllegalArgumentException("queueKey는 필수입니다.");
         }
 
-        return problemPickService.pickProblemId(
-                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+        return 1L;
+        //        return problemPickService.pickProblemId(
+        //                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
     }
 
     private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {

--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
@@ -44,7 +44,7 @@ public class ReadyCheckService {
 
     private static final int REQUIRED_MATCH_SIZE = 4;
     // TODO: 피지컬이슈로 60초로 바꿈, 나중에 15L로 원복해야함
-    private static final long READY_CHECK_TIMEOUT_SECONDS = 15L;
+    private static final long READY_CHECK_TIMEOUT_SECONDS = 60L;
 
     private final BattleRoomService battleRoomService;
     private final QueueProblemPicker queueProblemPicker;

--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
@@ -44,7 +44,7 @@ public class ReadyCheckService {
 
     private static final int REQUIRED_MATCH_SIZE = 4;
     // TODO: 피지컬이슈로 60초로 바꿈, 나중에 15L로 원복해야함
-    private static final long READY_CHECK_TIMEOUT_SECONDS = 60L;
+    private static final long READY_CHECK_TIMEOUT_SECONDS = 15L;
 
     private final BattleRoomService battleRoomService;
     private final QueueProblemPicker queueProblemPicker;

--- a/src/main/java/com/back/domain/matching/queue/store/MatchingStoreProperties.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchingStoreProperties.java
@@ -5,8 +5,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * matching 상태 저장소 선택 설정을 묶는다.
  *
- * 이번 단계에서는 설정 구조만 먼저 도입하고,
- * 실제 구현체 전환은 다음 하위 이슈에서 연결한다.
+ * 기본값은 기존 InMemory 저장소를 유지하고,
+ * dev 등 필요한 환경에서 Redis 저장소로 전환할 수 있게 한다.
  */
 @ConfigurationProperties(prefix = "matching.store")
 public class MatchingStoreProperties {

--- a/src/main/java/com/back/domain/matching/queue/store/MatchingStorePropertiesConfig.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchingStorePropertiesConfig.java
@@ -4,10 +4,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 /**
- * matching 저장소 설정 바인딩만 먼저 연다.
+ * matching 저장소 설정 바인딩을 연다.
  *
- * 이번 단계에서는 구현체 스위칭까지 연결하지 않고,
- * 설정 키와 바인딩 구조만 안전하게 고정한다.
+ * 구현체 선택은 `matching.store.type` 값으로 제어하고,
+ * 각 저장소 구현체는 조건부 빈으로 연결한다.
  */
 @Configuration
 @EnableConfigurationProperties(MatchingStoreProperties.class)

--- a/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisKeys.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisKeys.java
@@ -7,8 +7,8 @@ import com.back.domain.matching.queue.model.QueueKey;
 /**
  * matching Redis key 규칙을 한 곳에 모아 둔다.
  *
- * 이후 하위 이슈에서 Redis 저장소 구현이 늘어나더라도
- * key 네이밍 규칙은 이 유틸만 기준으로 사용한다.
+ * 이후 하위 이슈에서 Redis 저장소 구현이 더 확장되더라도
+ * key 조합 규칙은 이 유틸만 기준으로 사용한다.
  */
 public final class MatchingRedisKeys {
 
@@ -41,17 +41,38 @@ public final class MatchingRedisKeys {
     }
 
     /**
-     * user -> match 연결도 사용자별 단일 key 로 고정한다.
+     * user -> match 연결은 사용자별 단일 key 로 고정한다.
      */
     public static String userMatch(Long userId) {
         return USER_MATCH_PREFIX + ":" + requireId(userId, "userId");
     }
 
     /**
-     * match session 본문은 matchId 로 조회한다.
+     * ready-check session 본문은 matchId 로 조회한다.
      */
     public static String match(Long matchId) {
         return MATCH_PREFIX + ":" + requireId(matchId, "matchId");
+    }
+
+    /**
+     * ready-check session key 를 훑을 때 사용하는 임시 패턴이다.
+     */
+    public static String matchPattern() {
+        return MATCH_PREFIX + ":*";
+    }
+
+    /**
+     * user:match 인덱스 전체를 훑을 때 사용하는 패턴이다.
+     */
+    public static String userMatchPattern() {
+        return USER_MATCH_PREFIX + ":*";
+    }
+
+    /**
+     * match session key prefix 를 외부 helper 에서 재사용할 수 있게 노출한다.
+     */
+    public static String matchPrefix() {
+        return MATCH_PREFIX + ":";
     }
 
     /**
@@ -62,7 +83,7 @@ public final class MatchingRedisKeys {
     }
 
     /**
-     * match sequence 도 단일 증가 key 로 유지한다.
+     * match sequence 는 단일 증가 key 로 유지한다.
      */
     public static String matchSequence() {
         return MATCH_SEQUENCE_KEY;

--- a/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializer.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisSerializer.java
@@ -13,11 +13,13 @@ import com.back.domain.matching.queue.model.ReadyDecision;
 import com.back.domain.matching.queue.model.WaitingUser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
- * matching 상태를 Redis 문자열 값으로 저장할 때 사용할 직렬화 규칙을 모은다.
+ * matching 상태를 Redis 문자열 값으로 저장할 때 사용하는 직렬화 규칙을 모은다.
  *
- * 이번 단계에서는 StringRedisTemplate + JSON 저장 방식을 기준으로 고정한다.
+ * 이 구현은 StringRedisTemplate + JSON 조합을 기준으로 유지하고,
+ * Redis 문서 비교와 Lua/CAS 전이를 위해 날짜 값도 ISO 문자열로 고정한다.
  */
 @Component
 public class MatchingRedisSerializer {
@@ -25,11 +27,12 @@ public class MatchingRedisSerializer {
     private final ObjectMapper objectMapper;
 
     public MatchingRedisSerializer(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+        this.objectMapper = objectMapper.copy().findAndRegisterModules();
+        this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     /**
-     * match session 본문은 JSON 문자열 하나로 저장한다.
+     * match session 본문을 JSON 문자열 하나로 저장한다.
      */
     public String writeMatchSession(MatchSession matchSession) {
         return writeValue(MatchSessionDocument.from(matchSession), "match session");
@@ -43,7 +46,7 @@ public class MatchingRedisSerializer {
     }
 
     /**
-     * queue list와 userQueue index에는 같은 WaitingUser JSON 문자열을 저장한다.
+     * queue list 와 userQueue index 에는 같은 WaitingUser JSON 문자열을 저장한다.
      */
     public String writeWaitingUser(WaitingUser waitingUser) {
         return writeValue(WaitingUserDocument.from(waitingUser), "waiting user");
@@ -65,7 +68,7 @@ public class MatchingRedisSerializer {
     }
 
     /**
-     * queue list와 userQueue index는 같은 복원 규칙을 사용한다.
+     * queue list 와 userQueue index 는 같은 복원 규칙을 사용한다.
      */
     public WaitingUser readWaitingUser(String value) {
         WaitingUserDocument document = readValue(value, WaitingUserDocument.class, "waiting user");
@@ -94,8 +97,8 @@ public class MatchingRedisSerializer {
     }
 
     /**
-     * MatchSession 의 계산 메서드가 JSON 에 섞이지 않도록
-     * Redis 저장 전용 스냅샷 구조를 별도로 둔다.
+     * MatchSession 은 계산 메서드가 JSON 에 섞이지 않도록
+     * Redis 저장 전용 스냅샷 구조로 한 번 감싼다.
      */
     private record MatchSessionDocument(
             Long matchId,
@@ -136,7 +139,7 @@ public class MatchingRedisSerializer {
     }
 
     /**
-     * WaitingUser도 joinedAt을 유지해야 rollback과 디버깅 시점이 흐려지지 않는다.
+     * WaitingUser 는 joinedAt 도 유지해야 rollback 과 디버깅 시점이 흐려지지 않는다.
      */
     private record WaitingUserDocument(Long userId, String nickname, QueueKey queueKey, LocalDateTime joinedAt) {
 

--- a/src/main/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStore.java
@@ -2,7 +2,11 @@ package com.back.domain.matching.queue.store.redis;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
@@ -13,21 +17,19 @@ import org.springframework.stereotype.Component;
 
 import com.back.domain.matching.queue.dto.QueueStateV2Response;
 import com.back.domain.matching.queue.model.MatchSession;
+import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.ReadyDecision;
 import com.back.domain.matching.queue.model.WaitingUser;
-import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
 import com.back.domain.matching.queue.store.MatchStateStore;
 import com.back.domain.matching.queue.store.MatchingStoreProperties;
 import com.back.global.exception.ServiceException;
 
 /**
- * Redis 기반 matching 저장소다.
+ * Redis 기반 matching 상태 저장소
  *
- * 이번 단계에서는 SEARCHING 구간의 queue 상태만 Redis로 옮기고,
- * ready-check 세션 본문과 상태 전이는 기존 인메모리 구현에 위임한다.
- *
- * 즉 queue는 Redis, ready-check는 memory인 하이브리드 저장소이며
- * 다음 하위 이슈에서 ready-check 전이도 Redis로 옮길 수 있게 경계를 먼저 만든다.
+ * queue 와 ready-check 모두 Redis 를 단일 원본으로 사용하고,
+ * 복합 상태 전이는 Lua script 또는 Redis CAS 경계로 보호한다.
  */
 @Primary
 @Component
@@ -35,8 +37,10 @@ import com.back.global.exception.ServiceException;
 public class RedisMatchStateStore implements MatchStateStore {
 
     private static final int REQUIRED_MATCH_SIZE = 4;
+    private static final int MAX_SESSION_UPDATE_RETRY = 20;
 
     private static final RedisScript<Long> ENQUEUE_SCRIPT = longScript("""
+            -- MATCHING:QUEUE_ENQUEUE
             if redis.call('EXISTS', KEYS[1]) == 1 then
                 return -1
             end
@@ -46,6 +50,7 @@ public class RedisMatchStateStore implements MatchStateStore {
             """);
 
     private static final RedisScript<Long> QUEUE_CONTAINS_SCRIPT = longScript("""
+            -- MATCHING:QUEUE_CONTAINS
             local pos = redis.call('LPOS', KEYS[1], ARGV[1])
             if pos then
                 return 1
@@ -54,6 +59,7 @@ public class RedisMatchStateStore implements MatchStateStore {
             """);
 
     private static final RedisScript<List> POLL_SCRIPT = listScript("""
+            -- MATCHING:QUEUE_POLL
             local count = tonumber(ARGV[1])
             if redis.call('LLEN', KEYS[1]) < count then
                 return {}
@@ -72,6 +78,7 @@ public class RedisMatchStateStore implements MatchStateStore {
             """);
 
     private static final RedisScript<List> CANCEL_SCRIPT = listScript("""
+            -- MATCHING:QUEUE_CANCEL
             local removed = redis.call('LREM', KEYS[2], 1, ARGV[1])
             redis.call('DEL', KEYS[1])
             local size = redis.call('LLEN', KEYS[2])
@@ -82,6 +89,7 @@ public class RedisMatchStateStore implements MatchStateStore {
             """);
 
     private static final RedisScript<Long> ROLLBACK_SCRIPT = longScript("""
+            -- MATCHING:QUEUE_ROLLBACK
             for i = #ARGV, 1, -1 do
                 redis.call('LPUSH', KEYS[1], ARGV[i])
             end
@@ -93,20 +101,65 @@ public class RedisMatchStateStore implements MatchStateStore {
             return redis.call('LLEN', KEYS[1])
             """);
 
+    private static final RedisScript<String> MARK_ACCEPT_PENDING_SCRIPT = stringScript("""
+            -- MATCHING:MATCH_MARK_ACCEPT_PENDING
+            local participantCount = tonumber(ARGV[3])
+            redis.call('SET', KEYS[1], ARGV[1])
+
+            for i = 1, participantCount do
+                redis.call('SET', KEYS[i + 1], ARGV[2])
+            end
+
+            for i = participantCount + 2, #KEYS do
+                redis.call('DEL', KEYS[i])
+            end
+
+            return ARGV[1]
+            """);
+
+    private static final RedisScript<Long> COMPARE_AND_SET_SCRIPT = longScript("""
+            -- MATCHING:MATCH_COMPARE_AND_SET
+            if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+                return 0
+            end
+            redis.call('SET', KEYS[1], ARGV[2])
+            return 1
+            """);
+
+    private static final RedisScript<Long> DELETE_IF_VALUE_SCRIPT = longScript("""
+            -- MATCHING:DELETE_IF_VALUE
+            if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+                return 0
+            end
+            redis.call('DEL', KEYS[1])
+            return 1
+            """);
+
+    private static final RedisScript<Long> CLEAR_TERMINAL_SCRIPT = longScript("""
+            -- MATCHING:MATCH_CLEAR_TERMINAL
+            local expected = ARGV[1]
+
+            for i = 2, #KEYS do
+                if redis.call('GET', KEYS[i]) == expected then
+                    redis.call('DEL', KEYS[i])
+                end
+            end
+
+            redis.call('DEL', KEYS[1])
+            return 1
+            """);
+
     private final StringRedisTemplate redisTemplate;
     private final MatchingRedisSerializer serializer;
     private final MatchingStoreProperties storeProperties;
-    private final InMemoryMatchStateStore delegate;
 
     public RedisMatchStateStore(
             StringRedisTemplate redisTemplate,
             MatchingRedisSerializer serializer,
-            MatchingStoreProperties storeProperties,
-            InMemoryMatchStateStore delegate) {
+            MatchingStoreProperties storeProperties) {
         this.redisTemplate = redisTemplate;
         this.serializer = serializer;
         this.storeProperties = storeProperties;
-        this.delegate = delegate;
     }
 
     @Override
@@ -184,7 +237,7 @@ public class RedisMatchStateStore implements MatchStateStore {
 
         List<String> payloads = new ArrayList<>();
 
-        // queue 복구와 userQueue 복구를 같은 payload 기준으로 함께 되돌린다.
+        // queue 복구와 userQueue 복구를 같은 payload 기준으로 한 번에 되돌린다.
         for (WaitingUser user : users) {
             keys.add(MatchingRedisKeys.userQueue(user.getUserId()));
             payloads.add(serializer.writeWaitingUser(user));
@@ -195,45 +248,152 @@ public class RedisMatchStateStore implements MatchStateStore {
 
     @Override
     public MatchSession markAcceptPending(QueueKey queueKey, List<WaitingUser> matchedUsers, LocalDateTime deadline) {
-        if (matchedUsers != null && !matchedUsers.isEmpty()) {
-            // queue에서 handoff 된 사용자는 SEARCHING 사용자로 보이지 않게 userQueue key를 먼저 정리한다.
-            redisTemplate.delete(matchedUsers.stream()
-                    .map(WaitingUser::getUserId)
-                    .map(MatchingRedisKeys::userQueue)
-                    .toList());
+        if (matchedUsers == null || matchedUsers.isEmpty()) {
+            throw new IllegalArgumentException("matchedUsers 는 비어 있을 수 없습니다.");
         }
 
-        return delegate.markAcceptPending(queueKey, matchedUsers, deadline);
+        Long matchId = redisTemplate.opsForValue().increment(MatchingRedisKeys.matchSequence());
+        if (matchId == null) {
+            throw new IllegalStateException("Redis match sequence 결과를 확인할 수 없습니다.");
+        }
+
+        List<Long> participantIds =
+                matchedUsers.stream().map(WaitingUser::getUserId).toList();
+        Map<Long, String> participantNicknames = new LinkedHashMap<>();
+        matchedUsers.forEach(user -> participantNicknames.put(user.getUserId(), user.getNickname()));
+
+        MatchSession matchSession =
+                MatchSession.acceptPending(matchId, queueKey, participantIds, participantNicknames, deadline);
+        String sessionJson = serializer.writeMatchSession(matchSession);
+
+        List<String> keys = new ArrayList<>();
+        keys.add(MatchingRedisKeys.match(matchId));
+        participantIds.forEach(participantId -> keys.add(MatchingRedisKeys.userMatch(participantId)));
+        participantIds.forEach(participantId -> keys.add(MatchingRedisKeys.userQueue(participantId)));
+
+        String storedJson = redisTemplate.execute(
+                MARK_ACCEPT_PENDING_SCRIPT,
+                keys,
+                sessionJson,
+                String.valueOf(matchId),
+                String.valueOf(participantIds.size()));
+
+        if (storedJson == null || storedJson.isBlank()) {
+            throw new IllegalStateException("Redis ready-check 세션 저장 결과를 확인할 수 없습니다.");
+        }
+
+        return serializer.readMatchSession(storedJson);
     }
 
     @Override
     public MatchSession accept(Long matchId, Long userId) {
-        return delegate.accept(matchId, userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        return updateMatchSession(matchId, currentSession -> {
+            ensureParticipant(currentSession, userId, "매치 참가자가 아닌 사용자는 수락할 수 없습니다.");
+
+            if (currentSession.isExpiredAt(now)) {
+                return currentSession.status() == MatchSessionStatus.ACCEPT_PENDING
+                        ? currentSession.expired()
+                        : currentSession;
+            }
+
+            if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                return currentSession;
+            }
+
+            if (currentSession.decisionOf(userId) == ReadyDecision.ACCEPTED) {
+                return currentSession;
+            }
+
+            return currentSession.withDecision(userId, ReadyDecision.ACCEPTED);
+        });
     }
 
     @Override
     public MatchSession decline(Long matchId, Long userId) {
-        return delegate.decline(matchId, userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        return updateMatchSession(matchId, currentSession -> {
+            ensureParticipant(currentSession, userId, "매치 참가자가 아닌 사용자는 거절할 수 없습니다.");
+
+            if (currentSession.isExpiredAt(now)) {
+                return currentSession.status() == MatchSessionStatus.ACCEPT_PENDING
+                        ? currentSession.expired()
+                        : currentSession;
+            }
+
+            if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                return currentSession;
+            }
+
+            return currentSession.withDecision(userId, ReadyDecision.DECLINED).cancelled();
+        });
     }
 
     @Override
     public RoomCreationAttempt tryBeginRoomCreation(Long matchId) {
-        return delegate.tryBeginRoomCreation(matchId);
+        String matchKey = MatchingRedisKeys.match(matchId);
+
+        for (int retry = 0; retry < MAX_SESSION_UPDATE_RETRY; retry++) {
+            String currentJson = redisTemplate.opsForValue().get(matchKey);
+            MatchSession currentSession = requireMatchSession(currentJson);
+
+            if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                return new RoomCreationAttempt(currentSession, false);
+            }
+
+            if (!currentSession.isAllAccepted()) {
+                return new RoomCreationAttempt(currentSession, false);
+            }
+
+            MatchSession roomCreatingSession = currentSession.roomCreating();
+            String updatedJson = serializer.writeMatchSession(roomCreatingSession);
+
+            if (compareAndSet(matchKey, currentJson, updatedJson)) {
+                return new RoomCreationAttempt(roomCreatingSession, true);
+            }
+        }
+
+        throw new IllegalStateException("Redis room 생성 선점 상태를 갱신하지 못했습니다.");
     }
 
     @Override
     public MatchSession markRoomReady(Long matchId, Long roomId) {
-        return delegate.markRoomReady(matchId, roomId);
+        return updateMatchSession(matchId, currentSession -> {
+            if (currentSession.status() == MatchSessionStatus.ROOM_READY) {
+                return currentSession;
+            }
+
+            if (currentSession.status() != MatchSessionStatus.ROOM_CREATING
+                    && currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                return currentSession;
+            }
+
+            return currentSession.roomReady(roomId);
+        });
     }
 
     @Override
     public MatchSession expire(Long matchId) {
-        return delegate.expire(matchId);
+        return updateMatchSession(matchId, currentSession -> {
+            if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                return currentSession;
+            }
+
+            return currentSession.expired();
+        });
     }
 
     @Override
     public MatchSession cancelMatch(Long matchId) {
-        return delegate.cancelMatch(matchId);
+        return updateMatchSession(matchId, currentSession -> {
+            if (currentSession.status() == MatchSessionStatus.CANCELLED) {
+                return currentSession;
+            }
+
+            return currentSession.cancelled();
+        });
     }
 
     @Override
@@ -263,50 +423,172 @@ public class RedisMatchStateStore implements MatchStateStore {
 
     @Override
     public MatchSession findMatchSessionByUserId(Long userId) {
-        return delegate.findMatchSessionByUserId(userId);
+        String userMatchKey = MatchingRedisKeys.userMatch(userId);
+        String matchIdValue = redisTemplate.opsForValue().get(userMatchKey);
+
+        if (matchIdValue == null || matchIdValue.isBlank()) {
+            return null;
+        }
+
+        Long matchId = parseMatchIdValue(matchIdValue);
+        String matchJson = redisTemplate.opsForValue().get(MatchingRedisKeys.match(matchId));
+
+        if (matchJson == null || matchJson.isBlank()) {
+            deleteIfValue(userMatchKey, matchIdValue);
+            return null;
+        }
+
+        MatchSession matchSession = serializer.readMatchSession(matchJson);
+
+        if (!matchSession.hasParticipant(userId)) {
+            deleteIfValue(userMatchKey, matchIdValue);
+            return null;
+        }
+
+        if (matchSession.status() == MatchSessionStatus.CLOSED) {
+            deleteIfValue(userMatchKey, matchIdValue);
+            return null;
+        }
+
+        if (matchSession.status() == MatchSessionStatus.CANCELLED
+                || matchSession.status() == MatchSessionStatus.EXPIRED) {
+            clearTerminalMatch(matchId);
+            return null;
+        }
+
+        return matchSession;
     }
 
     @Override
     public List<Long> findExpiredAcceptPendingMatchIds(LocalDateTime now) {
-        return delegate.findExpiredAcceptPendingMatchIds(now);
+        Set<String> keys = redisTemplate.keys(MatchingRedisKeys.matchPattern());
+
+        if (keys == null || keys.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> expiredMatchIds = new ArrayList<>();
+
+        // deadline index 도입 전까지는 match 세션 key 들을 임시로 pattern scan 하며 만료 대상을 찾는다.
+        for (String key : keys) {
+            Long matchId = extractMatchIdFromKey(key);
+            if (matchId == null) {
+                continue;
+            }
+
+            String sessionJson = redisTemplate.opsForValue().get(key);
+            if (sessionJson == null || sessionJson.isBlank()) {
+                continue;
+            }
+
+            MatchSession matchSession = serializer.readMatchSession(sessionJson);
+            if (matchSession.status() == MatchSessionStatus.ACCEPT_PENDING
+                    && matchSession.deadline() != null
+                    && !matchSession.deadline().isAfter(now)) {
+                expiredMatchIds.add(matchSession.matchId());
+            }
+        }
+
+        expiredMatchIds.sort(Long::compareTo);
+        return expiredMatchIds;
     }
 
     @Override
     public void clearTerminalMatch(Long matchId) {
-        delegate.clearTerminalMatch(matchId);
+        String matchKey = MatchingRedisKeys.match(matchId);
+        String matchJson = redisTemplate.opsForValue().get(matchKey);
+
+        if (matchJson == null || matchJson.isBlank()) {
+            removeUserMatchLinksByScan(matchId);
+            return;
+        }
+
+        MatchSession matchSession = serializer.readMatchSession(matchJson);
+        List<String> keys = new ArrayList<>();
+        keys.add(matchKey);
+        matchSession.participantIds().forEach(participantId -> keys.add(MatchingRedisKeys.userMatch(participantId)));
+
+        redisTemplate.execute(CLEAR_TERMINAL_SCRIPT, keys, String.valueOf(matchId));
     }
 
     @Override
     public void clearMatchedRoom(Long userId, Long roomId) {
-        delegate.clearMatchedRoom(userId, roomId);
+        if (roomId == null) {
+            return;
+        }
+
+        String userMatchKey = MatchingRedisKeys.userMatch(userId);
+        String matchIdValue = redisTemplate.opsForValue().get(userMatchKey);
+
+        if (matchIdValue == null || matchIdValue.isBlank()) {
+            return;
+        }
+
+        Long matchId = parseMatchIdValue(matchIdValue);
+        String matchKey = MatchingRedisKeys.match(matchId);
+        String matchJson = redisTemplate.opsForValue().get(matchKey);
+
+        if (matchJson == null || matchJson.isBlank()) {
+            deleteIfValue(userMatchKey, matchIdValue);
+            return;
+        }
+
+        MatchSession matchSession = serializer.readMatchSession(matchJson);
+        if (!roomId.equals(matchSession.roomId())) {
+            return;
+        }
+
+        deleteIfValue(userMatchKey, matchIdValue);
+
+        boolean hasRemainingReference = matchSession.participantIds().stream()
+                .map(MatchingRedisKeys::userMatch)
+                .map(key -> redisTemplate.opsForValue().get(key))
+                .anyMatch(matchIdValue::equals);
+
+        if (!hasRemainingReference) {
+            compareAndDelete(matchKey, matchJson);
+        }
     }
 
-    /**
-     * 다음 하위 이슈에서 실제 전환을 시작할 때 바로 사용할 기본 의존성 접근점이다.
-     */
-    StringRedisTemplate redisTemplate() {
-        return redisTemplate;
+    private MatchSession updateMatchSession(Long matchId, Function<MatchSession, MatchSession> updater) {
+        String matchKey = MatchingRedisKeys.match(matchId);
+
+        for (int retry = 0; retry < MAX_SESSION_UPDATE_RETRY; retry++) {
+            String currentJson = redisTemplate.opsForValue().get(matchKey);
+            MatchSession currentSession = requireMatchSession(currentJson);
+            MatchSession updatedSession = updater.apply(currentSession);
+
+            if (updatedSession.equals(currentSession)) {
+                return updatedSession;
+            }
+
+            String updatedJson = serializer.writeMatchSession(updatedSession);
+            if (compareAndSet(matchKey, currentJson, updatedJson)) {
+                return updatedSession;
+            }
+        }
+
+        throw new IllegalStateException("Redis 매치 세션 상태를 갱신하지 못했습니다.");
     }
 
-    /**
-     * 직렬화 방식은 StringRedisTemplate + JSON 조합으로 고정한다.
-     */
-    MatchingRedisSerializer serializer() {
-        return serializer;
-    }
-
-    /**
-     * 설정 구조는 미리 받아 두되, 이번 단계에서는 동작 분기에만 사용한다.
-     */
-    MatchingStoreProperties storeProperties() {
-        return storeProperties;
+    private MatchSession requireMatchSession(String sessionJson) {
+        if (sessionJson == null || sessionJson.isBlank()) {
+            throw new IllegalStateException("존재하지 않는 매치 세션입니다.");
+        }
+        return serializer.readMatchSession(sessionJson);
     }
 
     private void ensureJoinEligibility(Long userId) {
-        MatchSession matchSession = delegate.findMatchSessionByUserId(userId);
+        MatchSession matchSession = findMatchSessionByUserId(userId);
 
         if (matchSession != null) {
             throw new ServiceException("409-1", "이미 진행 중인 매칭이 있습니다.");
+        }
+    }
+
+    private void ensureParticipant(MatchSession matchSession, Long userId, String message) {
+        if (!matchSession.hasParticipant(userId)) {
+            throw new IllegalStateException(message);
         }
     }
 
@@ -314,14 +596,14 @@ public class RedisMatchStateStore implements MatchStateStore {
         String userQueueKey = MatchingRedisKeys.userQueue(userId);
         String payload = redisTemplate.opsForValue().get(userQueueKey);
 
-        if (payload == null) {
+        if (payload == null || payload.isBlank()) {
             return null;
         }
 
         WaitingUser waitingUser = serializer.readWaitingUser(payload);
         String queueKey = MatchingRedisKeys.queue(waitingUser.getQueueKey());
 
-        // userQueue만 남고 실제 queue list에는 없으면 stale 데이터로 보고 현재 사용자 기준으로 정리한다.
+        // userQueue 만 남고 실제 queue list 에는 없으면 stale 데이터로 보고 즉시 정리한다.
         Long contains = redisTemplate.execute(QUEUE_CONTAINS_SCRIPT, List.of(queueKey), payload);
 
         if (contains == null || contains == 0L) {
@@ -330,6 +612,57 @@ public class RedisMatchStateStore implements MatchStateStore {
         }
 
         return payload;
+    }
+
+    private boolean compareAndSet(String key, String expectedValue, String updatedValue) {
+        Long updated = redisTemplate.execute(COMPARE_AND_SET_SCRIPT, List.of(key), expectedValue, updatedValue);
+        return updated != null && updated == 1L;
+    }
+
+    private boolean compareAndDelete(String key, String expectedValue) {
+        Long deleted = redisTemplate.execute(DELETE_IF_VALUE_SCRIPT, List.of(key), expectedValue);
+        return deleted != null && deleted == 1L;
+    }
+
+    private boolean deleteIfValue(String key, String expectedValue) {
+        return compareAndDelete(key, expectedValue);
+    }
+
+    private void removeUserMatchLinksByScan(Long matchId) {
+        String matchIdValue = String.valueOf(matchId);
+        Set<String> keys = redisTemplate.keys(MatchingRedisKeys.userMatchPattern());
+
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        for (String key : keys) {
+            String currentValue = redisTemplate.opsForValue().get(key);
+            if (matchIdValue.equals(currentValue)) {
+                deleteIfValue(key, matchIdValue);
+            }
+        }
+    }
+
+    private Long parseMatchIdValue(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("user:match 값이 올바른 matchId 가 아닙니다.", e);
+        }
+    }
+
+    private Long extractMatchIdFromKey(String key) {
+        if (key == null || !key.startsWith(MatchingRedisKeys.matchPrefix())) {
+            return null;
+        }
+
+        String suffix = key.substring(MatchingRedisKeys.matchPrefix().length());
+        if (suffix.isBlank() || !suffix.chars().allMatch(Character::isDigit)) {
+            return null;
+        }
+
+        return Long.parseLong(suffix);
     }
 
     @SuppressWarnings("unchecked")
@@ -377,6 +710,13 @@ public class RedisMatchStateStore implements MatchStateStore {
         DefaultRedisScript<List> script = new DefaultRedisScript<>();
         script.setScriptText(scriptText);
         script.setResultType(List.class);
+        return script;
+    }
+
+    private static RedisScript<String> stringScript(String scriptText) {
+        DefaultRedisScript<String> script = new DefaultRedisScript<>();
+        script.setScriptText(scriptText);
+        script.setResultType(String.class);
         return script;
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -49,3 +49,7 @@ logging:
   level:
     root: WARN
     com.back: INFO
+
+matching:
+  store:
+    type: redis

--- a/src/test/java/com/back/domain/matching/queue/service/RedisQueueReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/RedisQueueReadyCheckServiceTest.java
@@ -3,19 +3,30 @@ package com.back.domain.matching.queue.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import com.back.domain.battle.battleroom.dto.CreateRoomRequest;
+import com.back.domain.battle.battleroom.dto.CreateRoomResponse;
 import com.back.domain.battle.battleroom.service.BattleRoomService;
 import com.back.domain.matching.queue.adapter.QueueProblemPicker;
 import com.back.domain.matching.queue.dto.MatchStateV2Response;
@@ -26,7 +37,6 @@ import com.back.domain.matching.queue.dto.QueueStatusResponse;
 import com.back.domain.matching.queue.model.Difficulty;
 import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
-import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
 import com.back.domain.matching.queue.store.MatchingStoreProperties;
 import com.back.domain.matching.queue.store.redis.FakeStringRedisTemplate;
 import com.back.domain.matching.queue.store.redis.MatchingRedisSerializer;
@@ -42,22 +52,21 @@ class RedisQueueReadyCheckServiceTest {
     private FakeStringRedisTemplate redisTemplate;
     private MatchingRedisSerializer serializer;
     private ReadyCheckService readyCheckService;
+    private RedisMatchStateStore store;
 
     @BeforeEach
     void setUp() {
         redisTemplate = new FakeStringRedisTemplate();
         serializer = new MatchingRedisSerializer(
                 JsonMapper.builder().findAndAddModules().build());
-        readyCheckService = new ReadyCheckService(
-                battleRoomService,
-                queueProblemPicker,
-                new RedisMatchStateStore(
-                        redisTemplate, serializer, matchingStoreProperties(), new InMemoryMatchStateStore()),
-                matchingEventPublisher);
+        store = new RedisMatchStateStore(redisTemplate, serializer, matchingStoreProperties());
+        readyCheckService = new ReadyCheckService(battleRoomService, queueProblemPicker, store, matchingEventPublisher);
+
+        when(queueProblemPicker.pick(any(QueueKey.class), anyList())).thenReturn(1L);
     }
 
     @Test
-    @DisplayName("Redis queue 경로에서도 queue/me 는 SEARCHING 동안 waitingCount와 requiredCount를 반환한다")
+    @DisplayName("Redis queue 경로에서는 queue/me 가 SEARCHING 동안 waitingCount 와 requiredCount 를 반환한다")
     void getMyQueueStateV2_returnsSearchingInfo() {
         QueueStatusResponse response = joinUser(1L);
 
@@ -73,7 +82,7 @@ class RedisQueueReadyCheckServiceTest {
     }
 
     @Test
-    @DisplayName("Redis queue 경로에서도 cancel 후 감소한 waitingCount를 queue topic 이벤트로 발행한다")
+    @DisplayName("Redis queue 경로에서는 cancel 시 감소한 waitingCount 를 queue topic 이벤트로 발행한다")
     void cancelQueueV2_publishesQueueStateChanged() {
         joinUser(1L);
         joinUser(2L);
@@ -86,7 +95,29 @@ class RedisQueueReadyCheckServiceTest {
     }
 
     @Test
-    @DisplayName("Redis queue 경로에서도 4번째 join 시 matched 4명에게 READY_CHECK_STARTED를 발행한다")
+    @DisplayName("4번째 join 이후 matches/me 는 Redis ready-check 세션을 읽어 ACCEPT_PENDING 을 반환한다")
+    void getMyMatchStateV2_returnsAcceptPending_whenFourthUserJoins() {
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        QueueStatusResponse fourthResponse = joinUser(4L);
+
+        MatchStateV2Response response = readyCheckService.getMyMatchStateV2(1L);
+
+        assertThat(fourthResponse.getWaitingCount()).isEqualTo(0);
+        assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isFalse();
+        assertThat(response.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+        assertThat(response.room()).isNull();
+        assertThat(response.readyCheck()).isNotNull();
+        assertThat(response.readyCheck().acceptedCount()).isEqualTo(0);
+        assertThat(response.readyCheck().requiredCount()).isEqualTo(4);
+        assertThat(response.readyCheck().participants())
+                .extracting(participant -> participant.nickname())
+                .containsExactly("m1", "m2", "m3", "m4");
+    }
+
+    @Test
+    @DisplayName("4번째 join 시 matched 4명에게 READY_CHECK_STARTED 를 발행한다")
     void joinQueueV2_publishesReadyCheckStarted_whenFourthUserJoins() {
         joinUser(1L);
         joinUser(2L);
@@ -94,12 +125,8 @@ class RedisQueueReadyCheckServiceTest {
 
         readyCheckService.joinQueueV2(4L, "m4", createRequest("Array", Difficulty.EASY));
 
-        MatchStateV2Response matchState = readyCheckService.getMyMatchStateV2(1L);
         ArgumentCaptor<Long> userIdCaptor = ArgumentCaptor.forClass(Long.class);
         ArgumentCaptor<MatchStateV2Response> responseCaptor = ArgumentCaptor.forClass(MatchStateV2Response.class);
-
-        assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isFalse();
-        assertThat(matchState.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
 
         verify(matchingEventPublisher, times(4))
                 .publishReadyCheckStarted(userIdCaptor.capture(), responseCaptor.capture());
@@ -114,7 +141,151 @@ class RedisQueueReadyCheckServiceTest {
     }
 
     @Test
-    @DisplayName("Redis queue 경로에서도 ready-check 세션 생성 실패 시 rollback 후 queue waitingCount 복구 이벤트를 발행한다")
+    @DisplayName("일반 accept 는 matched 4명에게 READY_DECISION_CHANGED 를 발행한다")
+    void acceptMatch_publishesReadyDecisionChanged() {
+        Long matchId = createAcceptPendingMatch();
+        clearInvocations(matchingEventPublisher);
+
+        MatchStateV2Response response = readyCheckService.acceptMatch(1L, matchId);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+        assertThat(response.readyCheck().acceptedCount()).isEqualTo(1);
+        assertThat(response.readyCheck().acceptedByMe()).isTrue();
+        verify(matchingEventPublisher, times(4)).publishReadyDecisionChanged(any(), any());
+    }
+
+    @Test
+    @DisplayName("백엔드 재시작 후에도 Redis ready-check 세션은 matches/me 로 복구된다")
+    void getMyMatchStateV2_recoversFromRedisAfterRestart() {
+        Long matchId = createAcceptPendingMatch();
+        ReadyCheckService restartedService = new ReadyCheckService(
+                battleRoomService,
+                queueProblemPicker,
+                new RedisMatchStateStore(redisTemplate, serializer, matchingStoreProperties()),
+                matchingEventPublisher);
+
+        MatchStateV2Response response = restartedService.getMyMatchStateV2(1L);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.ACCEPT_PENDING);
+        assertThat(response.readyCheck().matchId()).isEqualTo(matchId);
+    }
+
+    @Test
+    @DisplayName("전원 수락이 완료되면 ROOM_READY 와 roomId 를 반환한다")
+    void acceptMatch_returnsRoomReady_whenAllUsersAccepted() {
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class)))
+                .thenReturn(new CreateRoomResponse(100L, "WAITING"));
+
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        readyCheckService.acceptMatch(1L, matchId);
+        readyCheckService.acceptMatch(2L, matchId);
+        readyCheckService.acceptMatch(3L, matchId);
+        clearInvocations(matchingEventPublisher);
+        MatchStateV2Response response = readyCheckService.acceptMatch(4L, matchId);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.ROOM_READY);
+        assertThat(response.room()).isNotNull();
+        assertThat(response.room().roomId()).isEqualTo(100L);
+        assertThat(response.readyCheck().acceptedCount()).isEqualTo(4);
+        verify(battleRoomService, times(1)).createRoom(any(CreateRoomRequest.class));
+        verify(matchingEventPublisher, times(4)).publishRoomReady(any(), any());
+    }
+
+    @Test
+    @DisplayName("한 명이라도 거절하면 세션 전체가 CANCELLED 로 종료된다")
+    void declineMatch_returnsCancelled() {
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+        clearInvocations(matchingEventPublisher);
+
+        MatchStateV2Response response = readyCheckService.declineMatch(2L, matchId);
+
+        assertThat(response.status()).isEqualTo(MatchStatus.CANCELLED);
+        assertThat(response.message()).isNotNull();
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        verify(matchingEventPublisher, times(4)).publishMatchCancelled(any(), any());
+    }
+
+    @Test
+    @DisplayName("만료 스케줄러는 Redis ready-check 세션을 찾아 MATCH_EXPIRED 를 발행하고 즉시 정리한다")
+    void expireTimedOutMatches_publishesExpiredAndClearsSession() {
+        QueueKey queueKey = new QueueKey("Array", Difficulty.EASY);
+        List<WaitingUser> users = List.of(
+                new WaitingUser(1L, "m1", queueKey),
+                new WaitingUser(2L, "m2", queueKey),
+                new WaitingUser(3L, "m3", queueKey),
+                new WaitingUser(4L, "m4", queueKey));
+
+        store.markAcceptPending(queueKey, users, LocalDateTime.now().minusSeconds(1));
+        clearInvocations(matchingEventPublisher);
+
+        readyCheckService.expireTimedOutMatches();
+
+        assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        verify(matchingEventPublisher, times(4)).publishMatchExpired(any(), any());
+    }
+
+    @Test
+    @DisplayName("마지막 accept 경쟁에서도 room 은 한 번만 생성된다")
+    void acceptMatch_createsRoomOnlyOnce_whenLastAcceptsRace() throws Exception {
+        AtomicInteger createRoomCallCount = new AtomicInteger();
+        when(battleRoomService.createRoom(any(CreateRoomRequest.class))).thenAnswer(invocation -> {
+            createRoomCallCount.incrementAndGet();
+            Thread.sleep(200);
+            return new CreateRoomResponse(100L, "WAITING");
+        });
+
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+
+        readyCheckService.acceptMatch(1L, matchId);
+        readyCheckService.acceptMatch(2L, matchId);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<MatchStateV2Response> user3Future = executorService.submit(() -> {
+                startLatch.await();
+                return readyCheckService.acceptMatch(3L, matchId);
+            });
+            Future<MatchStateV2Response> user4Future = executorService.submit(() -> {
+                startLatch.await();
+                return readyCheckService.acceptMatch(4L, matchId);
+            });
+
+            startLatch.countDown();
+
+            MatchStateV2Response user3Response = user3Future.get(5, TimeUnit.SECONDS);
+            MatchStateV2Response user4Response = user4Future.get(5, TimeUnit.SECONDS);
+            MatchStateV2Response finalState = readyCheckService.getMyMatchStateV2(1L);
+
+            assertThat(createRoomCallCount.get()).isEqualTo(1);
+            assertThat(user3Response.status()).isIn(MatchStatus.ACCEPT_PENDING, MatchStatus.ROOM_READY);
+            assertThat(user4Response.status()).isIn(MatchStatus.ACCEPT_PENDING, MatchStatus.ROOM_READY);
+            assertThat(finalState.status()).isEqualTo(MatchStatus.ROOM_READY);
+            assertThat(finalState.room()).isNotNull();
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("ready-check 세션 생성 실패 시 rollback 후 queue waitingCount 복구 이벤트를 발행한다")
     void joinQueueV2_publishesRecoveredQueueEvent_whenMarkAcceptPendingFails() {
         ExplodingRedisMatchStateStore failingStore =
                 new ExplodingRedisMatchStateStore(redisTemplate, serializer, matchingStoreProperties());
@@ -141,6 +312,14 @@ class RedisQueueReadyCheckServiceTest {
         return properties;
     }
 
+    private Long createAcceptPendingMatch() {
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
+        return readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+    }
+
     private QueueJoinRequest createRequest(String category, Difficulty difficulty) {
         return new QueueJoinRequest(category, difficulty);
     }
@@ -155,7 +334,7 @@ class RedisQueueReadyCheckServiceTest {
                 FakeStringRedisTemplate redisTemplate,
                 MatchingRedisSerializer serializer,
                 MatchingStoreProperties properties) {
-            super(redisTemplate, serializer, properties, new InMemoryMatchStateStore());
+            super(redisTemplate, serializer, properties);
         }
 
         @Override

--- a/src/test/java/com/back/domain/matching/queue/store/redis/FakeStringRedisTemplate.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/FakeStringRedisTemplate.java
@@ -8,9 +8,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -18,29 +20,49 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.script.RedisScript;
 
 /**
- * Redis queue 전환 로직을 빠르게 검증하기 위한 테스트 전용 템플릿이다.
+ * Redis matching store 테스트를 빠르게 검증하기 위한 테스트 전용 템플릿이다.
  *
- * 이번 단계에서는 StringRedisTemplate이 사용하는 최소 기능만 흉내 내고,
- * Lua script는 store가 기대하는 결과만 메모리 자료구조로 재현한다.
+ * StringRedisTemplate 이 사용하는 최소 기능만 흉내 내고,
+ * store 가 기대하는 Lua script 결과를 메모리 자료구조로 재현한다.
  */
 public class FakeStringRedisTemplate extends StringRedisTemplate {
 
+    private final Object monitor = new Object();
     private final Map<String, String> values = new HashMap<>();
     private final Map<String, LinkedList<String>> lists = new HashMap<>();
     private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
     private final ListOperations<String, String> listOperations = mock(ListOperations.class);
 
     public FakeStringRedisTemplate() {
-        when(valueOperations.get(anyString())).thenAnswer(invocation -> values.get(invocation.getArgument(0)));
-        when(listOperations.size(anyString()))
-                .thenAnswer(invocation -> (long) list(invocation.getArgument(0)).size());
+        when(valueOperations.get(anyString())).thenAnswer(invocation -> {
+            synchronized (monitor) {
+                return values.get(invocation.getArgument(0));
+            }
+        });
+        when(valueOperations.increment(anyString())).thenAnswer(invocation -> {
+            synchronized (monitor) {
+                String key = invocation.getArgument(0);
+                long nextValue = Long.parseLong(values.getOrDefault(key, "0")) + 1L;
+                values.put(key, String.valueOf(nextValue));
+                return nextValue;
+            }
+        });
+        when(listOperations.size(anyString())).thenAnswer(invocation -> {
+            synchronized (monitor) {
+                return (long) list(invocation.getArgument(0)).size();
+            }
+        });
         when(listOperations.index(anyString(), anyLong())).thenAnswer(invocation -> {
-            LinkedList<String> queue = list(invocation.getArgument(0));
-            long index = invocation.getArgument(1);
-            return index >= 0 && index < queue.size() ? queue.get((int) index) : null;
+            synchronized (monitor) {
+                LinkedList<String> queue = list(invocation.getArgument(0));
+                long index = invocation.getArgument(1);
+                return index >= 0 && index < queue.size() ? queue.get((int) index) : null;
+            }
         });
         doAnswer(invocation -> {
-                    values.put(invocation.getArgument(0), invocation.getArgument(1));
+                    synchronized (monitor) {
+                        values.put(invocation.getArgument(0), invocation.getArgument(1));
+                    }
                     return null;
                 })
                 .when(valueOperations)
@@ -59,50 +81,82 @@ public class FakeStringRedisTemplate extends StringRedisTemplate {
 
     @Override
     public Boolean delete(String key) {
-        boolean removed = values.remove(key) != null;
-        removed = lists.remove(key) != null || removed;
-        return removed;
+        synchronized (monitor) {
+            boolean removed = values.remove(key) != null;
+            removed = lists.remove(key) != null || removed;
+            return removed;
+        }
     }
 
     @Override
     public Long delete(Collection<String> keys) {
-        long removedCount = 0L;
+        synchronized (monitor) {
+            long removedCount = 0L;
 
-        for (String key : keys) {
-            if (Boolean.TRUE.equals(delete(key))) {
-                removedCount++;
+            for (String key : keys) {
+                if (Boolean.TRUE.equals(delete(key))) {
+                    removedCount++;
+                }
             }
-        }
 
-        return removedCount;
+            return removedCount;
+        }
+    }
+
+    @Override
+    public Set<String> keys(String pattern) {
+        synchronized (monitor) {
+            Set<String> result = new LinkedHashSet<>();
+            values.keySet().stream().filter(key -> matches(key, pattern)).forEach(result::add);
+            lists.keySet().stream().filter(key -> matches(key, pattern)).forEach(result::add);
+            return result;
+        }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T> T execute(RedisScript<T> script, List<String> keys, Object... args) {
-        Class<T> resultType = script.getResultType();
+        synchronized (monitor) {
+            String scriptText = script.getScriptAsString();
 
-        if (Long.class.equals(resultType) && keys.size() == 2 && args.length == 1) {
-            return (T) handleEnqueue(keys, args);
+            if (scriptText.contains("MATCHING:QUEUE_ENQUEUE")) {
+                return (T) handleEnqueue(keys, args);
+            }
+
+            if (scriptText.contains("MATCHING:QUEUE_CONTAINS")) {
+                return (T) handleQueueContains(keys, args);
+            }
+
+            if (scriptText.contains("MATCHING:QUEUE_POLL")) {
+                return (T) handlePoll(keys, args);
+            }
+
+            if (scriptText.contains("MATCHING:QUEUE_CANCEL")) {
+                return (T) handleCancel(keys, args);
+            }
+
+            if (scriptText.contains("MATCHING:QUEUE_ROLLBACK")) {
+                return (T) handleRollback(keys, args);
+            }
+
+            if (scriptText.contains("MATCHING:MATCH_MARK_ACCEPT_PENDING")) {
+                return (T) handleMarkAcceptPending(keys, args);
+            }
+
+            if (scriptText.contains("MATCHING:MATCH_COMPARE_AND_SET")) {
+                return (T) handleCompareAndSet(keys, args);
+            }
+
+            if (scriptText.contains("MATCHING:DELETE_IF_VALUE")) {
+                return (T) handleDeleteIfValue(keys, args);
+            }
+
+            if (scriptText.contains("MATCHING:MATCH_CLEAR_TERMINAL")) {
+                return (T) handleClearTerminal(keys, args);
+            }
+
+            throw new UnsupportedOperationException("테스트 템플릿이 처리하지 않는 Redis script 호출입니다.");
         }
-
-        if (Long.class.equals(resultType) && keys.size() == 1 && args.length == 1) {
-            return (T) handleQueueContains(keys, args);
-        }
-
-        if (List.class.equals(resultType) && keys.size() == 1 && args.length == 1) {
-            return (T) handlePoll(keys, args);
-        }
-
-        if (List.class.equals(resultType) && keys.size() == 2 && args.length == 1) {
-            return (T) handleCancel(keys, args);
-        }
-
-        if (Long.class.equals(resultType) && keys.size() >= 2 && args.length >= 1) {
-            return (T) handleRollback(keys, args);
-        }
-
-        throw new UnsupportedOperationException("테스트 템플릿이 처리하지 않는 Redis script 호출입니다.");
     }
 
     private Long handleEnqueue(List<String> keys, Object[] args) {
@@ -171,6 +225,75 @@ public class FakeStringRedisTemplate extends StringRedisTemplate {
         }
 
         return (long) queue.size();
+    }
+
+    private String handleMarkAcceptPending(List<String> keys, Object[] args) {
+        String sessionJson = String.valueOf(args[0]);
+        String matchId = String.valueOf(args[1]);
+        int participantCount = Integer.parseInt(String.valueOf(args[2]));
+
+        values.put(keys.get(0), sessionJson);
+
+        for (int i = 1; i <= participantCount; i++) {
+            values.put(keys.get(i), matchId);
+        }
+
+        for (int i = participantCount + 1; i < keys.size(); i++) {
+            values.remove(keys.get(i));
+        }
+
+        return sessionJson;
+    }
+
+    private Long handleCompareAndSet(List<String> keys, Object[] args) {
+        String key = keys.get(0);
+        String expected = String.valueOf(args[0]);
+        String updated = String.valueOf(args[1]);
+        String current = values.get(key);
+
+        if (!expected.equals(current)) {
+            return 0L;
+        }
+
+        values.put(key, updated);
+        return 1L;
+    }
+
+    private Long handleDeleteIfValue(List<String> keys, Object[] args) {
+        String key = keys.get(0);
+        String expected = String.valueOf(args[0]);
+        String current = values.get(key);
+
+        if (!expected.equals(current)) {
+            return 0L;
+        }
+
+        values.remove(key);
+        return 1L;
+    }
+
+    private Long handleClearTerminal(List<String> keys, Object[] args) {
+        String expected = String.valueOf(args[0]);
+
+        for (int i = 1; i < keys.size(); i++) {
+            if (expected.equals(values.get(keys.get(i)))) {
+                values.remove(keys.get(i));
+            }
+        }
+
+        values.remove(keys.get(0));
+        return 1L;
+    }
+
+    private boolean matches(String key, String pattern) {
+        int wildcardIndex = pattern.indexOf('*');
+        if (wildcardIndex < 0) {
+            return key.equals(pattern);
+        }
+
+        String prefix = pattern.substring(0, wildcardIndex);
+        String suffix = pattern.substring(wildcardIndex + 1);
+        return key.startsWith(prefix) && key.endsWith(suffix);
     }
 
     private LinkedList<String> list(String key) {

--- a/src/test/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStoreTest.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStoreTest.java
@@ -15,8 +15,8 @@ import com.back.domain.matching.queue.model.Difficulty;
 import com.back.domain.matching.queue.model.MatchSession;
 import com.back.domain.matching.queue.model.MatchSessionStatus;
 import com.back.domain.matching.queue.model.QueueKey;
+import com.back.domain.matching.queue.model.ReadyDecision;
 import com.back.domain.matching.queue.model.WaitingUser;
-import com.back.domain.matching.queue.store.InMemoryMatchStateStore;
 import com.back.domain.matching.queue.store.MatchStateStore;
 import com.back.domain.matching.queue.store.MatchingStoreProperties;
 import com.back.global.exception.ServiceException;
@@ -27,19 +27,17 @@ class RedisMatchStateStoreTest {
     private FakeStringRedisTemplate redisTemplate;
     private MatchingRedisSerializer serializer;
     private RedisMatchStateStore store;
-    private InMemoryMatchStateStore delegate;
 
     @BeforeEach
     void setUp() {
         redisTemplate = new FakeStringRedisTemplate();
         serializer = new MatchingRedisSerializer(
                 JsonMapper.builder().findAndAddModules().build());
-        delegate = new InMemoryMatchStateStore();
 
         MatchingStoreProperties properties = new MatchingStoreProperties();
         properties.setType(MatchingStoreProperties.StoreType.REDIS);
 
-        store = new RedisMatchStateStore(redisTemplate, serializer, properties, delegate);
+        store = new RedisMatchStateStore(redisTemplate, serializer, properties);
     }
 
     @Test
@@ -100,49 +98,8 @@ class RedisMatchStateStoreTest {
     }
 
     @Test
-    @DisplayName("인원이 부족하면 pollMatchCandidates 는 null 을 반환한다")
-    void pollMatchCandidates_returnsNullWhenQueueIsShort() {
-        QueueKey queueKey = queueKey();
-        store.enqueue(1L, "m1", queueKey);
-        store.enqueue(2L, "m2", queueKey);
-        store.enqueue(3L, "m3", queueKey);
-
-        List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
-
-        assertThat(matchedUsers).isNull();
-    }
-
-    @Test
-    @DisplayName("pollMatchCandidates 는 Redis queue 에서 FIFO 순서로 4명을 꺼낸다")
-    void pollMatchCandidates_returnsFifoUsers() {
-        QueueKey queueKey = queueKey();
-        enqueueUsers(queueKey, 4);
-
-        List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
-
-        assertThat(matchedUsers).extracting(WaitingUser::getUserId).containsExactly(1L, 2L, 3L, 4L);
-        assertThat(store.getWaitingCount(queueKey)).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("rollbackPolledUsers 는 queue 순서와 userQueue index 를 함께 복구한다")
-    void rollbackPolledUsers_restoresQueueOrderAndUserQueue() {
-        QueueKey queueKey = queueKey();
-        enqueueUsers(queueKey, 4);
-        List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
-
-        store.rollbackPolledUsers(queueKey, matchedUsers);
-
-        List<WaitingUser> restoredUsers = store.pollMatchCandidates(queueKey, 4);
-
-        assertThat(restoredUsers).extracting(WaitingUser::getUserId).containsExactly(1L, 2L, 3L, 4L);
-        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userQueue(1L)))
-                .isNotNull();
-    }
-
-    @Test
-    @DisplayName("markAcceptPending 은 userQueue Redis key 를 정리하고 ready-check 본문은 인메모리 delegate 에 저장한다")
-    void markAcceptPending_handsOffToInMemoryDelegate() {
+    @DisplayName("markAcceptPending 은 match 문서와 userMatch 인덱스를 함께 저장하고 userQueue 를 삭제한다")
+    void markAcceptPending_storesReadyCheckStateInRedis() {
         QueueKey queueKey = queueKey();
         enqueueUsers(queueKey, 4);
         List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
@@ -151,9 +108,148 @@ class RedisMatchStateStoreTest {
                 store.markAcceptPending(queueKey, matchedUsers, LocalDateTime.of(2026, 4, 6, 12, 30, 0));
 
         assertThat(matchSession.status()).isEqualTo(MatchSessionStatus.ACCEPT_PENDING);
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.match(matchSession.matchId())))
+                .isNotNull();
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userMatch(1L)))
+                .isEqualTo(String.valueOf(matchSession.matchId()));
         assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userQueue(1L)))
                 .isNull();
-        assertThat(delegate.findMatchSessionByUserId(1L)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("findMatchSessionByUserId 는 Redis ready-check 세션을 읽고 stale link 를 정리한다")
+    void findMatchSessionByUserId_readsSessionAndCleansStaleLink() {
+        MatchSession matchSession = createAcceptPendingMatch(LocalDateTime.of(2026, 4, 6, 12, 30, 0));
+
+        MatchSession found = store.findMatchSessionByUserId(1L);
+
+        assertThat(found).isNotNull();
+        assertThat(found.matchId()).isEqualTo(matchSession.matchId());
+
+        redisTemplate.opsForValue().set(MatchingRedisKeys.userMatch(99L), "999");
+        assertThat(store.findMatchSessionByUserId(99L)).isNull();
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userMatch(99L)))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("accept 는 decision 을 갱신하고 중복 accept 는 현재 상태를 유지한다")
+    void accept_updatesDecisionAndKeepsDuplicateAccept() {
+        MatchSession matchSession = createAcceptPendingMatch(LocalDateTime.now().plusSeconds(30));
+
+        MatchSession accepted = store.accept(matchSession.matchId(), 1L);
+        MatchSession duplicated = store.accept(matchSession.matchId(), 1L);
+
+        assertThat(accepted.decisionOf(1L)).isEqualTo(ReadyDecision.ACCEPTED);
+        assertThat(duplicated.decisionOf(1L)).isEqualTo(ReadyDecision.ACCEPTED);
+        assertThat(duplicated.acceptedCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("decline 은 CANCELLED 로 전이한다")
+    void decline_returnsCancelled() {
+        MatchSession matchSession = createAcceptPendingMatch(LocalDateTime.now().plusSeconds(30));
+
+        MatchSession declined = store.decline(matchSession.matchId(), 2L);
+
+        assertThat(declined.status()).isEqualTo(MatchSessionStatus.CANCELLED);
+        assertThat(declined.decisionOf(2L)).isEqualTo(ReadyDecision.DECLINED);
+    }
+
+    @Test
+    @DisplayName("deadline 이 지난 세션에서 accept 하면 EXPIRED 를 우선 반영한다")
+    void accept_returnsExpiredWhenDeadlinePassed() {
+        MatchSession matchSession = createAcceptPendingMatch(LocalDateTime.now().minusSeconds(1));
+
+        MatchSession expired = store.accept(matchSession.matchId(), 1L);
+
+        assertThat(expired.status()).isEqualTo(MatchSessionStatus.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("tryBeginRoomCreation 은 마지막 accept 경쟁에서도 한 번만 선점한다")
+    void tryBeginRoomCreation_acquiresOnlyOnce() {
+        MatchSession matchSession = createAcceptPendingMatch(LocalDateTime.now().plusSeconds(30));
+        store.accept(matchSession.matchId(), 1L);
+        store.accept(matchSession.matchId(), 2L);
+        store.accept(matchSession.matchId(), 3L);
+        store.accept(matchSession.matchId(), 4L);
+
+        MatchStateStore.RoomCreationAttempt firstAttempt = store.tryBeginRoomCreation(matchSession.matchId());
+        MatchStateStore.RoomCreationAttempt secondAttempt = store.tryBeginRoomCreation(matchSession.matchId());
+
+        assertThat(firstAttempt.acquired()).isTrue();
+        assertThat(firstAttempt.matchSession().status()).isEqualTo(MatchSessionStatus.ROOM_CREATING);
+        assertThat(secondAttempt.acquired()).isFalse();
+        assertThat(secondAttempt.matchSession().status()).isEqualTo(MatchSessionStatus.ROOM_CREATING);
+    }
+
+    @Test
+    @DisplayName("markRoomReady 와 clearMatchedRoom 은 참가자 참조를 기준으로 세션을 정리한다")
+    void markRoomReadyAndClearMatchedRoom_cleanupByReferences() {
+        MatchSession matchSession = createAcceptPendingMatch(LocalDateTime.now().plusSeconds(30));
+        store.accept(matchSession.matchId(), 1L);
+        store.accept(matchSession.matchId(), 2L);
+        store.accept(matchSession.matchId(), 3L);
+        store.accept(matchSession.matchId(), 4L);
+        store.tryBeginRoomCreation(matchSession.matchId());
+
+        MatchSession roomReady = store.markRoomReady(matchSession.matchId(), 100L);
+        store.clearMatchedRoom(1L, 100L);
+
+        assertThat(roomReady.status()).isEqualTo(MatchSessionStatus.ROOM_READY);
+        assertThat(store.findMatchSessionByUserId(1L)).isNull();
+        assertThat(store.findMatchSessionByUserId(2L)).isNotNull();
+
+        store.clearMatchedRoom(2L, 100L);
+        store.clearMatchedRoom(3L, 100L);
+        store.clearMatchedRoom(4L, 100L);
+
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.match(matchSession.matchId())))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("clearTerminalMatch 는 match 문서와 userMatch 인덱스를 함께 정리한다")
+    void clearTerminalMatch_removesMatchAndUserLinks() {
+        MatchSession matchSession = createAcceptPendingMatch(LocalDateTime.now().plusSeconds(30));
+        store.decline(matchSession.matchId(), 1L);
+
+        store.clearTerminalMatch(matchSession.matchId());
+
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.match(matchSession.matchId())))
+                .isNull();
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userMatch(1L)))
+                .isNull();
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userMatch(4L)))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("findExpiredAcceptPendingMatchIds 는 임시 match key scan 기준으로 만료 세션만 반환한다")
+    void findExpiredAcceptPendingMatchIds_returnsExpiredMatches() {
+        MatchSession expired = createAcceptPendingMatch(LocalDateTime.now().minusSeconds(1));
+        MatchSession active = createAcceptPendingMatch(LocalDateTime.now().plusSeconds(30), 11L);
+
+        List<Long> expiredMatchIds = store.findExpiredAcceptPendingMatchIds(LocalDateTime.now());
+
+        assertThat(expiredMatchIds).contains(expired.matchId());
+        assertThat(expiredMatchIds).doesNotContain(active.matchId());
+    }
+
+    private MatchSession createAcceptPendingMatch(LocalDateTime deadline) {
+        return createAcceptPendingMatch(deadline, 1L);
+    }
+
+    private MatchSession createAcceptPendingMatch(LocalDateTime deadline, long startUserId) {
+        QueueKey queueKey = queueKey();
+        List<WaitingUser> matchedUsers = List.of(
+                new WaitingUser(startUserId, "m" + startUserId, queueKey),
+                new WaitingUser(startUserId + 1, "m" + (startUserId + 1), queueKey),
+                new WaitingUser(startUserId + 2, "m" + (startUserId + 2), queueKey),
+                new WaitingUser(startUserId + 3, "m" + (startUserId + 3), queueKey));
+
+        return store.markAcceptPending(queueKey, matchedUsers, deadline);
     }
 
     private QueueKey queueKey() {


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #148 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #148 

---

<html>
<body>
<h1>[refactor] matching queue 상태를 Redis 기반 hybrid store로 전환</h1>

<h3>개요</h3>
<p>이번 PR은 현재 인메모리 기반으로 관리하던 matching 상태 중에서 <strong>SEARCHING 구간의 queue 상태</strong>를 Redis로 옮기고, <strong>ready-check 세션 본문과 이후 상태 전이</strong>는 기존 인메모리 저장소에 그대로 위임하는 hybrid 구조로 전환한 작업입니다.</p>
<p>즉, 이번 단계에서 Redis로 옮긴 범위는 아래와 같습니다.</p>
<ul>
<li>queue 대기열 자체</li>
<li>user -&gt; queue 연결</li>
<li>queue 기반 waitingCount / queue/me 조회</li>
<li>4인 poll 및 rollback</li>
</ul>

<p>반면 아래 ready-check 상태 전이는 아직 기존 인메모리 저장소를 그대로 사용합니다.</p>
<ul>
<li><code>markAcceptPending</code> 이후 match session 본문</li>
<li><code>accept</code>, <code>decline</code></li>
<li><code>tryBeginRoomCreation</code>, <code>markRoomReady</code></li>
<li><code>expire</code>, <code>cancelMatch</code></li>
<li><code>findMatchSessionByUserId</code>, <code>clearTerminalMatch</code>, <code>clearMatchedRoom</code></li>
</ul>

<p>즉, 이번 PR의 핵심은 <strong>queue/searching 구간만 Redis로 먼저 이전하고, ready-check 이후는 메모리 delegate로 넘기는 하이브리드 저장소 경계</strong>를 실제 동작하는 코드로 만든 것입니다.</p>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) dev 환경에서 matching store 기본값을 Redis로 전환</h3>
<p>기존 설정 구조는 이미 <code>matching.store.type</code>를 지원하고 있었고, 이번 PR에서는 <code>application-dev.yml</code>에서 dev 환경 기본값을 Redis로 바꿨습니다.</p>

<pre><code class="language-yml">matching:
  store:
    type: redis
</code></pre>

<p>즉, dev 프로필에서는 이제 <code>RedisMatchStateStore</code>가 실제 matching 저장소로 선택됩니다.</p>

<h3>2) <code>RedisMatchStateStore</code>를 실제 런타임 빈으로 연결</h3>
<p>이전 단계의 Redis 저장소는 스켈레톤 수준이었지만, 이번 PR에서는 실제 런타임 빈으로 동작하도록 조건부 등록을 붙였습니다.</p>

<pre><code class="language-java">@Primary
@Component
@ConditionalOnProperty(prefix = "matching.store", name = "type", havingValue = "redis")
public class RedisMatchStateStore implements MatchStateStore
</code></pre>

<p>의미는 아래와 같습니다.</p>
<ul>
<li><code>matching.store.type=redis</code>일 때만 활성화</li>
<li><code>MatchStateStore</code> 주입 시 Redis 구현체를 우선 사용</li>
<li>기존 인메모리 저장소는 ready-check delegate 용으로 계속 남김</li>
</ul>

<p>즉, 이 PR부터는 “Redis 설계 파일만 있는 상태”가 아니라 실제 서비스가 Redis queue 경로를 사용하게 됩니다.</p>

<h3>3) queue/searching 상태를 Redis로 저장하는 하이브리드 구조 도입</h3>
<p><code>RedisMatchStateStore</code>는 내부적으로 아래 4가지 의존성을 가집니다.</p>

<pre><code class="language-java">private final StringRedisTemplate redisTemplate;
private final MatchingRedisSerializer serializer;
private final MatchingStoreProperties storeProperties;
private final InMemoryMatchStateStore delegate;
</code></pre>

<p>책임 분리는 아래와 같습니다.</p>
<ul>
<li><code>redisTemplate</code> : queue, userQueue index, poll/rollback/cancel 등 Redis 조작</li>
<li><code>serializer</code> : WaitingUser / MatchSession / QueueKey JSON 직렬화 규칙</li>
<li><code>storeProperties</code> : 저장소 타입 설정 유지</li>
<li><code>delegate</code> : 아직 Redis로 옮기지 않은 ready-check 세션 본문 및 상태 전이 처리</li>
</ul>

<p>즉, queue는 Redis, ready-check는 memory인 hybrid store가 이번 PR의 핵심 구조입니다.</p>

<h3>4) Redis enqueue를 Lua script 기반으로 구현</h3>
<p>queue 참가 시에는 단순히 두 번의 Redis 호출을 따로 날리는 것이 아니라, <strong>중복 참가 검사 + userQueue index 저장 + queue push + size 반환</strong>을 한 번에 처리하는 Lua script를 사용했습니다.</p>

<pre><code class="language-lua">if redis.call('EXISTS', KEYS[1]) == 1 then
    return -1
end
redis.call('SET', KEYS[1], ARGV[1])
redis.call('RPUSH', KEYS[2], ARGV[1])
return redis.call('LLEN', KEYS[2])
</code></pre>

<p>여기서 key 의미는 아래와 같습니다.</p>
<ul>
<li><code>KEYS[1]</code> : <code>matching:user:queue:{userId}</code></li>
<li><code>KEYS[2]</code> : <code>matching:queue:{category}:{difficulty}</code></li>
<li><code>ARGV[1]</code> : 직렬화된 <code>WaitingUser</code> payload</li>
</ul>

<p>즉, join 시에는 Redis 안에서 아래 작업을 원자적으로 수행합니다.</p>
<ul>
<li>이미 userQueue key가 있는지 확인</li>
<li>없으면 userQueue key 저장</li>
<li>queue list 뒤쪽에 payload push</li>
<li>현재 queue size 반환</li>
</ul>

<h3>5) duplicate join 예외를 Redis 경로에서도 동일하게 유지</h3>
<p>Redis 경로에서도 기존과 동일하게 중복 queue 참가를 <code>409-1</code> 예외로 막습니다.</p>

<pre><code class="language-java">if (currentSize == -1L) {
    throw new ServiceException("409-1", "이미 매칭 대기열에 참가 중인 사용자입니다.");
}
</code></pre>

<p>또한 enqueue 전에 <code>ensureJoinEligibility(userId)</code>를 호출해, 이미 active match session에 연결된 사용자는 기존 정책대로 재join을 막습니다.</p>

<pre><code class="language-java">private void ensureJoinEligibility(Long userId) {
    MatchSession matchSession = delegate.findMatchSessionByUserId(userId);

    if (matchSession != null) {
        throw new ServiceException("409-1", "이미 진행 중인 매칭이 있습니다.");
    }
}
</code></pre>

<p>즉, Redis queue로 바뀌어도 “이미 SEARCHING 중인 사용자”와 “이미 active match session이 있는 사용자” 모두 재참가 차단 정책을 유지합니다.</p>

<h3>6) <code>WaitingUser</code>를 Redis 저장용으로 확장</h3>
<p>기존 <code>WaitingUser</code>는 기본 생성 시점의 <code>joinedAt</code>을 내부에서 <code>LocalDateTime.now()</code>로만 만들 수 있었습니다. 이번 PR에서는 Redis 직렬화 복원 시 원래 시각을 유지할 수 있도록 생성자를 확장했습니다.</p>

<pre><code class="language-java">public WaitingUser(Long userId, String nickname, QueueKey queueKey) {
    this(userId, nickname, queueKey, LocalDateTime.now());
}

public WaitingUser(Long userId, String nickname, QueueKey queueKey, LocalDateTime joinedAt) {
    this.userId = userId;
    this.nickname = nickname;
    this.queueKey = queueKey;
    this.joinedAt = joinedAt;
}
</code></pre>

<p>즉, Redis에서 복원된 queue 사용자도 기존 joinedAt 정보를 잃지 않도록 만들었습니다.</p>

<h3>7) <code>MatchingRedisSerializer</code>에 <code>WaitingUser</code> 직렬화 규칙 추가</h3>
<p>기존 serializer는 <code>QueueKey</code>와 <code>MatchSession</code>만 다루고 있었지만, 이번 단계부터 queue 상태가 Redis로 이동하므로 <code>WaitingUser</code> 직렬화/역직렬화도 추가했습니다.</p>

<pre><code class="language-java">public String writeWaitingUser(WaitingUser waitingUser)
public WaitingUser readWaitingUser(String value)
</code></pre>

<p>내부적으로는 저장 전용 document를 두어 joinedAt까지 유지한 채 복원할 수 있게 했습니다.</p>

<pre><code class="language-java">private record WaitingUserDocument(
        Long userId,
        String nickname,
        QueueKey queueKey,
        LocalDateTime joinedAt
) { ... }
</code></pre>

<p>즉, Redis queue list와 userQueue index에는 동일한 <code>WaitingUser JSON</code> 문자열을 저장합니다.</p>

<h3>8) queue 상태 조회도 Redis 기준으로 전환</h3>
<p><code>getQueueStateV2()</code>는 이제 Redis의 <code>userQueue</code> key와 queue list를 기준으로 SEARCHING snapshot을 만듭니다.</p>

<pre><code class="language-java">String payload = findActiveQueuePayload(userId);

if (payload == null) {
    return new QueueStateV2Response(false, null, null, 0, REQUIRED_MATCH_SIZE);
}

WaitingUser waitingUser = serializer.readWaitingUser(payload);
QueueKey queueKey = waitingUser.getQueueKey();

return new QueueStateV2Response(
        true,
        queueKey.category(),
        queueKey.difficulty().name(),
        getWaitingCount(queueKey),
        REQUIRED_MATCH_SIZE);
</code></pre>

<p>즉, queue/me 응답은 더 이상 인메모리 Deque가 아니라 Redis에 저장된 queue 상태를 읽어 반환합니다.</p>

<h3>9) stale userQueue index 정리 로직 추가</h3>
<p>Redis 환경에서는 <code>matching:user:queue:{userId}</code> key는 남아 있지만 실제 queue list에는 payload가 없는 stale 상태가 생길 수 있습니다. 이를 방지하기 위해 <code>findActiveQueuePayload()</code>에서 queue list에 실제 payload가 있는지 검증한 뒤, 없으면 현재 사용자 기준 stale 데이터를 정리합니다.</p>

<pre><code class="language-java">Long contains = redisTemplate.execute(QUEUE_CONTAINS_SCRIPT, List.of(queueKey), payload);

if (contains == null || contains == 0L) {
    redisTemplate.delete(userQueueKey);
    return null;
}
</code></pre>

<p>즉, userQueue index만 남아 있는 깨진 상태는 queue 조회 시 자동으로 회복됩니다.</p>

<h3>10) cancel도 Redis queue와 userQueue index를 함께 정리</h3>
<p>cancel은 Redis Lua script로 아래 작업을 한 번에 처리합니다.</p>

<pre><code class="language-lua">local removed = redis.call('LREM', KEYS[2], 1, ARGV[1])
redis.call('DEL', KEYS[1])
local size = redis.call('LLEN', KEYS[2])
if size == 0 then
    redis.call('DEL', KEYS[2])
end
return {removed, size}
</code></pre>

<p>즉, cancel 시에는 아래가 같이 처리됩니다.</p>
<ul>
<li>queue list에서 해당 WaitingUser payload 제거</li>
<li>userQueue index 삭제</li>
<li>queue가 비었으면 queue key 자체 삭제</li>
<li>남은 waitingCount 반환</li>
</ul>

<p>따라서 기존 인메모리 cancel과 같은 의미를 Redis 기준으로 유지합니다.</p>

<h3>11) 4인 poll도 Redis FIFO queue 기준으로 전환</h3>
<p><code>pollMatchCandidates()</code>는 Redis list에서 FIFO 순서로 4명을 꺼내도록 구현했습니다.</p>

<pre><code class="language-lua">local count = tonumber(ARGV[1])
if redis.call('LLEN', KEYS[1]) < count then
    return {}
end

local result = {}
for i = 1, count do
    result[i] = redis.call('LPOP', KEYS[1])
end

if redis.call('LLEN', KEYS[1]) == 0 then
    redis.call('DEL', KEYS[1])
end

return result
</code></pre>

<p>즉, queue 인원이 부족하면 빈 결과를 반환하고, 충분하면 앞에서부터 4명을 꺼낸 뒤 queue가 비면 key 자체를 정리합니다.</p>

<h3>12) rollback도 Redis queue와 userQueue index를 함께 복구</h3>
<p>ready-check 세션 생성 도중 실패했을 때는 poll했던 4명을 queue 앞쪽으로 되돌리고, 각 사용자의 userQueue index도 같이 복구해야 합니다. 이를 위해 rollback도 Lua script로 구현했습니다.</p>

<pre><code class="language-lua">for i = #ARGV, 1, -1 do
    redis.call('LPUSH', KEYS[1], ARGV[i])
end

for i = 2, #KEYS do
    redis.call('SET', KEYS[i], ARGV[i - 1])
end

return redis.call('LLEN', KEYS[1])
</code></pre>

<p>즉, rollback 시에는:</p>
<ul>
<li>queue는 원래 FIFO 순서가 유지되도록 역순 <code>LPUSH</code></li>
<li>각 사용자의 <code>matching:user:queue:{userId}</code> key도 함께 복구</li>
</ul>

<p>즉, Redis queue 경로에서도 실패 rollback의 의미를 그대로 유지합니다.</p>

<h3>13) 4명 handoff 이후에는 ready-check 세션 본문을 인메모리 delegate에 저장</h3>
<p>이번 PR은 queue/searching 상태만 Redis로 옮긴 단계이므로, 4명이 poll된 뒤 ready-check 세션을 만드는 시점에는 기존 인메모리 저장소로 handoff 합니다.</p>

<pre><code class="language-java">@Override
public MatchSession markAcceptPending(QueueKey queueKey, List&lt;WaitingUser&gt; matchedUsers, LocalDateTime deadline) {
    if (matchedUsers != null && !matchedUsers.isEmpty()) {
        redisTemplate.delete(matchedUsers.stream()
                .map(WaitingUser::getUserId)
                .map(MatchingRedisKeys::userQueue)
                .toList());
    }

    return delegate.markAcceptPending(queueKey, matchedUsers, deadline);
}
</code></pre>

<p>즉, 이 시점에 하는 일은 아래와 같습니다.</p>
<ul>
<li>SEARCHING 사용자로 보이지 않도록 userQueue Redis key 삭제</li>
<li>ready-check 세션 본문은 기존 <code>InMemoryMatchStateStore</code>에 저장</li>
</ul>

<p>따라서 현재 구조는 정확히 <strong>queue는 Redis, match session은 memory</strong>입니다.</p>

<h3>14) ready-check 이후 상태 전이는 기존 delegate 그대로 사용</h3>
<p>아래 메서드들은 이번 PR에서 Redis로 옮기지 않고 기존 인메모리 delegate를 그대로 사용합니다.</p>

<pre><code class="language-java">accept(...)
decline(...)
tryBeginRoomCreation(...)
markRoomReady(...)
expire(...)
cancelMatch(...)
findMatchSessionByUserId(...)
findExpiredAcceptPendingMatchIds(...)
clearTerminalMatch(...)
clearMatchedRoom(...)
</code></pre>

<p>즉, ready-check 본문과 이후 상태 전이는 다음 하위 이슈에서 Redis로 넘길 예정이고, 이번 단계에서는 queue 경로만 먼저 옮겨 서비스 동작을 안정적으로 유지하도록 했습니다.</p>

<h3>15) Redis serializer는 Spring bean으로 등록</h3>
<p><code>MatchingRedisSerializer</code>에는 이번 단계부터 <code>@Component</code>를 붙여 실제 저장소 bean에서 주입받아 사용할 수 있도록 했습니다.</p>

<pre><code class="language-java">@Component
public class MatchingRedisSerializer { ... }
</code></pre>

<p>즉, 이제 serializer는 테스트 유틸이 아니라 실제 Redis 저장소 런타임 구성 요소가 됩니다.</p>

<h3>16) Redis queue 경로 전용 테스트 더블 추가</h3>
<p>Redis queue 전환 로직을 빠르게 검증하기 위해 <code>FakeStringRedisTemplate</code>를 새로 추가했습니다.</p>
<p>이 테스트 더블은 실제 Redis 전체를 흉내 내는 것이 아니라, 이번 단계에서 store가 사용하는 최소 기능만 메모리 자료구조로 재현합니다.</p>

<ul>
<li><code>opsForValue().get/set</code></li>
<li><code>opsForList().size/index</code></li>
<li><code>delete</code></li>
<li>현재 store가 호출하는 Lua script 패턴별 <code>execute(...)</code></li>
</ul>

<p>즉, Redis queue 전환 로직을 빠르게 단위 테스트할 수 있는 최소 환경을 마련한 것입니다.</p>

<h3>17) 테스트 추가</h3>

<p><code>RedisMatchStateStoreTest</code></p>
<ul>
<li>enqueue 시 <code>WaitingUser</code> payload가 Redis queue와 userQueue index에 함께 저장되는지 확인</li>
<li>중복 enqueue가 기존과 같은 예외로 차단되는지 확인</li>
<li>cancel이 Redis queue와 userQueue index를 함께 정리하는지 확인</li>
<li>queue/me가 Redis 기준 SEARCHING snapshot을 반환하는지 확인</li>
<li>인원 부족 시 poll이 null을 반환하는지 확인</li>
<li>poll이 FIFO 순서로 4명을 꺼내는지 확인</li>
<li>rollback이 queue 순서와 userQueue index를 함께 복구하는지 확인</li>
<li>markAcceptPending이 userQueue Redis key를 지우고 인메모리 delegate로 handoff하는지 확인</li>
</ul>

<p><code>RedisQueueReadyCheckServiceTest</code></p>
<ul>
<li>Redis queue 경로에서도 queue/me가 waitingCount / requiredCount를 정상 반환하는지 확인</li>
<li>Redis queue 경로에서도 cancel 후 queue topic 이벤트가 정상 발행되는지 확인</li>
<li>Redis queue 경로에서도 4번째 join 시 READY_CHECK_STARTED handoff 이벤트가 정상 발행되는지 확인</li>
<li>Redis queue 경로에서도 markAcceptPending 실패 시 rollback 후 queue 상태 복구 이벤트가 발행되는지 확인</li>
</ul>

<p><code>MatchingRedisSerializerTest</code></p>
<ul>
<li><code>WaitingUser</code>가 joinedAt까지 유지한 채 JSON round-trip 가능한지 확인</li>
</ul>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">POST /api/v2/queue/join
  ↓
RedisMatchStateStore.enqueue()
  ↓
1. active match session 있으면 차단
2. userQueue key 중복 검사
3. WaitingUser JSON 저장
4. queue list 뒤에 push
5. waitingCount 반환

GET /api/v2/queue/me
  ↓
userQueue key 조회
  ↓
payload 복원
  ↓
실제 queue list 에 payload 존재하는지 확인
  ├─ 있으면 SEARCHING snapshot 반환
  └─ 없으면 stale userQueue 정리 후 inQueue=false

4명 모임
  ↓
Redis queue 에서 FIFO poll
  ↓
Redis userQueue key 삭제
  ↓
delegate(InMemoryMatchStateStore).markAcceptPending(...)
  ↓
이후 ready-check 상태 전이는 기존 memory 경로 사용
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>SEARCHING queue 상태를 실제 Redis 기반 저장소로 먼저 이전할 수 있습니다.</li>
<li>기존 서비스 계층은 유지하면서 queue와 ready-check를 단계적으로 분리 전환할 수 있습니다.</li>
<li>duplicate join, cancel, poll, rollback, queue/me 의미를 Redis에서도 기존과 동일하게 유지합니다.</li>
<li>ready-check 이후 상태 전이는 아직 안전하게 인메모리 delegate를 사용해 전환 리스크를 줄입니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li>dev 환경에서 <code>matching.store.type=redis</code>일 때 실제로 RedisMatchStateStore가 선택되는지 확인</li>
<li>queue join / cancel / queue/me / poll / rollback이 Redis 기준으로 정상 동작하는지 확인</li>
<li>4인 handoff 이후에는 SEARCHING Redis key가 정리되고, ready-check 세션은 기존 인메모리 delegate에 저장되는지 확인</li>
<li>stale userQueue index가 남아도 queue 조회 시 자동으로 정리되는지 확인</li>
<li>기존 READY_CHECK_STARTED / queue 상태 이벤트 흐름이 Redis queue 경로에서도 그대로 유지되는지 확인</li>
</ol>
</body>
</html>
