### PR TITLE
[refactor] matching expire 조회를 Redis deadline index로 전환

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -24,8 +24,10 @@ public class QueueProblemPicker {
         if (queueKey == null) {
             throw new IllegalArgumentException("queueKey는 필수입니다.");
         }
-        return problemPickService.pickProblemId(
-                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+        return 1L;
+
+        //        return problemPickService.pickProblemId(
+        //                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
     }
 
     private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {

--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -24,10 +24,9 @@ public class QueueProblemPicker {
         if (queueKey == null) {
             throw new IllegalArgumentException("queueKey는 필수입니다.");
         }
-        return 1L;
 
-        //        return problemPickService.pickProblemId(
-        //                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+        return problemPickService.pickProblemId(
+                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
     }
 
     private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {

--- a/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisKeys.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/MatchingRedisKeys.java
@@ -55,24 +55,10 @@ public final class MatchingRedisKeys {
     }
 
     /**
-     * ready-check session key 를 훑을 때 사용하는 임시 패턴이다.
-     */
-    public static String matchPattern() {
-        return MATCH_PREFIX + ":*";
-    }
-
-    /**
      * user:match 인덱스 전체를 훑을 때 사용하는 패턴이다.
      */
     public static String userMatchPattern() {
         return USER_MATCH_PREFIX + ":*";
-    }
-
-    /**
-     * match session key prefix 를 외부 helper 에서 재사용할 수 있게 노출한다.
-     */
-    public static String matchPrefix() {
-        return MATCH_PREFIX + ":";
     }
 
     /**

--- a/src/main/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStore.java
@@ -1,6 +1,7 @@
 package com.back.domain.matching.queue.store.redis;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -105,12 +106,13 @@ public class RedisMatchStateStore implements MatchStateStore {
             -- MATCHING:MATCH_MARK_ACCEPT_PENDING
             local participantCount = tonumber(ARGV[3])
             redis.call('SET', KEYS[1], ARGV[1])
+            redis.call('ZADD', KEYS[2], ARGV[4], ARGV[2])
 
             for i = 1, participantCount do
-                redis.call('SET', KEYS[i + 1], ARGV[2])
+                redis.call('SET', KEYS[i + 2], ARGV[2])
             end
 
-            for i = participantCount + 2, #KEYS do
+            for i = participantCount + 3, #KEYS do
                 redis.call('DEL', KEYS[i])
             end
 
@@ -268,6 +270,7 @@ public class RedisMatchStateStore implements MatchStateStore {
 
         List<String> keys = new ArrayList<>();
         keys.add(MatchingRedisKeys.match(matchId));
+        keys.add(MatchingRedisKeys.matchDeadline());
         participantIds.forEach(participantId -> keys.add(MatchingRedisKeys.userMatch(participantId)));
         participantIds.forEach(participantId -> keys.add(MatchingRedisKeys.userQueue(participantId)));
 
@@ -276,7 +279,8 @@ public class RedisMatchStateStore implements MatchStateStore {
                 keys,
                 sessionJson,
                 String.valueOf(matchId),
-                String.valueOf(participantIds.size()));
+                String.valueOf(participantIds.size()),
+                String.valueOf(deadlineScore(deadline)));
 
         if (storedJson == null || storedJson.isBlank()) {
             throw new IllegalStateException("Redis ready-check 세션 저장 결과를 확인할 수 없습니다.");
@@ -351,6 +355,7 @@ public class RedisMatchStateStore implements MatchStateStore {
             String updatedJson = serializer.writeMatchSession(roomCreatingSession);
 
             if (compareAndSet(matchKey, currentJson, updatedJson)) {
+                removeDeadlineIndex(matchId);
                 return new RoomCreationAttempt(roomCreatingSession, true);
             }
         }
@@ -378,7 +383,7 @@ public class RedisMatchStateStore implements MatchStateStore {
     public MatchSession expire(Long matchId) {
         return updateMatchSession(matchId, currentSession -> {
             if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
-                return currentSession;
+                throw new IllegalStateException("이미 만료 처리 대상이 아닌 매치 세션입니다.");
             }
 
             return currentSession.expired();
@@ -461,31 +466,46 @@ public class RedisMatchStateStore implements MatchStateStore {
 
     @Override
     public List<Long> findExpiredAcceptPendingMatchIds(LocalDateTime now) {
-        Set<String> keys = redisTemplate.keys(MatchingRedisKeys.matchPattern());
+        Set<String> candidates = redisTemplate
+                .opsForZSet()
+                .rangeByScore(MatchingRedisKeys.matchDeadline(), Double.NEGATIVE_INFINITY, deadlineScore(now));
 
-        if (keys == null || keys.isEmpty()) {
+        if (candidates == null || candidates.isEmpty()) {
             return List.of();
         }
 
         List<Long> expiredMatchIds = new ArrayList<>();
 
-        // deadline index 도입 전까지는 match 세션 key 들을 임시로 pattern scan 하며 만료 대상을 찾는다.
-        for (String key : keys) {
-            Long matchId = extractMatchIdFromKey(key);
+        // Redis ZSET deadline index 는 후보만 좁혀주고, 최종 만료 여부는 세션 문서를 다시 읽어 확정한다.
+        for (String candidate : candidates) {
+            Long matchId = parseDeadlineMember(candidate);
             if (matchId == null) {
+                redisTemplate.opsForZSet().remove(MatchingRedisKeys.matchDeadline(), candidate);
                 continue;
             }
 
+            String key = MatchingRedisKeys.match(matchId);
             String sessionJson = redisTemplate.opsForValue().get(key);
             if (sessionJson == null || sessionJson.isBlank()) {
+                removeDeadlineIndex(matchId);
                 continue;
             }
 
             MatchSession matchSession = serializer.readMatchSession(sessionJson);
-            if (matchSession.status() == MatchSessionStatus.ACCEPT_PENDING
-                    && matchSession.deadline() != null
-                    && !matchSession.deadline().isAfter(now)) {
+            if (matchSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
+                removeDeadlineIndex(matchId);
+                continue;
+            }
+
+            if (matchSession.deadline() == null) {
+                removeDeadlineIndex(matchId);
+                continue;
+            }
+
+            if (!matchSession.deadline().isAfter(now)) {
                 expiredMatchIds.add(matchSession.matchId());
+            } else {
+                addDeadlineIndex(matchSession);
             }
         }
 
@@ -500,6 +520,7 @@ public class RedisMatchStateStore implements MatchStateStore {
 
         if (matchJson == null || matchJson.isBlank()) {
             removeUserMatchLinksByScan(matchId);
+            removeDeadlineIndex(matchId);
             return;
         }
 
@@ -509,6 +530,7 @@ public class RedisMatchStateStore implements MatchStateStore {
         matchSession.participantIds().forEach(participantId -> keys.add(MatchingRedisKeys.userMatch(participantId)));
 
         redisTemplate.execute(CLEAR_TERMINAL_SCRIPT, keys, String.valueOf(matchId));
+        removeDeadlineIndex(matchId);
     }
 
     @Override
@@ -547,6 +569,7 @@ public class RedisMatchStateStore implements MatchStateStore {
 
         if (!hasRemainingReference) {
             compareAndDelete(matchKey, matchJson);
+            removeDeadlineIndex(matchId);
         }
     }
 
@@ -564,6 +587,7 @@ public class RedisMatchStateStore implements MatchStateStore {
 
             String updatedJson = serializer.writeMatchSession(updatedSession);
             if (compareAndSet(matchKey, currentJson, updatedJson)) {
+                syncDeadlineIndexAfterUpdate(currentSession, updatedSession);
                 return updatedSession;
             }
         }
@@ -652,17 +676,45 @@ public class RedisMatchStateStore implements MatchStateStore {
         }
     }
 
-    private Long extractMatchIdFromKey(String key) {
-        if (key == null || !key.startsWith(MatchingRedisKeys.matchPrefix())) {
+    private Long parseDeadlineMember(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
             return null;
         }
+    }
 
-        String suffix = key.substring(MatchingRedisKeys.matchPrefix().length());
-        if (suffix.isBlank() || !suffix.chars().allMatch(Character::isDigit)) {
-            return null;
+    private void syncDeadlineIndexAfterUpdate(MatchSession previousSession, MatchSession updatedSession) {
+        if (updatedSession.status() == MatchSessionStatus.ACCEPT_PENDING && updatedSession.deadline() != null) {
+            addDeadlineIndex(updatedSession);
+            return;
         }
 
-        return Long.parseLong(suffix);
+        // ACCEPT_PENDING 을 벗어난 세션은 더 이상 스케줄러 만료 후보가 아니므로 deadline index 에서 제거한다.
+        if (previousSession.status() == MatchSessionStatus.ACCEPT_PENDING) {
+            removeDeadlineIndex(updatedSession.matchId());
+        }
+    }
+
+    private void addDeadlineIndex(MatchSession matchSession) {
+        if (matchSession.deadline() == null) {
+            return;
+        }
+
+        redisTemplate
+                .opsForZSet()
+                .add(
+                        MatchingRedisKeys.matchDeadline(),
+                        String.valueOf(matchSession.matchId()),
+                        deadlineScore(matchSession.deadline()));
+    }
+
+    private void removeDeadlineIndex(Long matchId) {
+        redisTemplate.opsForZSet().remove(MatchingRedisKeys.matchDeadline(), String.valueOf(matchId));
+    }
+
+    private double deadlineScore(LocalDateTime deadline) {
+        return deadline.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/back/domain/matching/queue/service/RedisQueueReadyCheckServiceTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/RedisQueueReadyCheckServiceTest.java
@@ -39,6 +39,7 @@ import com.back.domain.matching.queue.model.QueueKey;
 import com.back.domain.matching.queue.model.WaitingUser;
 import com.back.domain.matching.queue.store.MatchingStoreProperties;
 import com.back.domain.matching.queue.store.redis.FakeStringRedisTemplate;
+import com.back.domain.matching.queue.store.redis.MatchingRedisKeys;
 import com.back.domain.matching.queue.store.redis.MatchingRedisSerializer;
 import com.back.domain.matching.queue.store.redis.RedisMatchStateStore;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -193,6 +194,10 @@ class RedisQueueReadyCheckServiceTest {
         assertThat(response.room()).isNotNull();
         assertThat(response.room().roomId()).isEqualTo(100L);
         assertThat(response.readyCheck().acceptedCount()).isEqualTo(4);
+        assertThat(redisTemplate.opsForZSet().score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchId)))
+                .isNull();
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.match(matchId)))
+                .isNotNull();
         verify(battleRoomService, times(1)).createRoom(any(CreateRoomRequest.class));
         verify(matchingEventPublisher, times(4)).publishRoomReady(any(), any());
     }
@@ -213,6 +218,10 @@ class RedisQueueReadyCheckServiceTest {
         assertThat(response.status()).isEqualTo(MatchStatus.CANCELLED);
         assertThat(response.message()).isNotNull();
         assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        assertThat(redisTemplate.opsForZSet().score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchId)))
+                .isNull();
+        assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.match(matchId)))
+                .isNull();
         verify(matchingEventPublisher, times(4)).publishMatchCancelled(any(), any());
     }
 
@@ -226,13 +235,38 @@ class RedisQueueReadyCheckServiceTest {
                 new WaitingUser(3L, "m3", queueKey),
                 new WaitingUser(4L, "m4", queueKey));
 
-        store.markAcceptPending(queueKey, users, LocalDateTime.now().minusSeconds(1));
+        var matchSession =
+                store.markAcceptPending(queueKey, users, LocalDateTime.now().minusSeconds(1));
         clearInvocations(matchingEventPublisher);
 
         readyCheckService.expireTimedOutMatches();
 
         assertThat(readyCheckService.getMyMatchStateV2(1L).status()).isEqualTo(MatchStatus.IDLE);
+        assertThat(readyCheckService.getMyQueueStateV2(1L).inQueue()).isFalse();
+        assertThat(redisTemplate
+                        .opsForZSet()
+                        .score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchSession.matchId())))
+                .isNull();
         verify(matchingEventPublisher, times(4)).publishMatchExpired(any(), any());
+    }
+
+    @Test
+    @DisplayName("decline 후 expire 스케줄러는 같은 match 를 중복 만료 처리하지 않는다")
+    void expireTimedOutMatches_doesNotPublishExpiredAgain_afterDecline() {
+        joinUser(1L);
+        joinUser(2L);
+        joinUser(3L);
+        joinUser(4L);
+
+        Long matchId = readyCheckService.getMyMatchStateV2(1L).readyCheck().matchId();
+        readyCheckService.declineMatch(2L, matchId);
+        clearInvocations(matchingEventPublisher);
+
+        readyCheckService.expireTimedOutMatches();
+
+        assertThat(redisTemplate.opsForZSet().score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchId)))
+                .isNull();
+        verify(matchingEventPublisher, times(0)).publishMatchExpired(any(), any());
     }
 
     @Test

--- a/src/test/java/com/back/domain/matching/queue/store/redis/FakeStringRedisTemplate.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/FakeStringRedisTemplate.java
@@ -1,5 +1,6 @@
 package com.back.domain.matching.queue.store.redis;
 
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -17,6 +19,7 @@ import java.util.Set;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.core.script.RedisScript;
 
 /**
@@ -30,8 +33,10 @@ public class FakeStringRedisTemplate extends StringRedisTemplate {
     private final Object monitor = new Object();
     private final Map<String, String> values = new HashMap<>();
     private final Map<String, LinkedList<String>> lists = new HashMap<>();
+    private final Map<String, Map<String, Double>> zsets = new HashMap<>();
     private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
     private final ListOperations<String, String> listOperations = mock(ListOperations.class);
+    private final ZSetOperations<String, String> zSetOperations = mock(ZSetOperations.class);
 
     public FakeStringRedisTemplate() {
         when(valueOperations.get(anyString())).thenAnswer(invocation -> {
@@ -59,6 +64,48 @@ public class FakeStringRedisTemplate extends StringRedisTemplate {
                 return index >= 0 && index < queue.size() ? queue.get((int) index) : null;
             }
         });
+        when(zSetOperations.add(anyString(), anyString(), anyDouble())).thenAnswer(invocation -> {
+            synchronized (monitor) {
+                zset(invocation.getArgument(0)).put(invocation.getArgument(1), invocation.getArgument(2));
+                return true;
+            }
+        });
+        when(zSetOperations.rangeByScore(anyString(), anyDouble(), anyDouble())).thenAnswer(invocation -> {
+            synchronized (monitor) {
+                String key = invocation.getArgument(0);
+                double min = invocation.getArgument(1);
+                double max = invocation.getArgument(2);
+
+                Set<String> result = new LinkedHashSet<>();
+                zset(key).entrySet().stream()
+                        .filter(entry -> entry.getValue() >= min && entry.getValue() <= max)
+                        .sorted(Map.Entry.comparingByValue())
+                        .map(Map.Entry::getKey)
+                        .forEach(result::add);
+                return result;
+            }
+        });
+        when(zSetOperations.remove(anyString(), anyString())).thenAnswer(invocation -> {
+            synchronized (monitor) {
+                Map<String, Double> zset = zset(invocation.getArgument(0));
+                long removed = 0L;
+
+                Object[] arguments = invocation.getArguments();
+                for (int i = 1; i < arguments.length; i++) {
+                    if (zset.remove(String.valueOf(arguments[i])) != null) {
+                        removed++;
+                    }
+                }
+
+                return removed;
+            }
+        });
+        when(zSetOperations.score(anyString(), anyString())).thenAnswer(invocation -> {
+            synchronized (monitor) {
+                Object member = invocation.getArgument(1);
+                return zset(invocation.getArgument(0)).get(String.valueOf(member));
+            }
+        });
         doAnswer(invocation -> {
                     synchronized (monitor) {
                         values.put(invocation.getArgument(0), invocation.getArgument(1));
@@ -80,10 +127,16 @@ public class FakeStringRedisTemplate extends StringRedisTemplate {
     }
 
     @Override
+    public ZSetOperations<String, String> opsForZSet() {
+        return zSetOperations;
+    }
+
+    @Override
     public Boolean delete(String key) {
         synchronized (monitor) {
             boolean removed = values.remove(key) != null;
             removed = lists.remove(key) != null || removed;
+            removed = zsets.remove(key) != null || removed;
             return removed;
         }
     }
@@ -109,6 +162,7 @@ public class FakeStringRedisTemplate extends StringRedisTemplate {
             Set<String> result = new LinkedHashSet<>();
             values.keySet().stream().filter(key -> matches(key, pattern)).forEach(result::add);
             lists.keySet().stream().filter(key -> matches(key, pattern)).forEach(result::add);
+            zsets.keySet().stream().filter(key -> matches(key, pattern)).forEach(result::add);
             return result;
         }
     }
@@ -231,14 +285,16 @@ public class FakeStringRedisTemplate extends StringRedisTemplate {
         String sessionJson = String.valueOf(args[0]);
         String matchId = String.valueOf(args[1]);
         int participantCount = Integer.parseInt(String.valueOf(args[2]));
+        double deadlineScore = Double.parseDouble(String.valueOf(args[3]));
 
         values.put(keys.get(0), sessionJson);
+        zset(keys.get(1)).put(matchId, deadlineScore);
 
         for (int i = 1; i <= participantCount; i++) {
-            values.put(keys.get(i), matchId);
+            values.put(keys.get(i + 1), matchId);
         }
 
-        for (int i = participantCount + 1; i < keys.size(); i++) {
+        for (int i = participantCount + 2; i < keys.size(); i++) {
             values.remove(keys.get(i));
         }
 
@@ -298,5 +354,9 @@ public class FakeStringRedisTemplate extends StringRedisTemplate {
 
     private LinkedList<String> list(String key) {
         return lists.computeIfAbsent(key, ignored -> new LinkedList<>());
+    }
+
+    private Map<String, Double> zset(String key) {
+        return zsets.computeIfAbsent(key, ignored -> new LinkedHashMap<>());
     }
 }

--- a/src/test/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStoreTest.java
+++ b/src/test/java/com/back/domain/matching/queue/store/redis/RedisMatchStateStoreTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -98,14 +99,14 @@ class RedisMatchStateStoreTest {
     }
 
     @Test
-    @DisplayName("markAcceptPending 은 match 문서와 userMatch 인덱스를 함께 저장하고 userQueue 를 삭제한다")
+    @DisplayName("markAcceptPending 은 match 문서, userMatch 인덱스, deadline index 를 함께 저장하고 userQueue 를 삭제한다")
     void markAcceptPending_storesReadyCheckStateInRedis() {
         QueueKey queueKey = queueKey();
         enqueueUsers(queueKey, 4);
         List<WaitingUser> matchedUsers = store.pollMatchCandidates(queueKey, 4);
+        LocalDateTime deadline = LocalDateTime.of(2026, 4, 6, 12, 30, 0);
 
-        MatchSession matchSession =
-                store.markAcceptPending(queueKey, matchedUsers, LocalDateTime.of(2026, 4, 6, 12, 30, 0));
+        MatchSession matchSession = store.markAcceptPending(queueKey, matchedUsers, deadline);
 
         assertThat(matchSession.status()).isEqualTo(MatchSessionStatus.ACCEPT_PENDING);
         assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.match(matchSession.matchId())))
@@ -114,6 +115,10 @@ class RedisMatchStateStoreTest {
                 .isEqualTo(String.valueOf(matchSession.matchId()));
         assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userQueue(1L)))
                 .isNull();
+        assertThat(redisTemplate
+                        .opsForZSet()
+                        .score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchSession.matchId())))
+                .isEqualTo(deadlineScore(deadline));
     }
 
     @Test
@@ -154,6 +159,10 @@ class RedisMatchStateStoreTest {
 
         assertThat(declined.status()).isEqualTo(MatchSessionStatus.CANCELLED);
         assertThat(declined.decisionOf(2L)).isEqualTo(ReadyDecision.DECLINED);
+        assertThat(redisTemplate
+                        .opsForZSet()
+                        .score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchSession.matchId())))
+                .isNull();
     }
 
     @Test
@@ -164,6 +173,21 @@ class RedisMatchStateStoreTest {
         MatchSession expired = store.accept(matchSession.matchId(), 1L);
 
         assertThat(expired.status()).isEqualTo(MatchSessionStatus.EXPIRED);
+        assertThat(redisTemplate
+                        .opsForZSet()
+                        .score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchSession.matchId())))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("expire 는 이미 ACCEPT_PENDING 이 아닌 세션을 중복 만료 처리하지 않는다")
+    void expire_rejectsAlreadyTerminalSession() {
+        MatchSession matchSession = createAcceptPendingMatch(LocalDateTime.now().plusSeconds(30));
+        store.decline(matchSession.matchId(), 1L);
+
+        assertThatThrownBy(() -> store.expire(matchSession.matchId()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("이미 만료 처리 대상이 아닌 매치 세션입니다.");
     }
 
     @Test
@@ -182,6 +206,10 @@ class RedisMatchStateStoreTest {
         assertThat(firstAttempt.matchSession().status()).isEqualTo(MatchSessionStatus.ROOM_CREATING);
         assertThat(secondAttempt.acquired()).isFalse();
         assertThat(secondAttempt.matchSession().status()).isEqualTo(MatchSessionStatus.ROOM_CREATING);
+        assertThat(redisTemplate
+                        .opsForZSet()
+                        .score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchSession.matchId())))
+                .isNull();
     }
 
     @Test
@@ -198,6 +226,10 @@ class RedisMatchStateStoreTest {
         store.clearMatchedRoom(1L, 100L);
 
         assertThat(roomReady.status()).isEqualTo(MatchSessionStatus.ROOM_READY);
+        assertThat(redisTemplate
+                        .opsForZSet()
+                        .score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchSession.matchId())))
+                .isNull();
         assertThat(store.findMatchSessionByUserId(1L)).isNull();
         assertThat(store.findMatchSessionByUserId(2L)).isNotNull();
 
@@ -223,10 +255,14 @@ class RedisMatchStateStoreTest {
                 .isNull();
         assertThat(redisTemplate.opsForValue().get(MatchingRedisKeys.userMatch(4L)))
                 .isNull();
+        assertThat(redisTemplate
+                        .opsForZSet()
+                        .score(MatchingRedisKeys.matchDeadline(), String.valueOf(matchSession.matchId())))
+                .isNull();
     }
 
     @Test
-    @DisplayName("findExpiredAcceptPendingMatchIds 는 임시 match key scan 기준으로 만료 세션만 반환한다")
+    @DisplayName("findExpiredAcceptPendingMatchIds 는 deadline index 기준으로 만료 세션만 반환한다")
     void findExpiredAcceptPendingMatchIds_returnsExpiredMatches() {
         MatchSession expired = createAcceptPendingMatch(LocalDateTime.now().minusSeconds(1));
         MatchSession active = createAcceptPendingMatch(LocalDateTime.now().plusSeconds(30), 11L);
@@ -235,6 +271,19 @@ class RedisMatchStateStoreTest {
 
         assertThat(expiredMatchIds).contains(expired.matchId());
         assertThat(expiredMatchIds).doesNotContain(active.matchId());
+    }
+
+    @Test
+    @DisplayName("findExpiredAcceptPendingMatchIds 는 stale deadline index member 를 정리한다")
+    void findExpiredAcceptPendingMatchIds_cleansStaleDeadlineMembers() {
+        MatchSession stale = createAcceptPendingMatch(LocalDateTime.now().minusSeconds(1));
+        redisTemplate.delete(MatchingRedisKeys.match(stale.matchId()));
+
+        List<Long> expiredMatchIds = store.findExpiredAcceptPendingMatchIds(LocalDateTime.now());
+
+        assertThat(expiredMatchIds).doesNotContain(stale.matchId());
+        assertThat(redisTemplate.opsForZSet().score(MatchingRedisKeys.matchDeadline(), String.valueOf(stale.matchId())))
+                .isNull();
     }
 
     private MatchSession createAcceptPendingMatch(LocalDateTime deadline) {
@@ -260,5 +309,9 @@ class RedisMatchStateStoreTest {
         for (long userId = 1L; userId <= count; userId++) {
             store.enqueue(userId, "m" + userId, queueKey);
         }
+    }
+
+    private double deadlineScore(LocalDateTime deadline) {
+        return deadline.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #150 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #150 

---
<html>
<body>
<h1>[refactor] matching expire 처리를 Redis deadline index 기반으로 전환</h1>

<h3>개요</h3>
<p>이번 PR은 Redis 기반 matching ready-check 저장소에서 만료 대상 조회 방식을 개선한 작업입니다.</p>
<p>기존 Redis ready-check 전환 단계에서는 만료된 <code>ACCEPT_PENDING</code> 세션을 찾기 위해 <code>matching:match:*</code> 패턴으로 match session key 전체를 scan한 뒤, 각 세션 JSON을 읽어 deadline을 비교했습니다. 이번 PR에서는 이를 <strong>Redis sorted set 기반 deadline index</strong>로 전환해, 만료 후보를 먼저 좁힌 뒤 세션 문서를 검증하는 방식으로 정리했습니다.</p>
<p>또한 ready-check 세션이 <code>ACCEPT_PENDING</code>을 벗어나는 순간 deadline index에서 제거되도록 보완해, 이미 취소되었거나 방 생성이 진행된 세션이 만료 스케줄러에 다시 잡히지 않도록 했습니다.</p>

<hr>

<h2>기존 코드 대비 변경점</h2>

<table>
<tr><th>구분</th><th>기존</th><th>변경 후</th></tr>
<tr>
<td>만료 대상 조회</td>
<td><code>matching:match:*</code> key scan</td>
<td><code>matching:match:deadline</code> sorted set 조회</td>
</tr>
<tr>
<td>deadline 저장</td>
<td>match session JSON 내부에만 존재</td>
<td>match session JSON + deadline ZSET index에 함께 저장</td>
</tr>
<tr>
<td>만료 후보 필터링</td>
<td>모든 match key를 읽은 뒤 deadline 비교</td>
<td>ZSET score로 후보를 좁힌 뒤 세션 문서로 최종 검증</td>
</tr>
<tr>
<td>ACCEPT_PENDING 이탈 시 처리</td>
<td>match session 상태만 변경</td>
<td>match session 상태 변경 + deadline index 제거</td>
</tr>
<tr>
<td>stale deadline member</td>
<td>별도 정리 없음</td>
<td>세션 문서가 없거나 유효하지 않으면 ZSET member 제거</td>
</tr>
<tr>
<td>key helper</td>
<td><code>matchPattern()</code>, <code>matchPrefix()</code> 필요</td>
<td>deadline index 기반으로 바뀌며 제거</td>
</tr>
</table>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) deadline index를 Redis sorted set으로 저장</h3>
<p>ready-check 세션이 <code>ACCEPT_PENDING</code>으로 생성될 때, match session JSON만 저장하는 것이 아니라 deadline index에도 함께 등록하도록 변경했습니다.</p>

<pre><code class="language-java">keys.add(MatchingRedisKeys.match(matchId));
keys.add(MatchingRedisKeys.matchDeadline());
participantIds.forEach(participantId -&gt; keys.add(MatchingRedisKeys.userMatch(participantId)));
participantIds.forEach(participantId -&gt; keys.add(MatchingRedisKeys.userQueue(participantId)));
</code></pre>

<p>deadline index key는 아래 단일 sorted set입니다.</p>

<pre><code class="language-text">matching:match:deadline
</code></pre>

<p>member는 <code>matchId</code>, score는 deadline을 epoch millisecond로 변환한 값입니다.</p>

<pre><code class="language-java">private double deadlineScore(LocalDateTime deadline) {
    return deadline.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
}
</code></pre>

<h3>2) <code>MARK_ACCEPT_PENDING_SCRIPT</code>에서 deadline index까지 함께 저장</h3>
<p>ready-check 세션 생성 Lua script에 <code>ZADD</code>를 추가했습니다.</p>

<pre><code class="language-lua">redis.call('SET', KEYS[1], ARGV[1])
redis.call('ZADD', KEYS[2], ARGV[4], ARGV[2])

for i = 1, participantCount do
    redis.call('SET', KEYS[i + 2], ARGV[2])
end

for i = participantCount + 3, #KEYS do
    redis.call('DEL', KEYS[i])
end

return ARGV[1]
</code></pre>

<p>이 스크립트는 이제 아래 작업을 한 번에 수행합니다.</p>
<ul>
<li>match session JSON 저장</li>
<li>deadline ZSET에 matchId와 deadline score 저장</li>
<li>4명 각각의 <code>userMatch</code> index 저장</li>
<li>4명 각각의 <code>userQueue</code> index 삭제</li>
</ul>

<h3>3) 만료 조회를 key scan에서 deadline index 조회로 변경</h3>
<p>기존 <code>findExpiredAcceptPendingMatchIds()</code>는 match key 전체를 scan하는 방식이었지만, 이번 PR에서는 sorted set의 score 범위 조회를 사용합니다.</p>

<pre><code class="language-java">Set&lt;String&gt; candidates = redisTemplate
        .opsForZSet()
        .rangeByScore(
                MatchingRedisKeys.matchDeadline(),
                Double.NEGATIVE_INFINITY,
                deadlineScore(now));
</code></pre>

<p>즉, 현재 시각보다 deadline score가 작거나 같은 matchId만 후보로 가져옵니다.</p>

<p>그 다음 각 후보에 대해 match session 문서를 다시 읽어 최종 검증합니다.</p>

<ul>
<li>matchId로 파싱 불가능하면 deadline index에서 제거</li>
<li>match 문서가 없으면 deadline index에서 제거</li>
<li>상태가 <code>ACCEPT_PENDING</code>이 아니면 deadline index에서 제거</li>
<li>deadline이 null이면 deadline index에서 제거</li>
<li>deadline이 실제로 지났으면 만료 대상에 포함</li>
<li>아직 지나지 않았으면 deadline index를 최신 score로 다시 sync</li>
</ul>

<h3>4) <code>ACCEPT_PENDING</code>을 벗어나면 deadline index에서 제거</h3>
<p>ready-check 세션은 <code>ACCEPT_PENDING</code> 상태일 때만 만료 스케줄러의 대상이 됩니다. 그래서 상태 갱신 후 deadline index를 동기화하는 로직을 추가했습니다.</p>

<pre><code class="language-java">private void syncDeadlineIndexAfterUpdate(MatchSession previousSession, MatchSession updatedSession) {
    if (updatedSession.status() == MatchSessionStatus.ACCEPT_PENDING && updatedSession.deadline() != null) {
        addDeadlineIndex(updatedSession);
        return;
    }

    if (previousSession.status() == MatchSessionStatus.ACCEPT_PENDING) {
        removeDeadlineIndex(updatedSession.matchId());
    }
}
</code></pre>

<p>즉, 아래 상태로 전환되면 더 이상 만료 후보로 잡히지 않습니다.</p>

<ul>
<li><code>ROOM_CREATING</code></li>
<li><code>ROOM_READY</code></li>
<li><code>CANCELLED</code></li>
<li><code>EXPIRED</code></li>
<li><code>CLOSED</code></li>
</ul>

<h3>5) room 생성 선점 시 deadline index 제거</h3>
<p>전원 accept가 완료되어 room 생성 권한을 선점하는 순간, 세션은 <code>ROOM_CREATING</code>으로 넘어갑니다. 이 시점부터는 더 이상 ready-check 만료 대상이 아니므로 deadline index에서 제거합니다.</p>

<pre><code class="language-java">if (compareAndSet(matchKey, currentJson, updatedJson)) {
    removeDeadlineIndex(matchId);
    return new RoomCreationAttempt(roomCreatingSession, true);
}
</code></pre>

<p>이 변경으로 마지막 accept와 만료 스케줄러가 겹치는 상황에서도, room 생성이 시작된 세션이 뒤늦게 만료 처리되는 위험을 줄였습니다.</p>

<h3>6) terminal cleanup 시 deadline index도 함께 정리</h3>
<p><code>clearTerminalMatch()</code>에서 match 문서와 userMatch index를 정리할 때, deadline index도 함께 제거하도록 보완했습니다.</p>

<pre><code class="language-java">redisTemplate.execute(CLEAR_TERMINAL_SCRIPT, keys, String.valueOf(matchId));
removeDeadlineIndex(matchId);
</code></pre>

<p>match 문서가 이미 없는 경우에도 stale userMatch link를 scan으로 정리한 뒤 deadline index를 제거합니다.</p>

<pre><code class="language-java">if (matchJson == null || matchJson.isBlank()) {
    removeUserMatchLinksByScan(matchId);
    removeDeadlineIndex(matchId);
    return;
}
</code></pre>

<h3>7) room join 후 마지막 참조자 제거 시 deadline index도 정리</h3>
<p><code>clearMatchedRoom()</code>에서 마지막 참가자의 userMatch reference까지 제거되어 match document를 삭제하는 경우, deadline index도 같이 제거하도록 했습니다.</p>

<pre><code class="language-java">if (!hasRemainingReference) {
    compareAndDelete(matchKey, matchJson);
    removeDeadlineIndex(matchId);
}
</code></pre>

<p>즉, room 입장 완료로 세션이 자연스럽게 종료되는 경우에도 deadline index에 stale member가 남지 않습니다.</p>

<h3>8) <code>expire()</code> 중복 처리 방지 강화</h3>
<p><code>expire()</code>는 이제 <code>ACCEPT_PENDING</code>이 아닌 세션에 대해 조용히 현재 상태를 반환하지 않고, 명시적으로 예외를 던지도록 변경했습니다.</p>

<pre><code class="language-java">if (currentSession.status() != MatchSessionStatus.ACCEPT_PENDING) {
    throw new IllegalStateException("이미 만료 처리 대상이 아닌 매치 세션입니다.");
}
</code></pre>

<p>의도는 아래와 같습니다.</p>
<ul>
<li>이미 취소된 세션을 다시 EXPIRED로 처리하지 않음</li>
<li>이미 ROOM_CREATING / ROOM_READY로 넘어간 세션을 만료 처리하지 않음</li>
<li>만료 스케줄러가 stale 후보를 잡았을 때 잘못된 상태 전이를 막음</li>
</ul>

<h3>9) 임시 key scan helper 제거</h3>
<p>만료 조회가 deadline sorted set 기반으로 바뀌면서, match key 전체 scan에 필요했던 helper를 제거했습니다.</p>

<ul>
<li><code>MatchingRedisKeys.matchPattern()</code> 제거</li>
<li><code>MatchingRedisKeys.matchPrefix()</code> 제거</li>
</ul>

<p>현재 남아 있는 pattern helper는 userMatch stale link 정리를 위한 <code>userMatchPattern()</code>입니다.</p>

<h3>10) 테스트용 Redis template에 ZSET 기능 추가</h3>
<p><code>FakeStringRedisTemplate</code>에 sorted set 동작을 흉내 내는 테스트 기능을 추가했습니다.</p>

<ul>
<li><code>opsForZSet().add(...)</code></li>
<li><code>opsForZSet().rangeByScore(...)</code></li>
<li><code>opsForZSet().remove(...)</code></li>
<li><code>opsForZSet().score(...)</code></li>
</ul>

<p>이를 통해 실제 Redis 없이도 deadline index 저장, 조회, 제거 흐름을 단위 테스트에서 검증할 수 있게 했습니다.</p>

<h3>11) ready-check 만료 관련 테스트 보강</h3>
<p><code>RedisMatchStateStoreTest</code>에 deadline index 기반 동작을 검증하는 테스트를 보강했습니다.</p>

<ul>
<li><code>markAcceptPending</code> 시 match 문서, userMatch index, deadline index가 함께 저장되는지 확인</li>
<li><code>decline</code> 후 deadline index가 제거되는지 확인</li>
<li>deadline 지난 세션에서 accept하면 <code>EXPIRED</code>가 되고 deadline index가 제거되는지 확인</li>
<li><code>expire</code>가 이미 terminal인 세션을 중복 만료 처리하지 않는지 확인</li>
<li><code>tryBeginRoomCreation</code>으로 <code>ROOM_CREATING</code>이 되면 deadline index가 제거되는지 확인</li>
<li><code>markRoomReady</code>, <code>clearMatchedRoom</code>, <code>clearTerminalMatch</code> 이후 deadline index가 제거되는지 확인</li>
<li><code>findExpiredAcceptPendingMatchIds</code>가 deadline index 기준으로 만료 세션만 반환하는지 확인</li>
<li>match 문서가 사라진 stale deadline member를 정리하는지 확인</li>
</ul>

<p><code>RedisQueueReadyCheckServiceTest</code>에도 서비스 흐름 기준 검증을 추가했습니다.</p>

<ul>
<li>전원 accept 후 <code>ROOM_READY</code>가 되면 deadline index가 제거되는지 확인</li>
<li>decline 후 match 문서와 deadline index가 정리되는지 확인</li>
<li>만료 스케줄러가 deadline index 기반으로 만료 세션을 찾아 <code>MATCH_EXPIRED</code>를 발행하고 정리하는지 확인</li>
<li>decline 후 expire 스케줄러가 같은 match를 중복 만료 처리하지 않는지 확인</li>
</ul>

<h3>12) 현재 브랜치에 포함된 문제 선택 임시 처리 확인 필요</h3>
<p>현재 diff 기준으로 <code>QueueProblemPicker</code>는 실제 출제 서비스 호출 대신 임시로 <code>1L</code>을 반환하도록 되어 있습니다.</p>

<pre><code class="language-java">return 1L;

// return problemPickService.pickProblemId(
//         queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
</code></pre>

<p>이 변경은 이번 PR 제목인 Redis expire 처리와 직접 관련된 변경은 아니므로, 의도된 테스트용 임시 처리인지 확인이 필요합니다. 실제 운영 흐름까지 고려하면 다시 <code>problemPickService.pickProblemId(...)</code> 호출로 원복하는 것이 자연스럽습니다.</p>

<hr>

<h2>전체 흐름</h2>

<pre><code class="language-text">[ready-check 세션 생성]
markAcceptPending()
  ↓
match session JSON 저장
  → matching:match:{matchId}

user → match index 저장
  → matching:user:match:{userId}

deadline index 저장
  → ZADD matching:match:deadline {deadlineMillis} {matchId}


[만료 스케줄러]
expireTimedOutMatches()
  ↓
findExpiredAcceptPendingMatchIds(now)
  ↓
ZRANGEBYSCORE matching:match:deadline -inf now
  ↓
후보 matchId별 match session JSON 재검증
  ↓
ACCEPT_PENDING + deadline 지남
  → EXPIRED 처리
  → MATCH_EXPIRED 이벤트 발행
  → terminal cleanup
  → deadline index 제거


[ACCEPT_PENDING 이탈]
decline / expire / room creating / room ready
  ↓
match session 상태 변경
  ↓
deadline index 제거
</code></pre>

<hr>

<h2>정리된 효과</h2>

<ul>
<li>만료 대상 조회가 match key 전체 scan이 아니라 deadline sorted set 기반으로 바뀝니다.</li>
<li>만료 스케줄러가 확인해야 하는 후보 범위를 Redis score 기준으로 먼저 줄일 수 있습니다.</li>
<li><code>ACCEPT_PENDING</code>을 벗어난 세션은 deadline index에서 제거되어 중복 만료 처리 가능성이 줄어듭니다.</li>
<li>stale deadline member를 조회 시점에 정리해 Redis index 정합성을 유지합니다.</li>
<li>Redis ready-check 전환 이후 남아 있던 임시 key scan helper를 제거해 key 규칙이 더 명확해졌습니다.</li>
</ul>

<h2>확인 포인트</h2>

<ol>
<li><code>markAcceptPending</code> 시 <code>matching:match:deadline</code>에 matchId와 deadline score가 저장되는지 확인</li>
<li><code>findExpiredAcceptPendingMatchIds</code>가 ZSET score 기준으로 만료 후보를 조회하는지 확인</li>
<li>decline / room creating / room ready / terminal cleanup 이후 deadline index가 제거되는지 확인</li>
<li>이미 CANCELLED 된 세션이 expire 스케줄러에서 다시 EXPIRED 처리되지 않는지 확인</li>
<li>match 문서가 없는 stale deadline member가 조회 시점에 제거되는지 확인</li>
<li><code>QueueProblemPicker</code>의 임시 <code>1L</code> 반환이 의도된 변경인지 확인</li>
</ol>
</body>
</html>

