### PR TITLE
[fix] 미인증 요청에 기본 403 대신 401 반환하도록 AuthenticationEntryPoint 설정

### DIFF
--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.back.global.jwt.JwtAuthenticationFilter;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -56,7 +57,14 @@ public class SecurityConfig {
                         .anyRequest()
                         .authenticated())
                 // UsernamePasswordAuthenticationFilter 앞에 JWT 필터 삽입
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                // 미인증 요청에 대해 기본 403 대신 401 반환
+                // — 프론트의 fetchBackendWithReissue가 401을 감지해 토큰 재발급 후 재시도함
+                .exceptionHandling(ex -> ex.authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"message\":\"로그인이 필요합니다.\"}");
+                }));
 
         return http.build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET:back-application-jwt-secret-key-must-be-at-least-32-bytes}
-  expiration: 360000 # 30초 (ms)
+  expiration: 3600000 # 1시간 (ms)
   refresh-expiration: 604800000 # 7일 (ms)
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #171 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #171 

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
  Spring Security는 커스텀 AuthenticationEntryPoint 없이 stateless 구성 시
  미인증 요청에 403을 반환함. 프론트의 fetchBackendWithReissue는 401만
  감지해 토큰 재발급을 시도하므로, 토큰 만료/미존재 시 재발급 로직이 동작하지
  않는 문제가 있었음.
  exceptionHandling에 AuthenticationEntryPoint를 추가해 미인증 요청에
  항상 401과 JSON 메시지를 반환하도록 수정.
+ accessToken 만료시간을 6분에서 1시간으로 수정

---

## ✅ 주요 변경 사항
1) 예) 새로운 기능 추가
2) 
3) 

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
```bash
# 예) ./gradlew test --tests "com.back.domain.email.scheduler.DdayEmailSchedulerTest"
```

- [ ] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
