### PR TITLE
[feat] 데이터 한글로 전환 스크립트

### DIFF
--- a/docs/local-db-compose-guide.md
+++ b/docs/local-db-compose-guide.md
@@ -48,11 +48,10 @@ cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && pyth
 원문(`problems`)은 유지하고, 번역본은 `problem_translations` 테이블에 upsert됩니다.
 
 ```bash
-cd "$(git rev-parse --show-toplevel)" && python3 -m pip install -U boto3 "psycopg[binary]"
+cd "$(git rev-parse --show-toplevel)" && python3 -m pip install -U "psycopg[binary]" openai
 cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/translate_problems_ko.py --dry-run --limit 50
-cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/translate_problems_ko.py --limit 200 --chunk-size 50
+cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/translate_problems_ko.py --force --limit 200 --chunk-size 50 --request-interval-ms 250
 ```
-
 주의:
 - 운영 환경에서는 EC2 IAM Role에 `TranslateText` 권한이 필요합니다.
 - `--force` 없이 재실행하면 source hash가 동일한 문제는 건너뜁니다.

--- a/docs/local-db-compose-guide.md
+++ b/docs/local-db-compose-guide.md
@@ -1,13 +1,16 @@
-# 로컬 DB/데이터 적재 가이드 (5단계)
+# 로컬 DB/데이터 적재 가이드 (6단계)
 
-아래 5단계만 실행하면 됩니다.
+아래 6단계만 실행하면 됩니다.
 
-## 1) PostgreSQL 실행/확인
+## 1) PostgreSQL + Redis 실행/확인
 
 ```bash
-cd "$(git rev-parse --show-toplevel)" && docker compose up -d postgres
-cd "$(git rev-parse --show-toplevel)" && docker compose ps
+cd "$(git rev-parse --show-toplevel)" && docker compose up -d postgres redis
+cd "$(git rev-parse --show-toplevel)" && docker compose ps postgres redis
 ```
+
+주의:
+- Redis가 떠 있지 않으면 Spring 부팅 시 `Unable to connect to Redis server: localhost:6379`로 실패할 수 있습니다.
 
 ## 2) Spring Boot 실행 (스키마 생성)
 
@@ -39,3 +42,17 @@ cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && pyth
 예시(`scripts/starter_overrides.example.json` 기준):
 - `source_problem_id = "852/A"`의 `java` starter만 지정한 코드로 교체
 - 그 외 언어(`python3` 등)는 4번에서 만든 기본 starter 유지
+
+## 6) 문제 본문 한국어 번역본 적재 (선택)
+
+원문(`problems`)은 유지하고, 번역본은 `problem_translations` 테이블에 upsert됩니다.
+
+```bash
+cd "$(git rev-parse --show-toplevel)" && python3 -m pip install -U boto3 "psycopg[binary]"
+cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/translate_problems_ko.py --dry-run --limit 50
+cd "$(git rev-parse --show-toplevel)" && set -a && source .env && set +a && python3 scripts/translate_problems_ko.py --limit 200 --chunk-size 50
+```
+
+주의:
+- 운영 환경에서는 EC2 IAM Role에 `TranslateText` 권한이 필요합니다.
+- `--force` 없이 재실행하면 source hash가 동일한 문제는 건너뜁니다.

--- a/docs/rds-problem-load-and-translation.md
+++ b/docs/rds-problem-load-and-translation.md
@@ -1,0 +1,82 @@
+# 운영 RDS 문제 적재 + 한국어 번역 배치 가이드
+
+## 1) 어디서 실행하나
+
+- 권장: **SSM Session Manager**로 운영 EC2에 접속해서 실행
+- 이유: RDS는 보통 VPC 내부 접근만 허용되므로 로컬에서 직접 접근이 막혀있음
+
+## 2) 사전 확인
+
+1. RDS 스냅샷 1회 생성
+2. EC2 IAM Role에 `translate:TranslateText` 권한 부여 (번역 배치 시)
+3. `/etc/environment` 또는 `.env`에 DB 접속 변수 확인
+
+필수 환경 변수:
+
+- `DB_HOST` (또는 `RDS_HOST`)
+- `DB_PORT` (기본 5432)
+- `DB_NAME`
+- `DB_USERNAME`
+- `DB_PASSWORD`
+- `AWS_REGION` (기본값 `ap-northeast-2`)
+
+## 3) 문제 데이터 적재 (소량 검증 → 본 적재)
+
+```bash
+cd /home/ubuntu/NBE8-10-final-Team01
+python3 -m pip install -U requests "psycopg[binary]"
+set -a && source /etc/environment && set +a
+
+# dry-run
+python3 scripts/load_openr1_verifiable.py --dry-run --limit 100 --chunk-size 50
+
+# 소량 실제 적재
+python3 scripts/load_openr1_verifiable.py --limit 100 --chunk-size 50
+
+# 본 적재 (offset으로 나눠서 반복)
+python3 scripts/load_openr1_verifiable.py --offset 0 --limit 500 --chunk-size 50
+python3 scripts/load_openr1_verifiable.py --offset 500 --limit 500 --chunk-size 50
+```
+
+주의:
+- 운영에서 `--truncate` 사용 금지
+
+## 4) starter code 생성
+
+```bash
+python3 scripts/generate_problem_language_profiles.py --limit 2000
+```
+
+## 5) 한국어 번역본 적재
+
+원문 `problems`는 유지하고, 번역은 `problem_translations` 테이블에 upsert 됩니다.
+
+```bash
+python3 -m pip install -U boto3 "psycopg[binary]"
+
+# dry-run
+python3 scripts/translate_problems_ko.py --dry-run --limit 50
+
+# 실제 적재
+python3 scripts/translate_problems_ko.py --limit 200 --chunk-size 50
+```
+
+옵션 예시:
+
+```bash
+# 이미 번역된 문제도 강제 재번역
+python3 scripts/translate_problems_ko.py --force --limit 200
+```
+
+번역 파이프라인(placeholder 보호/후처리) 로직을 변경한 뒤에는
+기존 `source_hash`와 동일해도 품질 개선본을 덮어써야 하므로 `--force` 실행을 권장합니다.
+
+## 6) 점검 SQL
+
+```sql
+SELECT COUNT(*) AS problems_count FROM problems;
+SELECT COUNT(*) AS test_cases_count FROM test_cases;
+SELECT COUNT(*) AS translated_ko_count
+FROM problem_translations
+WHERE language_code = 'ko';
+```

--- a/scripts/translate_problems_ko.py
+++ b/scripts/translate_problems_ko.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""
+문제 원문(영문)을 보존한 채 한국어 번역본을 별도 테이블(problem_translations)에 적재한다.
+
+기본 설계:
+- source 테이블: problems (title/content/input_format/output_format)
+- target 테이블: problem_translations (problem_id + language_code unique)
+- source_hash 비교로 변경 없는 문제는 건너뛰어 재실행(idempotent) 가능
+- AWS Translate 기반 번역 (EC2 IAM Role 환경 권장)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+psycopg = None
+boto3 = None
+
+# 제목 번역 예외/보정 사전 (필요 시 점진적으로 확장)
+TITLE_OVERRIDES = {
+    "GCD Sum": "최대공약수 합",
+    "BCPC": "BCPC",
+    "1-3-5": "1-3-5",
+}
+
+
+PROTECTED_SEGMENT_PATTERN = re.compile(
+    r"```[\s\S]*?```|\$\$[\s\S]*?\$\$|(?<!\$)\$(?!\$)(?:\\.|[^$\\])+(?<!\\)\$(?!\$)",
+    re.MULTILINE,
+)
+
+
+@dataclass
+class ProblemRow:
+    problem_id: int
+    title: str
+    content: str
+    input_format: str | None
+    output_format: str | None
+
+
+def ensure_psycopg() -> None:
+    global psycopg
+    if psycopg is not None:
+        return
+    try:
+        import psycopg as _psycopg
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(
+            "psycopg is required for DB write. Install with: pip install 'psycopg[binary]' boto3"
+        ) from exc
+    psycopg = _psycopg
+
+
+def ensure_boto3() -> None:
+    global boto3
+    if boto3 is not None:
+        return
+    try:
+        import boto3 as _boto3
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit("boto3 is required. Install with: pip install boto3") from exc
+    boto3 = _boto3
+
+
+def default_dsn() -> str:
+    host = os.getenv("DB_HOST", os.getenv("RDS_HOST", "localhost"))
+    port = os.getenv("DB_PORT", "5432")
+    name = os.getenv("DB_NAME", "back")
+    user = os.getenv("DB_USERNAME", "back")
+    password = os.getenv("DB_PASSWORD")
+    if not password:
+        raise ValueError(
+            "DB_PASSWORD is required. Export .env or pass --dsn/LOAD_DSN."
+        )
+    return f"postgresql://{user}:{password}@{host}:{port}/{name}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Translate problems fields into Korean and upsert into problem_translations."
+    )
+    parser.add_argument("--dsn", default=os.getenv("LOAD_DSN"), help="PostgreSQL DSN")
+    parser.add_argument("--offset", type=int, default=0)
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--chunk-size", type=int, default=50)
+    parser.add_argument("--language-code", default="ko")
+    parser.add_argument("--source-lang", default="en")
+    parser.add_argument(
+        "--aws-region", default=os.getenv("AWS_REGION", "ap-northeast-2")
+    )
+    parser.add_argument("--max-bytes-per-request", type=int, default=9000)
+    parser.add_argument(
+        "--request-interval-ms",
+        type=int,
+        default=120,
+        help="Translate API call interval in milliseconds",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=3,
+        help="Max retries per translate request",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-translate even when source hash is unchanged",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def ensure_schema(cur: Any) -> None:
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS problem_translations (
+            id BIGSERIAL PRIMARY KEY,
+            problem_id BIGINT NOT NULL REFERENCES problems(id) ON DELETE CASCADE,
+            language_code VARCHAR(10) NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            input_format TEXT,
+            output_format TEXT,
+            source_hash VARCHAR(64) NOT NULL,
+            provider VARCHAR(50) NOT NULL,
+            translated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            modified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_problem_translations_problem_lang UNIQUE (problem_id, language_code)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_problem_translations_lang_problem
+        ON problem_translations (language_code, problem_id)
+        """
+    )
+
+
+def fetch_problem_rows(cur: Any, offset: int, limit: int) -> list[ProblemRow]:
+    cur.execute(
+        """
+        SELECT id, title, content, input_format, output_format
+        FROM problems
+        ORDER BY id
+        OFFSET %s LIMIT %s
+        """,
+        (offset, limit),
+    )
+    rows: list[ProblemRow] = []
+    for row in cur.fetchall():
+        rows.append(
+            ProblemRow(
+                problem_id=int(row[0]),
+                title=row[1] or "",
+                content=row[2] or "",
+                input_format=row[3],
+                output_format=row[4],
+            )
+        )
+    return rows
+
+
+def fetch_existing_hashes(
+    cur: Any, problem_ids: list[int], language_code: str
+) -> dict[int, str]:
+    if not problem_ids:
+        return {}
+    cur.execute(
+        """
+        SELECT problem_id, source_hash
+        FROM problem_translations
+        WHERE language_code = %s
+          AND problem_id = ANY(%s)
+        """,
+        (language_code, problem_ids),
+    )
+    return {int(problem_id): source_hash for problem_id, source_hash in cur.fetchall()}
+
+
+def source_hash_for(problem: ProblemRow) -> str:
+    payload = {
+        "title": problem.title or "",
+        "content": problem.content or "",
+        "input_format": problem.input_format or "",
+        "output_format": problem.output_format or "",
+    }
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def split_text_by_bytes(text: str, max_bytes: int) -> list[str]:
+    if not text:
+        return [""]
+    if len(text.encode("utf-8")) <= max_bytes:
+        return [text]
+
+    chunks: list[str] = []
+    parts = re.split(r"(\n\n+)", text)
+    current = ""
+    for part in parts:
+        if not part:
+            continue
+
+        candidate = current + part
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            current = candidate
+            continue
+
+        if current:
+            chunks.append(current)
+            current = ""
+
+        # 단일 part가 너무 긴 경우 강제로 문자 단위 분할
+        if len(part.encode("utf-8")) > max_bytes:
+            segment = ""
+            for ch in part:
+                test = segment + ch
+                if len(test.encode("utf-8")) > max_bytes:
+                    if segment:
+                        chunks.append(segment)
+                    segment = ch
+                else:
+                    segment = test
+            if segment:
+                current = segment
+        else:
+            current = part
+
+    if current:
+        chunks.append(current)
+
+    return chunks
+
+
+def translate_text_chunks(
+    translator: "AwsTranslateClient", text: str, max_bytes_per_request: int
+) -> str:
+    if not text:
+        return text
+    pieces = split_text_by_bytes(text, max_bytes_per_request)
+    translated = [translator.translate(piece) for piece in pieces]
+    return "".join(translated)
+
+
+def translate_with_protected_segments(
+    translator: "AwsTranslateClient", text: str, max_bytes_per_request: int
+) -> str:
+    """
+    수식/코드 구간은 원문 그대로 유지하고 일반 텍스트만 번역한다.
+    placeholder 치환 방식보다 안전하게 수식 훼손을 방지한다.
+    """
+    result: list[str] = []
+    cursor = 0
+
+    for match in PROTECTED_SEGMENT_PATTERN.finditer(text):
+        if match.start() > cursor:
+            plain = text[cursor : match.start()]
+            result.append(translate_text_chunks(translator, plain, max_bytes_per_request))
+        result.append(match.group(0))
+        cursor = match.end()
+
+    if cursor < len(text):
+        tail = text[cursor:]
+        result.append(translate_text_chunks(translator, tail, max_bytes_per_request))
+
+    return "".join(result)
+
+
+def normalize_translated_text(text: str) -> str:
+    if not text:
+        return text
+
+    # ".그는" / "?이것" 형태를 ". 그는" / "? 이것"으로 보정
+    normalized = re.sub(r"([.!?])([가-힣A-Za-z])", r"\1 \2", text)
+    # 닫는 괄호/따옴표 뒤 공백이 사라진 경우 보정
+    normalized = re.sub(r"([)\]\"'])([가-힣A-Za-z])", r"\1 \2", normalized)
+    # 과도한 공백 축소
+    normalized = re.sub(r"[ \t]{2,}", " ", normalized)
+
+    lines = [line.strip() for line in normalized.splitlines()]
+    normalized = "\n".join(lines)
+    normalized = re.sub(r"\n{3,}", "\n\n", normalized)
+    return normalized.strip()
+
+
+def normalize_translated_title(original_title: str, translated_title: str) -> str:
+    original = (original_title or "").strip()
+    translated = (translated_title or "").strip()
+    if not translated:
+        return original
+
+    if original in TITLE_OVERRIDES:
+        return TITLE_OVERRIDES[original]
+
+    # 대회 약어/코드 형태는 원문 유지가 자연스럽다.
+    if re.fullmatch(r"[A-Z0-9][A-Z0-9\- ]{1,20}", original):
+        return original
+
+    return normalize_translated_text(translated)
+
+
+class AwsTranslateClient:
+    def __init__(
+        self,
+        region: str,
+        source_lang: str,
+        target_lang: str,
+        max_retries: int,
+        request_interval_ms: int,
+    ) -> None:
+        ensure_boto3()
+        self.client = boto3.client("translate", region_name=region)
+        self.source_lang = source_lang
+        self.target_lang = target_lang
+        self.max_retries = max_retries
+        self.request_interval_ms = request_interval_ms
+
+    def translate(self, text: str) -> str:
+        if not text:
+            return text
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = self.client.translate_text(
+                    Text=text,
+                    SourceLanguageCode=self.source_lang,
+                    TargetLanguageCode=self.target_lang,
+                )
+                result = response.get("TranslatedText")
+                if isinstance(result, str) and result.strip():
+                    if self.request_interval_ms > 0:
+                        time.sleep(self.request_interval_ms / 1000.0)
+                    return result
+                raise RuntimeError("AWS Translate returned empty TranslatedText")
+            except Exception:
+                if attempt >= self.max_retries:
+                    raise
+                time.sleep(min(2.0, 0.4 * attempt))
+        return text
+
+
+def translate_field(
+    translator: AwsTranslateClient,
+    text: str | None,
+    max_bytes_per_request: int,
+    *,
+    protect_segments: bool,
+) -> str | None:
+    if text is None:
+        return None
+    if not text.strip():
+        return text
+
+    if protect_segments:
+        translated = translate_with_protected_segments(
+            translator, text, max_bytes_per_request
+        )
+        return normalize_translated_text(translated)
+
+    translated = translate_text_chunks(translator, text, max_bytes_per_request)
+    return normalize_translated_text(translated)
+
+
+def upsert_translation(
+    cur: Any,
+    problem_id: int,
+    language_code: str,
+    title: str,
+    content: str,
+    input_format: str | None,
+    output_format: str | None,
+    src_hash: str,
+    provider: str,
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO problem_translations (
+            problem_id,
+            language_code,
+            title,
+            content,
+            input_format,
+            output_format,
+            source_hash,
+            provider
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (problem_id, language_code) DO UPDATE SET
+            title = EXCLUDED.title,
+            content = EXCLUDED.content,
+            input_format = EXCLUDED.input_format,
+            output_format = EXCLUDED.output_format,
+            source_hash = EXCLUDED.source_hash,
+            provider = EXCLUDED.provider,
+            translated_at = NOW(),
+            modified_at = NOW()
+        """,
+        (
+            problem_id,
+            language_code,
+            title,
+            content,
+            input_format,
+            output_format,
+            src_hash,
+            provider,
+        ),
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.dsn:
+        try:
+            args.dsn = default_dsn()
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+
+    stats = {
+        "rows_fetched": 0,
+        "translated": 0,
+        "skipped_unchanged": 0,
+        "failed": 0,
+    }
+
+    if args.dry_run:
+        print("dry-run mode: no DB write")
+
+    conn = None
+    cur = None
+    translator: AwsTranslateClient | None = None
+
+    try:
+        ensure_psycopg()
+        conn = psycopg.connect(args.dsn)
+        conn.autocommit = False
+        cur = conn.cursor()
+        ensure_schema(cur)
+        conn.commit()
+
+        translator = AwsTranslateClient(
+            region=args.aws_region,
+            source_lang=args.source_lang,
+            target_lang=args.language_code,
+            max_retries=args.max_retries,
+            request_interval_ms=args.request_interval_ms,
+        )
+
+        remaining = args.limit
+        next_offset = args.offset
+
+        while remaining > 0:
+            fetch_size = min(args.chunk_size, remaining)
+            rows = fetch_problem_rows(cur, next_offset, fetch_size)
+            if not rows:
+                break
+
+            stats["rows_fetched"] += len(rows)
+            problem_ids = [row.problem_id for row in rows]
+            existing_hashes = fetch_existing_hashes(cur, problem_ids, args.language_code)
+
+            for row in rows:
+                src_hash = source_hash_for(row)
+                old_hash = existing_hashes.get(row.problem_id)
+                if not args.force and old_hash == src_hash:
+                    stats["skipped_unchanged"] += 1
+                    continue
+
+                try:
+                    t_title = translate_field(
+                        translator,
+                        row.title,
+                        args.max_bytes_per_request,
+                        protect_segments=False,
+                    )
+                    t_title = normalize_translated_title(row.title, t_title or row.title)
+                    t_content = translate_field(
+                        translator,
+                        row.content,
+                        args.max_bytes_per_request,
+                        protect_segments=True,
+                    )
+                    t_input = translate_field(
+                        translator,
+                        row.input_format,
+                        args.max_bytes_per_request,
+                        protect_segments=True,
+                    )
+                    t_output = translate_field(
+                        translator,
+                        row.output_format,
+                        args.max_bytes_per_request,
+                        protect_segments=True,
+                    )
+
+                    if args.dry_run:
+                        stats["translated"] += 1
+                        continue
+
+                    upsert_translation(
+                        cur,
+                        problem_id=row.problem_id,
+                        language_code=args.language_code,
+                        title=t_title or row.title,
+                        content=t_content or row.content,
+                        input_format=t_input,
+                        output_format=t_output,
+                        src_hash=src_hash,
+                        provider=f"aws-translate:{args.aws_region}:mask-v1",
+                    )
+                    stats["translated"] += 1
+                except Exception as exc:
+                    stats["failed"] += 1
+                    print(
+                        f"translate failed: problem_id={row.problem_id} reason={exc}",
+                        file=sys.stderr,
+                    )
+
+            if not args.dry_run:
+                conn.commit()
+
+            next_offset += len(rows)
+            remaining -= len(rows)
+
+    except Exception:
+        if conn is not None:
+            conn.rollback()
+        raise
+    finally:
+        if cur is not None:
+            cur.close()
+        if conn is not None:
+            conn.close()
+
+    now = datetime.now().isoformat(timespec="seconds")
+    print(f"[{now}] translation summary")
+    for key, value in stats.items():
+        print(f"- {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/translate_problems_ko.py
+++ b/scripts/translate_problems_ko.py
@@ -6,7 +6,10 @@
 - source 테이블: problems (title/content/input_format/output_format)
 - target 테이블: problem_translations (problem_id + language_code unique)
 - source_hash 비교로 변경 없는 문제는 건너뛰어 재실행(idempotent) 가능
-- AWS Translate 기반 번역 (EC2 IAM Role 환경 권장)
+
+현재 번역 방식:
+- deep-translator의 GoogleTranslator 사용 (비공식 Google 번역 연동)
+- 수식/코드 구간은 보호하고 일반 텍스트만 번역
 """
 
 from __future__ import annotations
@@ -23,18 +26,21 @@ from datetime import datetime
 from typing import Any
 
 psycopg = None
-boto3 = None
+OpenAI = None
 
-# 제목 번역 예외/보정 사전 (필요 시 점진적으로 확장)
 TITLE_OVERRIDES = {
     "GCD Sum": "최대공약수 합",
     "BCPC": "BCPC",
     "1-3-5": "1-3-5",
 }
 
-
+# 긴 패턴부터 먼저 보호
 PROTECTED_SEGMENT_PATTERN = re.compile(
-    r"```[\s\S]*?```|\$\$[\s\S]*?\$\$|(?<!\$)\$(?!\$)(?:\\.|[^$\\])+(?<!\\)\$(?!\$)",
+    r"```[\s\S]*?```"                      # fenced code block
+    r"|`[^`\n]+`"                         # inline code
+    r"|\$\$\$[\s\S]*?\$\$\$"              # Codeforces-style triple-dollar math
+    r"|\$\$[\s\S]*?\$\$"                  # block math
+    r"|(?<!\$)\$(?!\$)(?:\\.|[^$\\])+(?<!\\)\$(?!\$)",  # inline $...$
     re.MULTILINE,
 )
 
@@ -54,22 +60,24 @@ def ensure_psycopg() -> None:
         return
     try:
         import psycopg as _psycopg
-    except ImportError as exc:  # pragma: no cover
+    except ImportError as exc:
         raise SystemExit(
-            "psycopg is required for DB write. Install with: pip install 'psycopg[binary]' boto3"
+            "psycopg is required for DB write. Install with: pip install 'psycopg[binary]' deep-translator"
         ) from exc
     psycopg = _psycopg
 
 
-def ensure_boto3() -> None:
-    global boto3
-    if boto3 is not None:
+def ensure_openai() -> None:
+    global OpenAI
+    if OpenAI is not None:
         return
     try:
-        import boto3 as _boto3
-    except ImportError as exc:  # pragma: no cover
-        raise SystemExit("boto3 is required. Install with: pip install boto3") from exc
-    boto3 = _boto3
+        from openai import OpenAI as _OpenAI
+    except ImportError as exc:
+        raise SystemExit(
+            "openai is required. Install with: pip install openai"
+        ) from exc
+    OpenAI = _OpenAI
 
 
 def default_dsn() -> str:
@@ -79,9 +87,7 @@ def default_dsn() -> str:
     user = os.getenv("DB_USERNAME", "back")
     password = os.getenv("DB_PASSWORD")
     if not password:
-        raise ValueError(
-            "DB_PASSWORD is required. Export .env or pass --dsn/LOAD_DSN."
-        )
+        raise ValueError("DB_PASSWORD is required. Export .env or pass --dsn/LOAD_DSN.")
     return f"postgresql://{user}:{password}@{host}:{port}/{name}"
 
 
@@ -96,14 +102,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--language-code", default="ko")
     parser.add_argument("--source-lang", default="en")
     parser.add_argument(
-        "--aws-region", default=os.getenv("AWS_REGION", "ap-northeast-2")
+        "--model",
+        default=os.getenv("OPENAI_TRANSLATE_MODEL", "gpt-5-nano"),
+        help="OpenAI model name",
     )
-    parser.add_argument("--max-bytes-per-request", type=int, default=9000)
+    parser.add_argument(
+        "--max-bytes-per-request",
+        type=int,
+        default=4500,
+        help="Translate request chunk size in UTF-8 bytes",
+    )
     parser.add_argument(
         "--request-interval-ms",
         type=int,
-        default=120,
-        help="Translate API call interval in milliseconds",
+        default=250,
+        help="Translate request interval in milliseconds",
     )
     parser.add_argument(
         "--max-retries",
@@ -124,8 +137,8 @@ def ensure_schema(cur: Any) -> None:
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS problem_translations (
-            id BIGSERIAL PRIMARY KEY,
-            problem_id BIGINT NOT NULL REFERENCES problems(id) ON DELETE CASCADE,
+                                                            id BIGSERIAL PRIMARY KEY,
+                                                            problem_id BIGINT NOT NULL REFERENCES problems(id) ON DELETE CASCADE,
             language_code VARCHAR(10) NOT NULL,
             title TEXT NOT NULL,
             content TEXT NOT NULL,
@@ -137,13 +150,13 @@ def ensure_schema(cur: Any) -> None:
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             modified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             CONSTRAINT uq_problem_translations_problem_lang UNIQUE (problem_id, language_code)
-        )
+            )
         """
     )
     cur.execute(
         """
         CREATE INDEX IF NOT EXISTS idx_problem_translations_lang_problem
-        ON problem_translations (language_code, problem_id)
+            ON problem_translations (language_code, problem_id)
         """
     )
 
@@ -173,7 +186,7 @@ def fetch_problem_rows(cur: Any, offset: int, limit: int) -> list[ProblemRow]:
 
 
 def fetch_existing_hashes(
-    cur: Any, problem_ids: list[int], language_code: str
+        cur: Any, problem_ids: list[int], language_code: str
 ) -> dict[int, str]:
     if not problem_ids:
         return {}
@@ -209,6 +222,7 @@ def split_text_by_bytes(text: str, max_bytes: int) -> list[str]:
     chunks: list[str] = []
     parts = re.split(r"(\n\n+)", text)
     current = ""
+
     for part in parts:
         if not part:
             continue
@@ -222,7 +236,6 @@ def split_text_by_bytes(text: str, max_bytes: int) -> list[str]:
             chunks.append(current)
             current = ""
 
-        # 단일 part가 너무 긴 경우 강제로 문자 단위 분할
         if len(part.encode("utf-8")) > max_bytes:
             segment = ""
             for ch in part:
@@ -245,7 +258,7 @@ def split_text_by_bytes(text: str, max_bytes: int) -> list[str]:
 
 
 def translate_text_chunks(
-    translator: "AwsTranslateClient", text: str, max_bytes_per_request: int
+        translator: "OpenAITranslateClient", text: str, max_bytes_per_request: int
 ) -> str:
     if not text:
         return text
@@ -255,18 +268,17 @@ def translate_text_chunks(
 
 
 def translate_with_protected_segments(
-    translator: "AwsTranslateClient", text: str, max_bytes_per_request: int
+        translator: "OpenAITranslateClient", text: str, max_bytes_per_request: int
 ) -> str:
     """
     수식/코드 구간은 원문 그대로 유지하고 일반 텍스트만 번역한다.
-    placeholder 치환 방식보다 안전하게 수식 훼손을 방지한다.
     """
     result: list[str] = []
     cursor = 0
 
     for match in PROTECTED_SEGMENT_PATTERN.finditer(text):
         if match.start() > cursor:
-            plain = text[cursor : match.start()]
+            plain = text[cursor:match.start()]
             result.append(translate_text_chunks(translator, plain, max_bytes_per_request))
         result.append(match.group(0))
         cursor = match.end()
@@ -282,48 +294,47 @@ def normalize_translated_text(text: str) -> str:
     if not text:
         return text
 
-    # ".그는" / "?이것" 형태를 ". 그는" / "? 이것"으로 보정
-    normalized = re.sub(r"([.!?])([가-힣A-Za-z])", r"\1 \2", text)
-    # 닫는 괄호/따옴표 뒤 공백이 사라진 경우 보정
+    normalized = text
+    normalized = re.sub(r"([.!?])([가-힣A-Za-z])", r"\1 \2", normalized)
     normalized = re.sub(r"([)\]\"'])([가-힣A-Za-z])", r"\1 \2", normalized)
-    # 과도한 공백 축소
     normalized = re.sub(r"[ \t]{2,}", " ", normalized)
 
     lines = [line.strip() for line in normalized.splitlines()]
     normalized = "\n".join(lines)
     normalized = re.sub(r"\n{3,}", "\n\n", normalized)
+
     return normalized.strip()
 
 
 def normalize_translated_title(original_title: str, translated_title: str) -> str:
     original = (original_title or "").strip()
     translated = (translated_title or "").strip()
+
     if not translated:
         return original
 
     if original in TITLE_OVERRIDES:
         return TITLE_OVERRIDES[original]
 
-    # 대회 약어/코드 형태는 원문 유지가 자연스럽다.
-    if re.fullmatch(r"[A-Z0-9][A-Z0-9\- ]{1,20}", original):
+    if re.fullmatch(r"[A-Z0-9][A-Z0-9 -]{1,20}", original):
         return original
 
     return normalize_translated_text(translated)
 
-
-class AwsTranslateClient:
+class OpenAITranslateClient:
     def __init__(
-        self,
-        region: str,
-        source_lang: str,
-        target_lang: str,
-        max_retries: int,
-        request_interval_ms: int,
+            self,
+            source_lang: str,
+            target_lang: str,
+            model: str,
+            max_retries: int,
+            request_interval_ms: int,
     ) -> None:
-        ensure_boto3()
-        self.client = boto3.client("translate", region_name=region)
+        ensure_openai()
+        self.client = OpenAI()
         self.source_lang = source_lang
         self.target_lang = target_lang
+        self.model = model
         self.max_retries = max_retries
         self.request_interval_ms = request_interval_ms
 
@@ -331,32 +342,43 @@ class AwsTranslateClient:
         if not text:
             return text
 
+        system_prompt = (
+            f"You are a professional translator. "
+            f"Translate the user's text from {self.source_lang} to {self.target_lang}. "
+            f"Preserve meaning faithfully. "
+            f"Do not add explanations, notes, markdown fences, or commentary. "
+            f"Return only the translated text."
+        )
+
         for attempt in range(1, self.max_retries + 1):
             try:
-                response = self.client.translate_text(
-                    Text=text,
-                    SourceLanguageCode=self.source_lang,
-                    TargetLanguageCode=self.target_lang,
+                response = self.client.responses.create(
+                    model=self.model,
+                    input=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": text},
+                    ],
                 )
-                result = response.get("TranslatedText")
+                result = response.output_text
                 if isinstance(result, str) and result.strip():
                     if self.request_interval_ms > 0:
                         time.sleep(self.request_interval_ms / 1000.0)
                     return result
-                raise RuntimeError("AWS Translate returned empty TranslatedText")
+                raise RuntimeError("OpenAI returned empty output_text")
             except Exception:
                 if attempt >= self.max_retries:
                     raise
-                time.sleep(min(2.0, 0.4 * attempt))
+                time.sleep(min(2.0, 0.5 * attempt))
+
         return text
 
 
 def translate_field(
-    translator: AwsTranslateClient,
-    text: str | None,
-    max_bytes_per_request: int,
-    *,
-    protect_segments: bool,
+        translator: OpenAITranslateClient,
+        text: str | None,
+        max_bytes_per_request: int,
+        *,
+        protect_segments: bool,
 ) -> str | None:
     if text is None:
         return None
@@ -374,15 +396,15 @@ def translate_field(
 
 
 def upsert_translation(
-    cur: Any,
-    problem_id: int,
-    language_code: str,
-    title: str,
-    content: str,
-    input_format: str | None,
-    output_format: str | None,
-    src_hash: str,
-    provider: str,
+        cur: Any,
+        problem_id: int,
+        language_code: str,
+        title: str,
+        content: str,
+        input_format: str | None,
+        output_format: str | None,
+        src_hash: str,
+        provider: str,
 ) -> None:
     cur.execute(
         """
@@ -397,15 +419,15 @@ def upsert_translation(
             provider
         )
         VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-        ON CONFLICT (problem_id, language_code) DO UPDATE SET
+            ON CONFLICT (problem_id, language_code) DO UPDATE SET
             title = EXCLUDED.title,
-            content = EXCLUDED.content,
-            input_format = EXCLUDED.input_format,
-            output_format = EXCLUDED.output_format,
-            source_hash = EXCLUDED.source_hash,
-            provider = EXCLUDED.provider,
-            translated_at = NOW(),
-            modified_at = NOW()
+                                                           content = EXCLUDED.content,
+                                                           input_format = EXCLUDED.input_format,
+                                                           output_format = EXCLUDED.output_format,
+                                                           source_hash = EXCLUDED.source_hash,
+                                                           provider = EXCLUDED.provider,
+                                                           translated_at = NOW(),
+                                                           modified_at = NOW()
         """,
         (
             problem_id,
@@ -441,7 +463,7 @@ def main() -> int:
 
     conn = None
     cur = None
-    translator: AwsTranslateClient | None = None
+    translator: OpenAITranslateClient | None = None
 
     try:
         ensure_psycopg()
@@ -451,10 +473,10 @@ def main() -> int:
         ensure_schema(cur)
         conn.commit()
 
-        translator = AwsTranslateClient(
-            region=args.aws_region,
+        translator = OpenAITranslateClient(
             source_lang=args.source_lang,
             target_lang=args.language_code,
+            model=args.model,
             max_retries=args.max_retries,
             request_interval_ms=args.request_interval_ms,
         )
@@ -487,6 +509,7 @@ def main() -> int:
                         protect_segments=False,
                     )
                     t_title = normalize_translated_title(row.title, t_title or row.title)
+
                     t_content = translate_field(
                         translator,
                         row.content,
@@ -519,7 +542,7 @@ def main() -> int:
                         input_format=t_input,
                         output_format=t_output,
                         src_hash=src_hash,
-                        provider=f"aws-translate:{args.aws_region}:mask-v1",
+                        provider=f"openai:{args.model}:v1",
                     )
                     stats["translated"] += 1
                 except Exception as exc:

--- a/src/main/java/com/back/domain/problem/problem/controller/ProblemController.java
+++ b/src/main/java/com/back/domain/problem/problem/controller/ProblemController.java
@@ -28,9 +28,7 @@ public class ProblemController {
 
     @GetMapping("/{problemId}")
     public ProblemDetailResponse getProblem(
-            @PathVariable("problemId") Long problemId,
-            @RequestParam(value = "lang", required = false) String lang
-    ) {
+            @PathVariable("problemId") Long problemId, @RequestParam(value = "lang", required = false) String lang) {
         return problemService.getProblem(problemId, lang);
     }
 }

--- a/src/main/java/com/back/domain/problem/problem/controller/ProblemController.java
+++ b/src/main/java/com/back/domain/problem/problem/controller/ProblemController.java
@@ -27,7 +27,10 @@ public class ProblemController {
     }
 
     @GetMapping("/{problemId}")
-    public ProblemDetailResponse getProblem(@PathVariable("problemId") Long problemId) {
-        return problemService.getProblem(problemId);
+    public ProblemDetailResponse getProblem(
+            @PathVariable("problemId") Long problemId,
+            @RequestParam(value = "lang", required = false) String lang
+    ) {
+        return problemService.getProblem(problemId, lang);
     }
 }

--- a/src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java
@@ -40,23 +40,13 @@ public record ProblemDetailResponse(
             List<SampleCase> sampleCases) {
         return new ProblemDetailResponse(
                 problem.getId(),
-                getTranslatedOrOriginal(
-                        translation != null ? translation.getTitle() : null,
-                        problem.getTitle()
-                ),
+                getTranslatedOrOriginal(translation != null ? translation.getTitle() : null, problem.getTitle()),
                 problem.getDifficulty().name(),
+                getTranslatedOrOriginal(translation != null ? translation.getContent() : null, problem.getContent()),
                 getTranslatedOrOriginal(
-                        translation != null ? translation.getContent() : null,
-                        problem.getContent()
-                ),
+                        translation != null ? translation.getInputFormat() : null, problem.getInputFormat()),
                 getTranslatedOrOriginal(
-                        translation != null ? translation.getInputFormat() : null,
-                        problem.getInputFormat()
-                ),
-                getTranslatedOrOriginal(
-                        translation != null ? translation.getOutputFormat() : null,
-                        problem.getOutputFormat()
-                ),
+                        translation != null ? translation.getOutputFormat() : null, problem.getOutputFormat()),
                 problem.getTimeLimitMs(),
                 problem.getMemoryLimitMb(),
                 language,

--- a/src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/ProblemDetailResponse.java
@@ -3,6 +3,7 @@ package com.back.domain.problem.problem.dto;
 import java.util.List;
 
 import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.translation.entity.ProblemTranslation;
 
 public record ProblemDetailResponse(
         Long problemId,
@@ -13,6 +14,7 @@ public record ProblemDetailResponse(
         String outputFormat,
         Long timeLimitMs,
         Long memoryLimitMb,
+        String language,
         // 문제 화면에서 언어 선택 드롭다운을 구성하기 위한 지원 언어 목록
         List<String> supportedLanguages,
         // 언어 선택 초기값(없으면 프론트에서 첫 번째 언어를 fallback으로 사용)
@@ -30,22 +32,44 @@ public record ProblemDetailResponse(
 
     public static ProblemDetailResponse from(
             Problem problem,
+            ProblemTranslation translation,
+            String language,
             List<String> supportedLanguages,
             String defaultLanguage,
             List<StarterCode> starterCodes,
             List<SampleCase> sampleCases) {
         return new ProblemDetailResponse(
                 problem.getId(),
-                problem.getTitle(),
+                getTranslatedOrOriginal(
+                        translation != null ? translation.getTitle() : null,
+                        problem.getTitle()
+                ),
                 problem.getDifficulty().name(),
-                problem.getContent(),
-                problem.getInputFormat(),
-                problem.getOutputFormat(),
+                getTranslatedOrOriginal(
+                        translation != null ? translation.getContent() : null,
+                        problem.getContent()
+                ),
+                getTranslatedOrOriginal(
+                        translation != null ? translation.getInputFormat() : null,
+                        problem.getInputFormat()
+                ),
+                getTranslatedOrOriginal(
+                        translation != null ? translation.getOutputFormat() : null,
+                        problem.getOutputFormat()
+                ),
                 problem.getTimeLimitMs(),
                 problem.getMemoryLimitMb(),
+                language,
                 supportedLanguages,
                 defaultLanguage,
                 starterCodes,
                 sampleCases);
+    }
+
+    private static String getTranslatedOrOriginal(String translatedValue, String originalValue) {
+        if (translatedValue == null || translatedValue.isBlank()) {
+            return originalValue;
+        }
+        return translatedValue;
     }
 }

--- a/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
+++ b/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
@@ -2,6 +2,8 @@ package com.back.domain.problem.problem.service;
 
 import java.util.List;
 
+import com.back.domain.problem.translation.entity.ProblemTranslation;
+import com.back.domain.problem.translation.repository.ProblemTranslationRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -28,6 +30,7 @@ public class ProblemService {
 
     private final ProblemRepository problemRepository;
     private final ProblemLanguageProfileRepository problemLanguageProfileRepository;
+    private final ProblemTranslationRepository problemTranslationRepository;
 
     public ProblemListResponse getProblems(int page, int size) {
         if (page < 0) {
@@ -43,7 +46,7 @@ public class ProblemService {
         return ProblemListResponse.from(problemPage);
     }
 
-    public ProblemDetailResponse getProblem(Long problemId) {
+    public ProblemDetailResponse getProblem(Long problemId, String lang) {
         if (problemId == null) {
             throw new ServiceException("400-1", "문제 ID는 필수입니다.");
         }
@@ -52,16 +55,16 @@ public class ProblemService {
                 .findById(problemId)
                 .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 문제입니다."));
 
+        ProblemTranslation translation = findTranslationIfNeeded(problemId, lang);
+
         List<ProblemLanguageProfile> languageProfiles =
                 problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(problemId);
 
-        // 언어 프로필을 기반으로 상세 화면의 언어 목록을 구성한다.
         List<String> supportedLanguages = languageProfiles.stream()
                 .map(ProblemLanguageProfile::getLanguageCode)
                 .distinct()
                 .toList();
 
-        // isDefault=true를 우선 사용하고, 없으면 첫 번째 언어를 기본값으로 선택한다.
         String defaultLanguage = languageProfiles.stream()
                 .filter(profile -> Boolean.TRUE.equals(profile.getIsDefault()))
                 .findFirst()
@@ -69,19 +72,48 @@ public class ProblemService {
                 .or(() -> languageProfiles.stream().findFirst().map(ProblemLanguageProfile::getLanguageCode))
                 .orElse(null);
 
-        // 프론트 에디터에서 언어 전환 시 바로 반영할 starter code 목록
         List<ProblemDetailResponse.StarterCode> starterCodes = languageProfiles.stream()
                 .map(profile ->
                         new ProblemDetailResponse.StarterCode(profile.getLanguageCode(), profile.getStarterCode()))
                 .toList();
 
-        // 채점용 hidden 케이스는 제외하고, sample 케이스만 노출한다.
         List<ProblemDetailResponse.SampleCase> sampleCases = problem.getTestCases().stream()
                 .filter(tc -> Boolean.TRUE.equals(tc.getIsSample()))
                 .map(this::toSampleCase)
                 .toList();
 
-        return ProblemDetailResponse.from(problem, supportedLanguages, defaultLanguage, starterCodes, sampleCases);
+        String responseLanguage = resolveResponseLanguage(lang, translation);
+
+        return ProblemDetailResponse.from(
+                problem,
+                translation,
+                responseLanguage,
+                supportedLanguages,
+                defaultLanguage,
+                starterCodes,
+                sampleCases
+        );
+    }
+
+    private ProblemTranslation findTranslationIfNeeded(Long problemId, String lang) {
+        if (!isKorean(lang)) {
+            return null;
+        }
+
+        return problemTranslationRepository
+                .findByProblem_IdAndLanguageCode(problemId, "ko")
+                .orElse(null);
+    }
+
+    private boolean isKorean(String lang) {
+        return lang != null && lang.equalsIgnoreCase("ko");
+    }
+
+    private String resolveResponseLanguage(String lang, ProblemTranslation translation) {
+        if (isKorean(lang) && translation != null) {
+            return "ko";
+        }
+        return "en";
     }
 
     private ProblemDetailResponse.SampleCase toSampleCase(TestCase testCase) {

--- a/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
+++ b/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
@@ -2,8 +2,6 @@ package com.back.domain.problem.problem.service;
 
 import java.util.List;
 
-import com.back.domain.problem.translation.entity.ProblemTranslation;
-import com.back.domain.problem.translation.repository.ProblemTranslationRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -17,6 +15,8 @@ import com.back.domain.problem.problem.dto.ProblemListResponse;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.repository.ProblemRepository;
 import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.domain.problem.translation.entity.ProblemTranslation;
+import com.back.domain.problem.translation.repository.ProblemTranslationRepository;
 import com.back.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
@@ -85,14 +85,7 @@ public class ProblemService {
         String responseLanguage = resolveResponseLanguage(lang, translation);
 
         return ProblemDetailResponse.from(
-                problem,
-                translation,
-                responseLanguage,
-                supportedLanguages,
-                defaultLanguage,
-                starterCodes,
-                sampleCases
-        );
+                problem, translation, responseLanguage, supportedLanguages, defaultLanguage, starterCodes, sampleCases);
     }
 
     private ProblemTranslation findTranslationIfNeeded(Long problemId, String lang) {

--- a/src/main/java/com/back/domain/problem/translation/entity/ProblemTranslation.java
+++ b/src/main/java/com/back/domain/problem/translation/entity/ProblemTranslation.java
@@ -1,0 +1,54 @@
+package com.back.domain.problem.translation.entity;
+
+import java.time.OffsetDateTime;
+
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "problem_translations",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"problem_id", "language_code"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemTranslation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    @Column(name = "language_code", nullable = false, length = 10)
+    private String languageCode;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "input_format", columnDefinition = "TEXT")
+    private String inputFormat;
+
+    @Column(name = "output_format", columnDefinition = "TEXT")
+    private String outputFormat;
+
+    @Column(name = "source_hash", length = 64)
+    private String sourceHash;
+
+    @Column(name = "provider", length = 50)
+    private String provider;
+
+    @Column(name = "translated_at", nullable = false)
+    private OffsetDateTime translatedAt;
+}

--- a/src/main/java/com/back/domain/problem/translation/entity/ProblemTranslation.java
+++ b/src/main/java/com/back/domain/problem/translation/entity/ProblemTranslation.java
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime;
 
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.global.jpa.entity.BaseEntity;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,10 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(
         name = "problem_translations",
-        uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"problem_id", "language_code"})
-        }
-)
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"problem_id", "language_code"})})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProblemTranslation extends BaseEntity {

--- a/src/main/java/com/back/domain/problem/translation/repository/ProblemTranslationRepository.java
+++ b/src/main/java/com/back/domain/problem/translation/repository/ProblemTranslationRepository.java
@@ -1,0 +1,11 @@
+package com.back.domain.problem.translation.repository;
+
+import java.util.Optional;
+
+import com.back.domain.problem.translation.entity.ProblemTranslation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemTranslationRepository extends JpaRepository<ProblemTranslation, Long> {
+
+    Optional<ProblemTranslation> findByProblem_IdAndLanguageCode(Long problemId, String languageCode);
+}

--- a/src/main/java/com/back/domain/problem/translation/repository/ProblemTranslationRepository.java
+++ b/src/main/java/com/back/domain/problem/translation/repository/ProblemTranslationRepository.java
@@ -2,8 +2,9 @@ package com.back.domain.problem.translation.repository;
 
 import java.util.Optional;
 
-import com.back.domain.problem.translation.entity.ProblemTranslation;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.problem.translation.entity.ProblemTranslation;
 
 public interface ProblemTranslationRepository extends JpaRepository<ProblemTranslation, Long> {
 

--- a/src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java
@@ -50,19 +50,55 @@ class ProblemControllerTest {
                 "A+B를 출력한다.",
                 1000L,
                 256L,
+                "ko",
                 List.of("python3", "java"),
                 "python3",
                 List.of(
                         new ProblemDetailResponse.StarterCode("python3", "print('hello')"),
                         new ProblemDetailResponse.StarterCode("java", "class Main {}")),
-                List.of(new ProblemDetailResponse.SampleCase("1 2", "3")));
-        when(problemService.getProblem(1L)).thenReturn(response);
+                List.of(new ProblemDetailResponse.SampleCase("1 2", "3"))
+        );
+
+        when(problemService.getProblem(1L, "ko")).thenReturn(response);
 
         // when
-        ProblemDetailResponse actual = problemController.getProblem(1L);
+        ProblemDetailResponse actual = problemController.getProblem(1L, "ko");
 
         // then
         assertThat(actual).isEqualTo(response);
-        verify(problemService).getProblem(1L);
+        verify(problemService).getProblem(1L, "ko");
+    }
+
+    @Test
+    @DisplayName("문제 단건 조회 시 lang이 없으면 null을 서비스에 전달한다")
+    void getProblem_withoutLang_passesNullToService() {
+        // given
+        ProblemDetailResponse response = new ProblemDetailResponse(
+                1L,
+                "A + B",
+                "EASY",
+                "You are given two integers A and B.",
+                "The first line contains A and B.",
+                "Print A+B.",
+                1000L,
+                256L,
+                "en",
+                List.of("python3", "java"),
+                "python3",
+                List.of(
+                        new ProblemDetailResponse.StarterCode("python3", "print('hello')"),
+                        new ProblemDetailResponse.StarterCode("java", "class Main {}")
+                ),
+                List.of(new ProblemDetailResponse.SampleCase("1 2", "3"))
+        );
+
+        when(problemService.getProblem(1L, null)).thenReturn(response);
+
+        // when
+        ProblemDetailResponse actual = problemController.getProblem(1L, null);
+
+        // then
+        assertThat(actual).isEqualTo(response);
+        verify(problemService).getProblem(1L, null);
     }
 }

--- a/src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/back/domain/problem/problem/controller/ProblemControllerTest.java
@@ -56,8 +56,7 @@ class ProblemControllerTest {
                 List.of(
                         new ProblemDetailResponse.StarterCode("python3", "print('hello')"),
                         new ProblemDetailResponse.StarterCode("java", "class Main {}")),
-                List.of(new ProblemDetailResponse.SampleCase("1 2", "3"))
-        );
+                List.of(new ProblemDetailResponse.SampleCase("1 2", "3")));
 
         when(problemService.getProblem(1L, "ko")).thenReturn(response);
 
@@ -87,10 +86,8 @@ class ProblemControllerTest {
                 "python3",
                 List.of(
                         new ProblemDetailResponse.StarterCode("python3", "print('hello')"),
-                        new ProblemDetailResponse.StarterCode("java", "class Main {}")
-                ),
-                List.of(new ProblemDetailResponse.SampleCase("1 2", "3"))
-        );
+                        new ProblemDetailResponse.StarterCode("java", "class Main {}")),
+                List.of(new ProblemDetailResponse.SampleCase("1 2", "3")));
 
         when(problemService.getProblem(1L, null)).thenReturn(response);
 

--- a/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
@@ -24,25 +24,19 @@ import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.problem.problem.repository.ProblemRepository;
 import com.back.domain.problem.testcase.entity.TestCase;
-import com.back.global.exception.ServiceException;
 import com.back.domain.problem.translation.entity.ProblemTranslation;
 import com.back.domain.problem.translation.repository.ProblemTranslationRepository;
-
+import com.back.global.exception.ServiceException;
 
 class ProblemServiceTest {
 
     private final ProblemRepository problemRepository = mock(ProblemRepository.class);
     private final ProblemLanguageProfileRepository problemLanguageProfileRepository =
             mock(ProblemLanguageProfileRepository.class);
-    private final ProblemTranslationRepository problemTranslationRepository =
-            mock(ProblemTranslationRepository.class);
+    private final ProblemTranslationRepository problemTranslationRepository = mock(ProblemTranslationRepository.class);
 
     private final ProblemService problemService =
-            new ProblemService(
-                    problemRepository,
-                    problemLanguageProfileRepository,
-                    problemTranslationRepository
-            );
+            new ProblemService(problemRepository, problemLanguageProfileRepository, problemTranslationRepository);
 
     @Test
     @DisplayName("문제 목록 조회 시 페이지 정보와 요약 목록을 반환한다")
@@ -153,8 +147,7 @@ class ProblemServiceTest {
                 .containsExactly(
                         new ProblemDetailResponse.StarterCode("python3", "print('hello')"),
                         new ProblemDetailResponse.StarterCode("java", "class Main {}"));
-        assertThat(response.sampleCases())
-                .containsExactly(new ProblemDetailResponse.SampleCase("1 2", "3"));
+        assertThat(response.sampleCases()).containsExactly(new ProblemDetailResponse.SampleCase("1 2", "3"));
     }
 
     @Test
@@ -190,8 +183,7 @@ class ProblemServiceTest {
         when(translation.getOutputFormat()).thenReturn("A+B 값을 출력합니다.");
 
         when(problemRepository.findById(1L)).thenReturn(Optional.of(problem));
-        when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L))
-                .thenReturn(List.of(pythonProfile));
+        when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L)).thenReturn(List.of(pythonProfile));
         when(problemTranslationRepository.findByProblemIdAndLanguageCode(1L, "ko"))
                 .thenReturn(Optional.of(translation));
 
@@ -231,8 +223,7 @@ class ProblemServiceTest {
         when(pythonProfile.getIsDefault()).thenReturn(true);
 
         when(problemRepository.findById(1L)).thenReturn(Optional.of(problem));
-        when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L))
-                .thenReturn(List.of(pythonProfile));
+        when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L)).thenReturn(List.of(pythonProfile));
         when(problemTranslationRepository.findByProblemIdAndLanguageCode(1L, "ko"))
                 .thenReturn(Optional.empty());
 

--- a/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
@@ -184,7 +184,7 @@ class ProblemServiceTest {
 
         when(problemRepository.findById(1L)).thenReturn(Optional.of(problem));
         when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L)).thenReturn(List.of(pythonProfile));
-        when(problemTranslationRepository.findByProblemIdAndLanguageCode(1L, "ko"))
+        when(problemTranslationRepository.findByProblem_IdAndLanguageCode(1L, "ko"))
                 .thenReturn(Optional.of(translation));
 
         // when
@@ -224,7 +224,7 @@ class ProblemServiceTest {
 
         when(problemRepository.findById(1L)).thenReturn(Optional.of(problem));
         when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L)).thenReturn(List.of(pythonProfile));
-        when(problemTranslationRepository.findByProblemIdAndLanguageCode(1L, "ko"))
+        when(problemTranslationRepository.findByProblem_IdAndLanguageCode(1L, "ko"))
                 .thenReturn(Optional.empty());
 
         // when

--- a/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
@@ -25,14 +25,24 @@ import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.problem.problem.repository.ProblemRepository;
 import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.global.exception.ServiceException;
+import com.back.domain.problem.translation.entity.ProblemTranslation;
+import com.back.domain.problem.translation.repository.ProblemTranslationRepository;
+
 
 class ProblemServiceTest {
 
     private final ProblemRepository problemRepository = mock(ProblemRepository.class);
     private final ProblemLanguageProfileRepository problemLanguageProfileRepository =
             mock(ProblemLanguageProfileRepository.class);
+    private final ProblemTranslationRepository problemTranslationRepository =
+            mock(ProblemTranslationRepository.class);
+
     private final ProblemService problemService =
-            new ProblemService(problemRepository, problemLanguageProfileRepository);
+            new ProblemService(
+                    problemRepository,
+                    problemLanguageProfileRepository,
+                    problemTranslationRepository
+            );
 
     @Test
     @DisplayName("문제 목록 조회 시 페이지 정보와 요약 목록을 반환한다")
@@ -87,8 +97,8 @@ class ProblemServiceTest {
     }
 
     @Test
-    @DisplayName("문제 ID로 단건 조회 시 프론트 전달용 상세 정보를 반환한다")
-    void getProblem_returnsProblemDetail() {
+    @DisplayName("문제 ID로 단건 조회 시 lang이 없으면 원문 상세 정보를 반환한다")
+    void getProblem_withoutLang_returnsOriginalProblemDetail() {
         // given
         Problem problem = mock(Problem.class);
         TestCase sampleCase = mock(TestCase.class);
@@ -115,6 +125,7 @@ class ProblemServiceTest {
         when(pythonProfile.getLanguageCode()).thenReturn("python3");
         when(pythonProfile.getStarterCode()).thenReturn("print('hello')");
         when(pythonProfile.getIsDefault()).thenReturn(true);
+
         when(javaProfile.getLanguageCode()).thenReturn("java");
         when(javaProfile.getStarterCode()).thenReturn("class Main {}");
         when(javaProfile.getIsDefault()).thenReturn(false);
@@ -124,7 +135,7 @@ class ProblemServiceTest {
                 .thenReturn(List.of(pythonProfile, javaProfile));
 
         // when
-        ProblemDetailResponse response = problemService.getProblem(1L);
+        ProblemDetailResponse response = problemService.getProblem(1L, null);
 
         // then
         assertThat(response.problemId()).isEqualTo(1L);
@@ -135,13 +146,106 @@ class ProblemServiceTest {
         assertThat(response.outputFormat()).isEqualTo("A+B를 출력한다.");
         assertThat(response.timeLimitMs()).isEqualTo(1000L);
         assertThat(response.memoryLimitMb()).isEqualTo(256L);
+        assertThat(response.language()).isEqualTo("en");
         assertThat(response.supportedLanguages()).containsExactly("python3", "java");
         assertThat(response.defaultLanguage()).isEqualTo("python3");
         assertThat(response.starterCodes())
                 .containsExactly(
                         new ProblemDetailResponse.StarterCode("python3", "print('hello')"),
                         new ProblemDetailResponse.StarterCode("java", "class Main {}"));
-        assertThat(response.sampleCases()).containsExactly(new ProblemDetailResponse.SampleCase("1 2", "3"));
+        assertThat(response.sampleCases())
+                .containsExactly(new ProblemDetailResponse.SampleCase("1 2", "3"));
+    }
+
+    @Test
+    @DisplayName("문제 ID로 단건 조회 시 lang이 ko이고 번역이 있으면 번역본을 반환한다")
+    void getProblem_withKoAndTranslation_returnsTranslatedDetail() {
+        // given
+        Problem problem = mock(Problem.class);
+        ProblemTranslation translation = mock(ProblemTranslation.class);
+        TestCase sampleCase = mock(TestCase.class);
+        ProblemLanguageProfile pythonProfile = mock(ProblemLanguageProfile.class);
+
+        when(problem.getId()).thenReturn(1L);
+        when(problem.getTitle()).thenReturn("A + B");
+        when(problem.getDifficulty()).thenReturn(DifficultyLevel.EASY);
+        when(problem.getContent()).thenReturn("Solve A + B.");
+        when(problem.getInputFormat()).thenReturn("Input A and B.");
+        when(problem.getOutputFormat()).thenReturn("Print A + B.");
+        when(problem.getTimeLimitMs()).thenReturn(1000L);
+        when(problem.getMemoryLimitMb()).thenReturn(256L);
+        when(problem.getTestCases()).thenReturn(List.of(sampleCase));
+
+        when(sampleCase.getIsSample()).thenReturn(true);
+        when(sampleCase.getInput()).thenReturn("1 2");
+        when(sampleCase.getExpectedOutput()).thenReturn("3");
+
+        when(pythonProfile.getLanguageCode()).thenReturn("python3");
+        when(pythonProfile.getStarterCode()).thenReturn("print('hello')");
+        when(pythonProfile.getIsDefault()).thenReturn(true);
+
+        when(translation.getTitle()).thenReturn("A + B");
+        when(translation.getContent()).thenReturn("두 정수 A와 B의 합을 구하세요.");
+        when(translation.getInputFormat()).thenReturn("한 줄에 A와 B가 주어집니다.");
+        when(translation.getOutputFormat()).thenReturn("A+B 값을 출력합니다.");
+
+        when(problemRepository.findById(1L)).thenReturn(Optional.of(problem));
+        when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L))
+                .thenReturn(List.of(pythonProfile));
+        when(problemTranslationRepository.findByProblemIdAndLanguageCode(1L, "ko"))
+                .thenReturn(Optional.of(translation));
+
+        // when
+        ProblemDetailResponse response = problemService.getProblem(1L, "ko");
+
+        // then
+        assertThat(response.problemId()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("A + B");
+        assertThat(response.content()).isEqualTo("두 정수 A와 B의 합을 구하세요.");
+        assertThat(response.inputFormat()).isEqualTo("한 줄에 A와 B가 주어집니다.");
+        assertThat(response.outputFormat()).isEqualTo("A+B 값을 출력합니다.");
+        assertThat(response.language()).isEqualTo("ko");
+        assertThat(response.supportedLanguages()).containsExactly("python3");
+        assertThat(response.defaultLanguage()).isEqualTo("python3");
+    }
+
+    @Test
+    @DisplayName("문제 ID로 단건 조회 시 lang이 ko여도 번역이 없으면 원문을 반환한다")
+    void getProblem_withKoWithoutTranslation_returnsOriginalDetail() {
+        // given
+        Problem problem = mock(Problem.class);
+        ProblemLanguageProfile pythonProfile = mock(ProblemLanguageProfile.class);
+
+        when(problem.getId()).thenReturn(1L);
+        when(problem.getTitle()).thenReturn("A + B");
+        when(problem.getDifficulty()).thenReturn(DifficultyLevel.EASY);
+        when(problem.getContent()).thenReturn("Solve A + B.");
+        when(problem.getInputFormat()).thenReturn("Input A and B.");
+        when(problem.getOutputFormat()).thenReturn("Print A + B.");
+        when(problem.getTimeLimitMs()).thenReturn(1000L);
+        when(problem.getMemoryLimitMb()).thenReturn(256L);
+        when(problem.getTestCases()).thenReturn(List.of());
+
+        when(pythonProfile.getLanguageCode()).thenReturn("python3");
+        when(pythonProfile.getStarterCode()).thenReturn("print('hello')");
+        when(pythonProfile.getIsDefault()).thenReturn(true);
+
+        when(problemRepository.findById(1L)).thenReturn(Optional.of(problem));
+        when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L))
+                .thenReturn(List.of(pythonProfile));
+        when(problemTranslationRepository.findByProblemIdAndLanguageCode(1L, "ko"))
+                .thenReturn(Optional.empty());
+
+        // when
+        ProblemDetailResponse response = problemService.getProblem(1L, "ko");
+
+        // then
+        assertThat(response.problemId()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("A + B");
+        assertThat(response.content()).isEqualTo("Solve A + B.");
+        assertThat(response.inputFormat()).isEqualTo("Input A and B.");
+        assertThat(response.outputFormat()).isEqualTo("Print A + B.");
+        assertThat(response.language()).isEqualTo("en");
     }
 
     @Test
@@ -151,7 +255,7 @@ class ProblemServiceTest {
         when(problemRepository.findById(999L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> problemService.getProblem(999L))
+        assertThatThrownBy(() -> problemService.getProblem(999L, null))
                 .isInstanceOf(ServiceException.class)
                 .hasMessage("404-1 : 존재하지 않는 문제입니다.");
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #이슈번호
closes #65

---

## 📝 작업 내용
문제 본문 한글화를 지원하기 위해 `problem_translations` 엔티티 및 조회 로직을 추가했습니다.  
문제 상세 API에서 `lang=ko` 요청 시 번역본을 우선 조회하고, 없으면 원문을 반환하도록 구성했습니다.  
또한 문제 원문을 별도 번역 테이블에 적재할 수 있도록 OpenAI API 기반 번역 스크립트를 추가했습니다.

---

## ✅ 주요 변경 사항
1) `problem_translations` 엔티티 / 레포지토리 / 조회 로직 추가
2) 문제 상세 API에 `lang` 파라미터 지원 및 번역본 fallback 처리
3) OpenAI API 기반 문제 번역 스크립트 추가 및 번역 적재 구조 반영

---

## 🧪 테스트 결과

