### PR TITLE
[Feat] 혼자풀기한 기록을 사용하여 복습주기에 맞춘 복습할 문제 알림 기능

### DIFF
--- a/src/main/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleController.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleController.java
@@ -1,7 +1,9 @@
 package com.back.domain.review.reviewschedule.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.member.member.entity.Member;
@@ -28,5 +30,15 @@ public class ReviewScheduleController {
         }
         TodayReviewResponse response = reviewScheduleService.getTodayReviews(actor.getId());
         return RsData.of("200", "오늘의 복습 문제를 조회했습니다.", response);
+    }
+
+    @PatchMapping("/dismiss")
+    public RsData<Void> dismissReview(@RequestParam Long problemId) {
+        Member actor = rq.getActor();
+        if (actor == null) {
+            return RsData.of("401", "로그인이 필요합니다.");
+        }
+        reviewScheduleService.dismissReview(problemId, actor.getId());
+        return RsData.of("200", "해당 문제를 복습 목록에서 제외했습니다.");
     }
 }

--- a/src/main/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleController.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleController.java
@@ -1,0 +1,32 @@
+package com.back.domain.review.reviewschedule.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
+import com.back.domain.review.reviewschedule.service.ReviewScheduleService;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/review")
+@RequiredArgsConstructor
+public class ReviewScheduleController {
+
+    private final ReviewScheduleService reviewScheduleService;
+    private final Rq rq;
+
+    @GetMapping("/today")
+    public RsData<TodayReviewResponse> getTodayReviews() {
+        Member actor = rq.getActor();
+        if (actor == null) {
+            return RsData.of("401", "로그인이 필요합니다.");
+        }
+        TodayReviewResponse response = reviewScheduleService.getTodayReviews(actor.getId());
+        return RsData.of("200", "오늘의 복습 문제를 조회했습니다.", response);
+    }
+}

--- a/src/main/java/com/back/domain/review/reviewschedule/dto/TodayReviewResponse.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/dto/TodayReviewResponse.java
@@ -1,0 +1,17 @@
+package com.back.domain.review.reviewschedule.dto;
+
+import java.util.List;
+
+import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
+
+public record TodayReviewResponse(List<ReviewItem> reviews) {
+
+    public record ReviewItem(Long problemId, String problemTitle, int reviewCount) {
+        public static ReviewItem from(ReviewSchedule schedule) {
+            return new ReviewItem(
+                    schedule.getProblem().getId(),
+                    schedule.getProblem().getTitle(),
+                    schedule.getReviewCount());
+        }
+    }
+}

--- a/src/main/java/com/back/domain/review/reviewschedule/dto/TodayReviewResponse.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/dto/TodayReviewResponse.java
@@ -9,9 +9,7 @@ public record TodayReviewResponse(List<ReviewItem> reviews) {
     public record ReviewItem(Long problemId, String problemTitle, int reviewCount) {
         public static ReviewItem from(ReviewSchedule schedule) {
             return new ReviewItem(
-                    schedule.getProblem().getId(),
-                    schedule.getProblem().getTitle(),
-                    schedule.getReviewCount());
+                    schedule.getProblem().getId(), schedule.getProblem().getTitle(), schedule.getReviewCount());
         }
     }
 }

--- a/src/main/java/com/back/domain/review/reviewschedule/entity/ReviewSchedule.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/entity/ReviewSchedule.java
@@ -31,6 +31,7 @@ public class ReviewSchedule extends BaseEntity {
 
     private LocalDateTime solvedAt;
     private LocalDateTime nextReviewAt;
+    @Column(nullable = false)
     private Integer reviewCount;
 
     @Column(nullable = false)

--- a/src/main/java/com/back/domain/review/reviewschedule/entity/ReviewSchedule.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/entity/ReviewSchedule.java
@@ -29,7 +29,29 @@ public class ReviewSchedule extends BaseEntity {
     @JoinColumn(name = "problem_id")
     private Problem problem;
 
-    private LocalDateTime solvedAt; // 마지막으로 푼 날짜
-    private LocalDateTime nextReviewAt; // 다음 복습 예정일
-    private Integer reviewCount; // 복습 횟수
+    private LocalDateTime solvedAt;
+    private LocalDateTime nextReviewAt;
+    private Integer reviewCount;
+
+    @Column(nullable = false)
+    private boolean isReviewRequired = true;
+
+    public static ReviewSchedule of(Member member, Problem problem,
+            LocalDateTime solvedAt, LocalDateTime nextReviewAt) {
+        ReviewSchedule schedule = new ReviewSchedule();
+        schedule.member = member;
+        schedule.problem = problem;
+        schedule.solvedAt = solvedAt;
+        schedule.nextReviewAt = nextReviewAt;
+        schedule.reviewCount = 1;
+        schedule.isReviewRequired = true;
+        return schedule;
+    }
+
+    public void updateOnAc(LocalDateTime solvedAt, LocalDateTime nextReviewAt, boolean isReviewRequired) {
+        this.solvedAt = solvedAt;
+        this.nextReviewAt = nextReviewAt;
+        this.reviewCount = this.reviewCount + 1;
+        this.isReviewRequired = isReviewRequired;
+    }
 }

--- a/src/main/java/com/back/domain/review/reviewschedule/entity/ReviewSchedule.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/entity/ReviewSchedule.java
@@ -54,4 +54,8 @@ public class ReviewSchedule extends BaseEntity {
         this.reviewCount = this.reviewCount + 1;
         this.isReviewRequired = isReviewRequired;
     }
+
+    public void dismiss() {
+        this.isReviewRequired = false;
+    }
 }

--- a/src/main/java/com/back/domain/review/reviewschedule/entity/ReviewSchedule.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/entity/ReviewSchedule.java
@@ -31,14 +31,15 @@ public class ReviewSchedule extends BaseEntity {
 
     private LocalDateTime solvedAt;
     private LocalDateTime nextReviewAt;
+
     @Column(nullable = false)
     private Integer reviewCount;
 
     @Column(nullable = false)
     private boolean isReviewRequired = true;
 
-    public static ReviewSchedule of(Member member, Problem problem,
-            LocalDateTime solvedAt, LocalDateTime nextReviewAt) {
+    public static ReviewSchedule of(
+            Member member, Problem problem, LocalDateTime solvedAt, LocalDateTime nextReviewAt) {
         ReviewSchedule schedule = new ReviewSchedule();
         schedule.member = member;
         schedule.problem = problem;

--- a/src/main/java/com/back/domain/review/reviewschedule/repository/ReviewScheduleRepository.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/repository/ReviewScheduleRepository.java
@@ -1,0 +1,13 @@
+package com.back.domain.review.reviewschedule.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
+
+public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, Long> {
+    Optional<ReviewSchedule> findByMemberAndProblem(Member member, Problem problem);
+}

--- a/src/main/java/com/back/domain/review/reviewschedule/repository/ReviewScheduleRepository.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/repository/ReviewScheduleRepository.java
@@ -1,13 +1,24 @@
 package com.back.domain.review.reviewschedule.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
 
 public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, Long> {
+
     Optional<ReviewSchedule> findByMemberAndProblem(Member member, Problem problem);
+
+    @Query("SELECT rs FROM ReviewSchedule rs JOIN FETCH rs.problem "
+            + "WHERE rs.member.id = :memberId "
+            + "AND rs.isReviewRequired = true "
+            + "AND rs.nextReviewAt <= :now")
+    List<ReviewSchedule> findTodayReviews(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/back/domain/review/reviewschedule/repository/ReviewScheduleRepository.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/repository/ReviewScheduleRepository.java
@@ -16,6 +16,8 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
 
     Optional<ReviewSchedule> findByMemberAndProblem(Member member, Problem problem);
 
+    Optional<ReviewSchedule> findByMemberIdAndProblemId(Long memberId, Long problemId);
+
     @Query("SELECT rs FROM ReviewSchedule rs JOIN FETCH rs.problem "
             + "WHERE rs.member.id = :memberId "
             + "AND rs.isReviewRequired = true "

--- a/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
@@ -2,8 +2,10 @@ package com.back.domain.review.reviewschedule.service;
 
 import java.time.LocalDateTime;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -29,6 +31,13 @@ public class ReviewScheduleService {
                 .map(TodayReviewResponse.ReviewItem::from)
                 .toList();
         return new TodayReviewResponse(items);
+    }
+
+    @Transactional
+    public void dismissReview(Long problemId, Long memberId) {
+        ReviewSchedule schedule = reviewScheduleRepository.findByMemberIdAndProblemId(memberId, problemId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "복습 스케줄을 찾을 수 없습니다."));
+        schedule.dismiss();
     }
 
     /**

--- a/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
@@ -5,8 +5,11 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
 import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
 import com.back.domain.review.reviewschedule.repository.ReviewScheduleRepository;
 
@@ -17,6 +20,16 @@ import lombok.RequiredArgsConstructor;
 public class ReviewScheduleService {
 
     private final ReviewScheduleRepository reviewScheduleRepository;
+
+    @Transactional(readOnly = true)
+    public TodayReviewResponse getTodayReviews(Long memberId) {
+        List<ReviewSchedule> schedules =
+                reviewScheduleRepository.findTodayReviews(memberId, LocalDateTime.now());
+        List<TodayReviewResponse.ReviewItem> items = schedules.stream()
+                .map(TodayReviewResponse.ReviewItem::from)
+                .toList();
+        return new TodayReviewResponse(items);
+    }
 
     /**
      * AC 결과를 복습 스케줄에 반영한다.

--- a/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
@@ -1,0 +1,60 @@
+package com.back.domain.review.reviewschedule.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
+import com.back.domain.review.reviewschedule.repository.ReviewScheduleRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewScheduleService {
+
+    private final ReviewScheduleRepository reviewScheduleRepository;
+
+    /**
+     * AC 결과를 복습 스케줄에 반영한다.
+     * - 기존 스케줄이 없으면 신규 생성 (reviewCount=1, nextReviewAt=+3일)
+     * - 기존 스케줄이 있으면 reviewCount를 증가시키고 다음 복습일을 갱신한다.
+     * - reviewCount가 4를 초과하면 isReviewRequired=false로 설정한다.
+     */
+    @Transactional
+    public void recordAcResult(Member member, Problem problem, LocalDateTime solvedAt) {
+        reviewScheduleRepository.findByMemberAndProblem(member, problem)
+                .ifPresentOrElse(
+                        schedule -> {
+                            int nextCount = schedule.getReviewCount() + 1;
+                            boolean isReviewRequired = nextCount <= 4;
+                            LocalDateTime nextReviewAt = isReviewRequired
+                                    ? calcNextReviewAt(solvedAt, nextCount)
+                                    : solvedAt;
+                            schedule.updateOnAc(solvedAt, nextReviewAt, isReviewRequired);
+                        },
+                        () -> reviewScheduleRepository.save(
+                                ReviewSchedule.of(member, problem, solvedAt, solvedAt.plusDays(3)))
+                );
+    }
+
+    /**
+     * 복습 간격 (스페이스 리피티션)
+     * reviewCount=1 → +3일
+     * reviewCount=2 → +7일
+     * reviewCount=3 → +30일
+     * reviewCount=4 → +180일
+     */
+    private LocalDateTime calcNextReviewAt(LocalDateTime base, int reviewCount) {
+        return switch (reviewCount) {
+            case 1 -> base.plusDays(3);
+            case 2 -> base.plusDays(7);
+            case 3 -> base.plusDays(30);
+            case 4 -> base.plusDays(180);
+            default -> base;
+        };
+    }
+}

--- a/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
@@ -1,13 +1,12 @@
 package com.back.domain.review.reviewschedule.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.List;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
@@ -25,17 +24,16 @@ public class ReviewScheduleService {
 
     @Transactional(readOnly = true)
     public TodayReviewResponse getTodayReviews(Long memberId) {
-        List<ReviewSchedule> schedules =
-                reviewScheduleRepository.findTodayReviews(memberId, LocalDateTime.now());
-        List<TodayReviewResponse.ReviewItem> items = schedules.stream()
-                .map(TodayReviewResponse.ReviewItem::from)
-                .toList();
+        List<ReviewSchedule> schedules = reviewScheduleRepository.findTodayReviews(memberId, LocalDateTime.now());
+        List<TodayReviewResponse.ReviewItem> items =
+                schedules.stream().map(TodayReviewResponse.ReviewItem::from).toList();
         return new TodayReviewResponse(items);
     }
 
     @Transactional
     public void dismissReview(Long problemId, Long memberId) {
-        ReviewSchedule schedule = reviewScheduleRepository.findByMemberIdAndProblemId(memberId, problemId)
+        ReviewSchedule schedule = reviewScheduleRepository
+                .findByMemberIdAndProblemId(memberId, problemId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "복습 스케줄을 찾을 수 없습니다."));
         schedule.dismiss();
     }
@@ -48,19 +46,18 @@ public class ReviewScheduleService {
      */
     @Transactional
     public void recordAcResult(Member member, Problem problem, LocalDateTime solvedAt) {
-        reviewScheduleRepository.findByMemberAndProblem(member, problem)
+        reviewScheduleRepository
+                .findByMemberAndProblem(member, problem)
                 .ifPresentOrElse(
                         schedule -> {
                             int nextCount = schedule.getReviewCount() + 1;
                             boolean isReviewRequired = nextCount <= 4;
-                            LocalDateTime nextReviewAt = isReviewRequired
-                                    ? calcNextReviewAt(solvedAt, nextCount)
-                                    : solvedAt;
+                            LocalDateTime nextReviewAt =
+                                    isReviewRequired ? calcNextReviewAt(solvedAt, nextCount) : solvedAt;
                             schedule.updateOnAc(solvedAt, nextReviewAt, isReviewRequired);
                         },
                         () -> reviewScheduleRepository.save(
-                                ReviewSchedule.of(member, problem, solvedAt, solvedAt.plusDays(3)))
-                );
+                                ReviewSchedule.of(member, problem, solvedAt, solvedAt.plusDays(3))));
     }
 
     /**

--- a/src/main/java/com/back/global/judge/SoloJudgeService.java
+++ b/src/main/java/com/back/global/judge/SoloJudgeService.java
@@ -75,10 +75,8 @@ public class SoloJudgeService {
         if (judgeResult == SubmissionResult.AC) {
             LocalDateTime now = LocalDateTime.now();
             // 문제별 첫 AC일 때만 솔로 난이도 점수/카운트를 반영한다.
-            ratingProfileService.applySoloFirstSolve(
-                    submission.getMember(), submission.getProblem(), now);
-            reviewScheduleService.recordAcResult(
-                    submission.getMember(), submission.getProblem(), now);
+            ratingProfileService.applySoloFirstSolve(submission.getMember(), submission.getProblem(), now);
+            reviewScheduleService.recordAcResult(submission.getMember(), submission.getProblem(), now);
         }
 
         publisher.publish(

--- a/src/main/java/com/back/global/judge/SoloJudgeService.java
+++ b/src/main/java/com/back/global/judge/SoloJudgeService.java
@@ -14,6 +14,7 @@ import com.back.domain.problem.solo.submission.repository.SoloSubmissionReposito
 import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.domain.rating.profile.service.RatingProfileService;
+import com.back.domain.review.reviewschedule.service.ReviewScheduleService;
 import com.back.global.judge.dto.Judge0SubmitRequest;
 import com.back.global.judge.dto.Judge0SubmitResponse;
 import com.back.global.judge.event.SoloJudgeRequestedEvent;
@@ -30,6 +31,7 @@ public class SoloJudgeService {
     private final Judge0ExecutionService judge0ExecutionService;
     private final SoloSubmissionRepository soloSubmissionRepository;
     private final RatingProfileService ratingProfileService;
+    private final ReviewScheduleService reviewScheduleService;
     private final WebSocketMessagePublisher publisher;
 
     @Async
@@ -71,9 +73,12 @@ public class SoloJudgeService {
         soloSubmissionRepository.save(submission);
 
         if (judgeResult == SubmissionResult.AC) {
+            LocalDateTime now = LocalDateTime.now();
             // 문제별 첫 AC일 때만 솔로 난이도 점수/카운트를 반영한다.
             ratingProfileService.applySoloFirstSolve(
-                    submission.getMember(), submission.getProblem(), LocalDateTime.now());
+                    submission.getMember(), submission.getProblem(), now);
+            reviewScheduleService.recordAcResult(
+                    submission.getMember(), submission.getProblem(), now);
         }
 
         publisher.publish(

--- a/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
@@ -22,8 +22,7 @@ class ReviewScheduleControllerTest {
 
     private final ReviewScheduleService reviewScheduleService = mock(ReviewScheduleService.class);
     private final Rq rq = mock(Rq.class);
-    private final ReviewScheduleController controller =
-            new ReviewScheduleController(reviewScheduleService, rq);
+    private final ReviewScheduleController controller = new ReviewScheduleController(reviewScheduleService, rq);
 
     @Test
     @DisplayName("비로그인 상태에서 요청하면 401을 반환한다")
@@ -40,8 +39,7 @@ class ReviewScheduleControllerTest {
     @DisplayName("로그인 상태에서 요청하면 서비스 결과와 함께 200을 반환한다")
     void getTodayReviews_authenticated_returns200WithItems() {
         Member actor = Member.of(1L, "test@test.com", "tester");
-        TodayReviewResponse.ReviewItem item =
-                new TodayReviewResponse.ReviewItem(10L, "문제A", 1);
+        TodayReviewResponse.ReviewItem item = new TodayReviewResponse.ReviewItem(10L, "문제A", 1);
         TodayReviewResponse serviceResponse = new TodayReviewResponse(List.of(item));
 
         when(rq.getActor()).thenReturn(actor);
@@ -79,7 +77,8 @@ class ReviewScheduleControllerTest {
         RsData<Void> result = controller.dismissReview(10L);
 
         assertThat(result.resultCode()).isEqualTo("401");
-        verify(reviewScheduleService, never()).dismissReview(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+        verify(reviewScheduleService, never())
+                .dismissReview(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
     }
 
     @Test

--- a/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
@@ -1,6 +1,7 @@
 package com.back.domain.review.reviewschedule.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -68,5 +69,29 @@ class ReviewScheduleControllerTest {
 
         assertThat(result.resultCode()).isEqualTo("200");
         assertThat(result.data().reviews()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("비로그인 상태에서 dismiss 요청하면 401을 반환한다")
+    void dismissReview_unauthenticated_returns401() {
+        when(rq.getActor()).thenReturn(null);
+
+        RsData<Void> result = controller.dismissReview(10L);
+
+        assertThat(result.resultCode()).isEqualTo("401");
+        verify(reviewScheduleService, never()).dismissReview(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("로그인 상태에서 dismiss 요청하면 서비스를 호출하고 200을 반환한다")
+    void dismissReview_authenticated_returns200() {
+        Member actor = Member.of(1L, "test@test.com", "tester");
+        when(rq.getActor()).thenReturn(actor);
+        doNothing().when(reviewScheduleService).dismissReview(10L, 1L);
+
+        RsData<Void> result = controller.dismissReview(10L);
+
+        assertThat(result.resultCode()).isEqualTo("200");
+        verify(reviewScheduleService).dismissReview(10L, 1L);
     }
 }

--- a/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
@@ -1,0 +1,72 @@
+package com.back.domain.review.reviewschedule.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
+import com.back.domain.review.reviewschedule.service.ReviewScheduleService;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+
+class ReviewScheduleControllerTest {
+
+    private final ReviewScheduleService reviewScheduleService = mock(ReviewScheduleService.class);
+    private final Rq rq = mock(Rq.class);
+    private final ReviewScheduleController controller =
+            new ReviewScheduleController(reviewScheduleService, rq);
+
+    @Test
+    @DisplayName("비로그인 상태에서 요청하면 401을 반환한다")
+    void getTodayReviews_unauthenticated_returns401() {
+        when(rq.getActor()).thenReturn(null);
+
+        RsData<TodayReviewResponse> result = controller.getTodayReviews();
+
+        assertThat(result.resultCode()).isEqualTo("401");
+        verify(reviewScheduleService, never()).getTodayReviews(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("로그인 상태에서 요청하면 서비스 결과와 함께 200을 반환한다")
+    void getTodayReviews_authenticated_returns200WithItems() {
+        Member actor = Member.of(1L, "test@test.com", "tester");
+        TodayReviewResponse.ReviewItem item =
+                new TodayReviewResponse.ReviewItem(10L, "문제A", 1);
+        TodayReviewResponse serviceResponse = new TodayReviewResponse(List.of(item));
+
+        when(rq.getActor()).thenReturn(actor);
+        when(reviewScheduleService.getTodayReviews(1L)).thenReturn(serviceResponse);
+
+        RsData<TodayReviewResponse> result = controller.getTodayReviews();
+
+        assertThat(result.resultCode()).isEqualTo("200");
+        assertThat(result.data().reviews()).hasSize(1);
+        assertThat(result.data().reviews().get(0).problemId()).isEqualTo(10L);
+        assertThat(result.data().reviews().get(0).problemTitle()).isEqualTo("문제A");
+        assertThat(result.data().reviews().get(0).reviewCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("오늘 복습할 문제가 없으면 빈 목록과 함께 200을 반환한다")
+    void getTodayReviews_authenticated_noItems_returns200WithEmptyList() {
+        Member actor = Member.of(2L, "user@test.com", "user");
+        TodayReviewResponse serviceResponse = new TodayReviewResponse(List.of());
+
+        when(rq.getActor()).thenReturn(actor);
+        when(reviewScheduleService.getTodayReviews(2L)).thenReturn(serviceResponse);
+
+        RsData<TodayReviewResponse> result = controller.getTodayReviews();
+
+        assertThat(result.resultCode()).isEqualTo("200");
+        assertThat(result.data().reviews()).isEmpty();
+    }
+}

--- a/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
 import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
 import com.back.domain.review.reviewschedule.repository.ReviewScheduleRepository;
 
@@ -102,6 +104,53 @@ class ReviewScheduleServiceTest {
 
         assertThat(existing.getReviewCount()).isEqualTo(5);
         assertThat(existing.isReviewRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("오늘 복습할 스케줄이 있으면 ReviewItem 목록을 반환한다")
+    void getTodayReviews_returnsItems() {
+        ReviewSchedule schedule1 = scheduleWithReviewCount(1);
+        ReviewSchedule schedule2 = scheduleWithReviewCount(2);
+
+        Problem p1 = mock(Problem.class);
+        Problem p2 = mock(Problem.class);
+        when(p1.getId()).thenReturn(10L);
+        when(p1.getTitle()).thenReturn("문제A");
+        when(p2.getId()).thenReturn(20L);
+        when(p2.getTitle()).thenReturn("문제B");
+
+        // reflection으로 problem 필드를 직접 설정하는 대신
+        // scheduleWithReviewCount가 this.problem(mock)을 사용하므로
+        // member/problem mock을 각 schedule 전용으로 따로 생성한다.
+        Member m1 = mock(Member.class);
+        Member m2 = mock(Member.class);
+        ReviewSchedule s1 = ReviewSchedule.of(m1, p1, solvedAt, solvedAt.plusDays(3));
+        ReviewSchedule s2 = ReviewSchedule.of(m2, p2, solvedAt, solvedAt.plusDays(3));
+        s2.updateOnAc(solvedAt, solvedAt.plusDays(7), true);
+
+        Long memberId = 99L;
+        when(reviewScheduleRepository.findTodayReviews(any(), any()))
+                .thenReturn(List.of(s1, s2));
+
+        TodayReviewResponse response = reviewScheduleService.getTodayReviews(memberId);
+
+        assertThat(response.reviews()).hasSize(2);
+        assertThat(response.reviews().get(0).problemId()).isEqualTo(10L);
+        assertThat(response.reviews().get(0).problemTitle()).isEqualTo("문제A");
+        assertThat(response.reviews().get(0).reviewCount()).isEqualTo(1);
+        assertThat(response.reviews().get(1).problemId()).isEqualTo(20L);
+        assertThat(response.reviews().get(1).reviewCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("오늘 복습할 스케줄이 없으면 빈 목록을 반환한다")
+    void getTodayReviews_returnsEmptyList() {
+        when(reviewScheduleRepository.findTodayReviews(any(), any()))
+                .thenReturn(List.of());
+
+        TodayReviewResponse response = reviewScheduleService.getTodayReviews(1L);
+
+        assertThat(response.reviews()).isEmpty();
     }
 
     /**

--- a/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
@@ -1,0 +1,119 @@
+package com.back.domain.review.reviewschedule.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
+import com.back.domain.review.reviewschedule.repository.ReviewScheduleRepository;
+
+class ReviewScheduleServiceTest {
+
+    private final ReviewScheduleRepository reviewScheduleRepository = mock(ReviewScheduleRepository.class);
+    private final ReviewScheduleService reviewScheduleService = new ReviewScheduleService(reviewScheduleRepository);
+
+    private final Member member = mock(Member.class);
+    private final Problem problem = mock(Problem.class);
+    private final LocalDateTime solvedAt = LocalDateTime.of(2026, 4, 9, 12, 0);
+
+    @Test
+    @DisplayName("첫 AC 시 reviewCount=1, nextReviewAt=+3일로 복습 스케줄을 신규 생성한다")
+    void firstAc_createsNewSchedule() {
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
+                .thenReturn(Optional.empty());
+
+        reviewScheduleService.recordAcResult(member, problem, solvedAt);
+
+        ArgumentCaptor<ReviewSchedule> captor = forClass(ReviewSchedule.class);
+        verify(reviewScheduleRepository).save(captor.capture());
+        ReviewSchedule saved = captor.getValue();
+
+        assertThat(saved.getReviewCount()).isEqualTo(1);
+        assertThat(saved.getSolvedAt()).isEqualTo(solvedAt);
+        assertThat(saved.getNextReviewAt()).isEqualTo(solvedAt.plusDays(3));
+        assertThat(saved.isReviewRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("두 번째 AC 시 nextReviewAt을 7일 후로 갱신한다")
+    void secondAc_updatesNextReviewTo7Days() {
+        ReviewSchedule existing = ReviewSchedule.of(member, problem, solvedAt.minusDays(3), solvedAt);
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
+                .thenReturn(Optional.of(existing));
+
+        reviewScheduleService.recordAcResult(member, problem, solvedAt);
+
+        assertThat(existing.getReviewCount()).isEqualTo(2);
+        assertThat(existing.getSolvedAt()).isEqualTo(solvedAt);
+        assertThat(existing.getNextReviewAt()).isEqualTo(solvedAt.plusDays(7));
+        assertThat(existing.isReviewRequired()).isTrue();
+        verify(reviewScheduleRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("세 번째 AC 시 nextReviewAt을 30일 후로 갱신한다")
+    void thirdAc_updatesNextReviewTo30Days() {
+        ReviewSchedule existing = scheduleWithReviewCount(2);
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
+                .thenReturn(Optional.of(existing));
+
+        reviewScheduleService.recordAcResult(member, problem, solvedAt);
+
+        assertThat(existing.getReviewCount()).isEqualTo(3);
+        assertThat(existing.getNextReviewAt()).isEqualTo(solvedAt.plusDays(30));
+        assertThat(existing.isReviewRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("네 번째 AC 시 nextReviewAt을 180일 후로 갱신한다")
+    void fourthAc_updatesNextReviewTo180Days() {
+        ReviewSchedule existing = scheduleWithReviewCount(3);
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
+                .thenReturn(Optional.of(existing));
+
+        reviewScheduleService.recordAcResult(member, problem, solvedAt);
+
+        assertThat(existing.getReviewCount()).isEqualTo(4);
+        assertThat(existing.getNextReviewAt()).isEqualTo(solvedAt.plusDays(180));
+        assertThat(existing.isReviewRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다섯 번째 AC 이후 모든 복습을 완료하면 isReviewRequired를 false로 설정한다")
+    void fifthAcOrMore_setsReviewRequiredFalse() {
+        ReviewSchedule existing = scheduleWithReviewCount(4);
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
+                .thenReturn(Optional.of(existing));
+
+        reviewScheduleService.recordAcResult(member, problem, solvedAt);
+
+        assertThat(existing.getReviewCount()).isEqualTo(5);
+        assertThat(existing.isReviewRequired()).isFalse();
+    }
+
+    /**
+     * reviewCount가 targetCount인 ReviewSchedule을 생성한다.
+     * ReviewSchedule.of()는 reviewCount=1로 생성되고,
+     * updateOnAc() 호출마다 reviewCount가 1씩 증가한다.
+     */
+    private ReviewSchedule scheduleWithReviewCount(int targetCount) {
+        ReviewSchedule schedule = ReviewSchedule.of(member, problem, solvedAt, solvedAt.plusDays(3));
+        for (int i = 1; i < targetCount; i++) {
+            schedule.updateOnAc(solvedAt, solvedAt.plusDays(1), true);
+        }
+        return schedule;
+    }
+}

--- a/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
@@ -1,6 +1,7 @@
 package com.back.domain.review.reviewschedule.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -11,6 +12,8 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.web.server.ResponseStatusException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -109,9 +112,6 @@ class ReviewScheduleServiceTest {
     @Test
     @DisplayName("오늘 복습할 스케줄이 있으면 ReviewItem 목록을 반환한다")
     void getTodayReviews_returnsItems() {
-        ReviewSchedule schedule1 = scheduleWithReviewCount(1);
-        ReviewSchedule schedule2 = scheduleWithReviewCount(2);
-
         Problem p1 = mock(Problem.class);
         Problem p2 = mock(Problem.class);
         when(p1.getId()).thenReturn(10L);
@@ -119,20 +119,16 @@ class ReviewScheduleServiceTest {
         when(p2.getId()).thenReturn(20L);
         when(p2.getTitle()).thenReturn("문제B");
 
-        // reflection으로 problem 필드를 직접 설정하는 대신
-        // scheduleWithReviewCount가 this.problem(mock)을 사용하므로
-        // member/problem mock을 각 schedule 전용으로 따로 생성한다.
         Member m1 = mock(Member.class);
         Member m2 = mock(Member.class);
         ReviewSchedule s1 = ReviewSchedule.of(m1, p1, solvedAt, solvedAt.plusDays(3));
         ReviewSchedule s2 = ReviewSchedule.of(m2, p2, solvedAt, solvedAt.plusDays(3));
         s2.updateOnAc(solvedAt, solvedAt.plusDays(7), true);
 
-        Long memberId = 99L;
         when(reviewScheduleRepository.findTodayReviews(any(), any()))
                 .thenReturn(List.of(s1, s2));
 
-        TodayReviewResponse response = reviewScheduleService.getTodayReviews(memberId);
+        TodayReviewResponse response = reviewScheduleService.getTodayReviews(99L);
 
         assertThat(response.reviews()).hasSize(2);
         assertThat(response.reviews().get(0).problemId()).isEqualTo(10L);
@@ -151,6 +147,28 @@ class ReviewScheduleServiceTest {
         TodayReviewResponse response = reviewScheduleService.getTodayReviews(1L);
 
         assertThat(response.reviews()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("dismissReview 호출 시 isReviewRequired가 false로 변경된다")
+    void dismissReview_setsReviewRequiredFalse() {
+        ReviewSchedule schedule = scheduleWithReviewCount(1);
+        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L))
+                .thenReturn(Optional.of(schedule));
+
+        reviewScheduleService.dismissReview(10L, 1L);
+
+        assertThat(schedule.isReviewRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 스케줄을 dismiss하면 예외가 발생한다")
+    void dismissReview_notFound_throwsException() {
+        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reviewScheduleService.dismissReview(10L, 1L))
+                .isInstanceOf(ResponseStatusException.class);
     }
 
     /**

--- a/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
@@ -13,11 +13,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.web.server.ResponseStatusException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
@@ -37,8 +36,7 @@ class ReviewScheduleServiceTest {
     @Test
     @DisplayName("첫 AC 시 reviewCount=1, nextReviewAt=+3일로 복습 스케줄을 신규 생성한다")
     void firstAc_createsNewSchedule() {
-        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
-                .thenReturn(Optional.empty());
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem)).thenReturn(Optional.empty());
 
         reviewScheduleService.recordAcResult(member, problem, solvedAt);
 
@@ -56,8 +54,7 @@ class ReviewScheduleServiceTest {
     @DisplayName("두 번째 AC 시 nextReviewAt을 7일 후로 갱신한다")
     void secondAc_updatesNextReviewTo7Days() {
         ReviewSchedule existing = ReviewSchedule.of(member, problem, solvedAt.minusDays(3), solvedAt);
-        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
-                .thenReturn(Optional.of(existing));
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem)).thenReturn(Optional.of(existing));
 
         reviewScheduleService.recordAcResult(member, problem, solvedAt);
 
@@ -72,8 +69,7 @@ class ReviewScheduleServiceTest {
     @DisplayName("세 번째 AC 시 nextReviewAt을 30일 후로 갱신한다")
     void thirdAc_updatesNextReviewTo30Days() {
         ReviewSchedule existing = scheduleWithReviewCount(2);
-        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
-                .thenReturn(Optional.of(existing));
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem)).thenReturn(Optional.of(existing));
 
         reviewScheduleService.recordAcResult(member, problem, solvedAt);
 
@@ -86,8 +82,7 @@ class ReviewScheduleServiceTest {
     @DisplayName("네 번째 AC 시 nextReviewAt을 180일 후로 갱신한다")
     void fourthAc_updatesNextReviewTo180Days() {
         ReviewSchedule existing = scheduleWithReviewCount(3);
-        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
-                .thenReturn(Optional.of(existing));
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem)).thenReturn(Optional.of(existing));
 
         reviewScheduleService.recordAcResult(member, problem, solvedAt);
 
@@ -100,8 +95,7 @@ class ReviewScheduleServiceTest {
     @DisplayName("다섯 번째 AC 이후 모든 복습을 완료하면 isReviewRequired를 false로 설정한다")
     void fifthAcOrMore_setsReviewRequiredFalse() {
         ReviewSchedule existing = scheduleWithReviewCount(4);
-        when(reviewScheduleRepository.findByMemberAndProblem(member, problem))
-                .thenReturn(Optional.of(existing));
+        when(reviewScheduleRepository.findByMemberAndProblem(member, problem)).thenReturn(Optional.of(existing));
 
         reviewScheduleService.recordAcResult(member, problem, solvedAt);
 
@@ -125,8 +119,7 @@ class ReviewScheduleServiceTest {
         ReviewSchedule s2 = ReviewSchedule.of(m2, p2, solvedAt, solvedAt.plusDays(3));
         s2.updateOnAc(solvedAt, solvedAt.plusDays(7), true);
 
-        when(reviewScheduleRepository.findTodayReviews(any(), any()))
-                .thenReturn(List.of(s1, s2));
+        when(reviewScheduleRepository.findTodayReviews(any(), any())).thenReturn(List.of(s1, s2));
 
         TodayReviewResponse response = reviewScheduleService.getTodayReviews(99L);
 
@@ -141,8 +134,7 @@ class ReviewScheduleServiceTest {
     @Test
     @DisplayName("오늘 복습할 스케줄이 없으면 빈 목록을 반환한다")
     void getTodayReviews_returnsEmptyList() {
-        when(reviewScheduleRepository.findTodayReviews(any(), any()))
-                .thenReturn(List.of());
+        when(reviewScheduleRepository.findTodayReviews(any(), any())).thenReturn(List.of());
 
         TodayReviewResponse response = reviewScheduleService.getTodayReviews(1L);
 
@@ -153,8 +145,7 @@ class ReviewScheduleServiceTest {
     @DisplayName("dismissReview 호출 시 isReviewRequired가 false로 변경된다")
     void dismissReview_setsReviewRequiredFalse() {
         ReviewSchedule schedule = scheduleWithReviewCount(1);
-        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L))
-                .thenReturn(Optional.of(schedule));
+        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L)).thenReturn(Optional.of(schedule));
 
         reviewScheduleService.dismissReview(10L, 1L);
 
@@ -164,8 +155,7 @@ class ReviewScheduleServiceTest {
     @Test
     @DisplayName("존재하지 않는 스케줄을 dismiss하면 예외가 발생한다")
     void dismissReview_notFound_throwsException() {
-        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L))
-                .thenReturn(Optional.empty());
+        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> reviewScheduleService.dismissReview(10L, 1L))
                 .isInstanceOf(ResponseStatusException.class);


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #178
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #178

---

## Summary

혼자풀기에서 AC가 나오면 복습 스케줄에 자동 반영하고,

오늘 복습할 문제 조회 및 수동 제외 API를 구현합니다.

### 핵심 기능

- ****AC 자동 반영****: `SoloJudgeService`에서 AC 결과가 나오면 `ReviewScheduleService.recordAcResult()`를 호출해 복습 스케줄을 생성/갱신

- ****스페이스 리피티션****: 복습 주기는 1회→+3일, 2회→+7일, 3회→+30일, 4회→+180일. 4회 초과 시 `isReviewRequired=false`로 자동 종료

- ****오늘의 복습 조회**** (`GET /api/v1/review/today`): 오늘 기준 복습 기한이 된 문제 목록 반환 (`problemId`, `problemTitle`, `reviewCount`)

- ****복습 수동 제외**** (`PATCH /api/v1/review/dismiss?problemId={id}`): 사용자가 특정 문제를 복습 목록에서 직접 제외

### 변경 파일

| 파일 | 변경 내용 |

|---|---|

| `ReviewSchedule.java` | `isReviewRequired` 필드 추가, `of()` / `updateOnAc()` / `dismiss()` 메서드 추가 |

| `ReviewScheduleRepository.java` | `findByMemberAndProblem`, `findByMemberIdAndProblemId`, `findTodayReviews` (JPQL + JOIN FETCH) |

| `ReviewScheduleService.java` | `getTodayReviews`, `recordAcResult`, `dismissReview` 구현 |

| `ReviewScheduleController.java` | `GET /today`, `PATCH /dismiss` 엔드포인트 |

| `SoloJudgeService.java` | AC 결과 시 `recordAcResult()` 호출 연동 |

### API 명세

GET  /api/v1/review/today

→ 200 { reviews: [{ problemId, problemTitle, reviewCount }] }

PATCH /api/v1/review/dismiss?problemId={id}

→ 200 (성공)

→ 401 (비로그인)

→ 404 (스케줄 없음)

## Test plan

- [x] `ReviewScheduleServiceTest` — `recordAcResult` 5개 케이스 (첫 AC 신규 생성, 2/3/4회차 간격, 5회차 이후 종료)

- [x] `ReviewScheduleServiceTest` — `getTodayReviews` 2개 케이스 (결과 있음, 빈 목록)

- [x] `ReviewScheduleServiceTest` — `dismissReview` 2개 케이스 (성공, 404 예외)

- [x] `ReviewScheduleControllerTest` — `getTodayReviews` 3개 케이스 (401, 200+결과, 200+빈목록)

- [x] `ReviewScheduleControllerTest` — `dismissReview` 2개 케이스 (401, 200)

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
