### PR TITLE
[feat] 랭킹 대시보드 API 및 집계 로직 추가

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
+++ b/src/main/java/com/back/domain/matching/queue/service/ReadyCheckService.java
@@ -219,7 +219,7 @@ public class ReadyCheckService {
                 publishMatchExpired(matchSession);
                 matchStateStore.clearTerminalMatch(matchId);
             } catch (IllegalStateException ignored) {
-                // 다른 요청이 먼저 정리한 세션은 그대로 건너뛴다.
+                // deadline 후보 조회 후 accept/decline/room 생성/다른 스케줄러가 먼저 처리한 세션은 건너뛴다.
             }
         }
     }

--- a/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
+++ b/src/main/java/com/back/domain/matching/queue/store/MatchStateStore.java
@@ -82,6 +82,7 @@ public interface MatchStateStore {
 
     /**
      * deadline이 지난 ready-check 세션을 EXPIRED 상태로 전환한다.
+     * deadline 후보 조회 후 다른 요청이 먼저 처리해 ACCEPT_PENDING이 아니면 예외를 던질 수 있다.
      */
     MatchSession expire(Long matchId);
 

--- a/src/main/java/com/back/domain/problem/submission/entity/Submission.java
+++ b/src/main/java/com/back/domain/problem/submission/entity/Submission.java
@@ -2,6 +2,7 @@ package com.back.domain.problem.submission.entity;
 
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.problem.problem.entity.Problem;
 import com.back.global.jpa.entity.BaseEntity;
 
 import jakarta.persistence.*;
@@ -27,6 +28,10 @@ public class Submission extends BaseEntity {
     @JoinColumn(name = "user_id")
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+
     @Column(columnDefinition = "TEXT")
     private String code;
 
@@ -42,6 +47,7 @@ public class Submission extends BaseEntity {
         Submission submission = new Submission();
         submission.battleRoom = battleRoom;
         submission.member = member;
+        submission.problem = battleRoom != null ? battleRoom.getProblem() : null;
         submission.code = code;
         submission.language = language;
         return submission;

--- a/src/main/java/com/back/domain/ranking/dashboard/controller/RankingDashboardController.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/controller/RankingDashboardController.java
@@ -1,0 +1,32 @@
+package com.back.domain.ranking.dashboard.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.ranking.dashboard.dto.RankingDashboardResponse;
+import com.back.domain.ranking.dashboard.service.RankingDashboardService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/rankings")
+public class RankingDashboardController {
+
+    private final RankingDashboardService rankingDashboardService;
+    private final Rq rq;
+
+    @GetMapping("/me/dashboard")
+    public RankingDashboardResponse getMyDashboard() {
+        Member actor = rq.getActor();
+        if (actor == null || actor.getId() == null) {
+            throw new ServiceException("MEMBER_401", "Login is required.");
+        }
+
+        return rankingDashboardService.getMyDashboard(actor.getId());
+    }
+}

--- a/src/main/java/com/back/domain/ranking/dashboard/dto/RankingDashboardResponse.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/dto/RankingDashboardResponse.java
@@ -1,0 +1,38 @@
+package com.back.domain.ranking.dashboard.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RankingDashboardResponse(
+        Profile profile,
+        List<ScoreTrendPoint> scoreTrend,
+        List<GateProgress> gateProgress,
+        List<NearbyRanking> nearbyRanking,
+        List<TierDistribution> tierDistribution,
+        List<TagStat> tagStats,
+        ReviewSummary reviewSummary) {
+
+    public record Profile(
+            Long memberId,
+            String nickname,
+            String tier,
+            long rank,
+            double percentile,
+            long score,
+            String nextTier,
+            long battleMatchCount,
+            int top2Rate,
+            long scoreDeltaTotal) {}
+
+    public record ScoreTrendPoint(String label, LocalDateTime occurredAt, long score, long delta) {}
+
+    public record GateProgress(String key, String label, long current, long target, String suffix) {}
+
+    public record NearbyRanking(long rank, Long memberId, String nickname, String tier, long score, boolean isMe) {}
+
+    public record TierDistribution(String tier, long count, double percentage, boolean isMyTier) {}
+
+    public record TagStat(String tag, long solvedCount, long submissionCount, int accuracy) {}
+
+    public record ReviewSummary(long dueTodayCount, long upcomingCount) {}
+}

--- a/src/main/java/com/back/domain/ranking/dashboard/repository/RankingDashboardQueryRepository.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/repository/RankingDashboardQueryRepository.java
@@ -1,0 +1,259 @@
+package com.back.domain.ranking.dashboard.repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import com.back.domain.ranking.dashboard.dto.RankingDashboardResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingDashboardQueryRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public Optional<MemberRankRow> findMemberRank(Long memberId) {
+        String sql = """
+                with ranked as (
+                    select
+                        m.id as member_id,
+                        m.nickname,
+                        m.tier,
+                        coalesce(m.score, 0) as score,
+                        row_number() over (order by coalesce(m.score, 0) desc, m.id asc) as rank_no,
+                        count(*) over () as total_count
+                    from members m
+                )
+                select member_id, nickname, tier, score, rank_no, total_count
+                from ranked
+                where member_id = :memberId
+                """;
+
+        return queryForOptional(
+                sql,
+                Map.of("memberId", memberId),
+                (rs, rowNum) -> new MemberRankRow(
+                        rs.getLong("member_id"),
+                        rs.getString("nickname"),
+                        rs.getString("tier"),
+                        getLong(rs, "score"),
+                        getLong(rs, "rank_no"),
+                        getLong(rs, "total_count")));
+    }
+
+    public BattleSummary findBattleSummary(Long memberId, int top2WindowSize) {
+        String summarySql = """
+                select
+                    count(*) as battle_match_count,
+                    coalesce(sum(bp.score_delta), 0) as score_delta_total
+                from battle_participants bp
+                join battle_rooms br on br.id = bp.room_id
+                where bp.user_id = :memberId
+                  and upper(br.status) = 'FINISHED'
+                """;
+
+        BattleSummary totalSummary = jdbcTemplate.queryForObject(
+                summarySql,
+                Map.of("memberId", memberId),
+                (rs, rowNum) ->
+                        new BattleSummary(getLong(rs, "battle_match_count"), 0, getLong(rs, "score_delta_total")));
+
+        String recentRanksSql = """
+                select bp.final_rank
+                from battle_participants bp
+                join battle_rooms br on br.id = bp.room_id
+                where bp.user_id = :memberId
+                  and upper(br.status) = 'FINISHED'
+                  and bp.final_rank is not null
+                order by coalesce(bp.finish_time, br.timer_end, br.modified_at, br.created_at, bp.created_at) desc,
+                         bp.id desc
+                limit :limit
+                """;
+
+        SqlParameterSource params =
+                new MapSqlParameterSource().addValue("memberId", memberId).addValue("limit", top2WindowSize);
+        List<Integer> recentRanks =
+                jdbcTemplate.query(recentRanksSql, params, (rs, rowNum) -> getInt(rs, "final_rank"));
+        int top2Rate = calculateTop2Rate(recentRanks);
+
+        return new BattleSummary(totalSummary.battleMatchCount(), top2Rate, totalSummary.scoreDeltaTotal());
+    }
+
+    public List<BattleTrendRow> findRecentBattleTrends(Long memberId, int limit) {
+        String sql = """
+                select
+                    coalesce(bp.finish_time, br.timer_end, br.modified_at, br.created_at, bp.created_at) as occurred_at,
+                    coalesce(bp.score_delta, 0) as delta
+                from battle_participants bp
+                join battle_rooms br on br.id = bp.room_id
+                where bp.user_id = :memberId
+                  and upper(br.status) = 'FINISHED'
+                order by coalesce(bp.finish_time, br.timer_end, br.modified_at, br.created_at, bp.created_at) desc,
+                         bp.id desc
+                limit :limit
+                """;
+
+        SqlParameterSource params =
+                new MapSqlParameterSource().addValue("memberId", memberId).addValue("limit", limit);
+        return jdbcTemplate.query(
+                sql,
+                params,
+                (rs, rowNum) -> new BattleTrendRow(getLocalDateTime(rs, "occurred_at"), getLong(rs, "delta")));
+    }
+
+    public long countSolvedAtLeast(Long memberId, int difficultyRating) {
+        String sql = """
+                select count(distinct coalesce(s.problem_id, br.problem_id)) as solved_count
+                from submissions s
+                left join battle_rooms br on br.id = s.room_id
+                join problems p on p.id = coalesce(s.problem_id, br.problem_id)
+                where s.user_id = :memberId
+                  and s.result = 'AC'
+                  and p.difficulty_rating >= :difficultyRating
+                """;
+
+        SqlParameterSource params = new MapSqlParameterSource()
+                .addValue("memberId", memberId)
+                .addValue("difficultyRating", difficultyRating);
+        Long count = jdbcTemplate.queryForObject(sql, params, Long.class);
+        return count == null ? 0L : count;
+    }
+
+    public List<NearbyRankingRow> findNearbyRanking(Long memberId, int radius) {
+        String sql = """
+                with ranked as (
+                    select
+                        m.id as member_id,
+                        m.nickname,
+                        m.tier,
+                        coalesce(m.score, 0) as score,
+                        row_number() over (order by coalesce(m.score, 0) desc, m.id asc) as rank_no
+                    from members m
+                ),
+                me as (
+                    select rank_no
+                    from ranked
+                    where member_id = :memberId
+                )
+                select r.rank_no, r.member_id, r.nickname, r.tier, r.score
+                from ranked r
+                cross join me
+                where r.rank_no between me.rank_no - :radius and me.rank_no + :radius
+                order by r.rank_no asc
+                """;
+
+        SqlParameterSource params =
+                new MapSqlParameterSource().addValue("memberId", memberId).addValue("radius", radius);
+        return jdbcTemplate.query(
+                sql,
+                params,
+                (rs, rowNum) -> new NearbyRankingRow(
+                        getLong(rs, "rank_no"),
+                        rs.getLong("member_id"),
+                        rs.getString("nickname"),
+                        rs.getString("tier"),
+                        getLong(rs, "score")));
+    }
+
+    public List<TierSourceRow> findTierSources() {
+        String sql = "select tier, coalesce(score, 0) as score from members";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> new TierSourceRow(rs.getString("tier"), getLong(rs, "score")));
+    }
+
+    public List<RankingDashboardResponse.TagStat> findTagStats(Long memberId) {
+        String sql = """
+                select
+                    t.name as tag,
+                    count(*) as submission_count,
+                    count(*) filter (where s.result = 'AC') as ac_submission_count,
+                    count(distinct coalesce(s.problem_id, br.problem_id)) filter (where s.result = 'AC') as solved_count
+                from submissions s
+                left join battle_rooms br on br.id = s.room_id
+                join problem_tag_connect ptc on ptc.problem_id = coalesce(s.problem_id, br.problem_id)
+                join tags t on t.id = ptc.tag_id
+                where s.user_id = :memberId
+                  and coalesce(s.problem_id, br.problem_id) is not null
+                group by t.id, t.name
+                order by solved_count desc, submission_count desc, t.name asc
+                limit 10
+                """;
+
+        return jdbcTemplate.query(sql, Map.of("memberId", memberId), (rs, rowNum) -> {
+            long submissionCount = getLong(rs, "submission_count");
+            long acSubmissionCount = getLong(rs, "ac_submission_count");
+            int accuracy =
+                    submissionCount == 0 ? 0 : (int) Math.round((double) acSubmissionCount * 100.0d / submissionCount);
+            return new RankingDashboardResponse.TagStat(
+                    rs.getString("tag"), getLong(rs, "solved_count"), submissionCount, accuracy);
+        });
+    }
+
+    public RankingDashboardResponse.ReviewSummary findReviewSummary(Long memberId, LocalDateTime now) {
+        String sql = """
+                select
+                    coalesce(sum(case when next_review_at <= :now then 1 else 0 end), 0) as due_today_count,
+                    coalesce(sum(case when next_review_at > :now then 1 else 0 end), 0) as upcoming_count
+                from review_schedule
+                where user_id = :memberId
+                """;
+
+        SqlParameterSource params =
+                new MapSqlParameterSource().addValue("memberId", memberId).addValue("now", now);
+        return jdbcTemplate.queryForObject(
+                sql,
+                params,
+                (rs, rowNum) -> new RankingDashboardResponse.ReviewSummary(
+                        getLong(rs, "due_today_count"), getLong(rs, "upcoming_count")));
+    }
+
+    private <T> Optional<T> queryForOptional(String sql, Map<String, ?> params, RowMapper<T> rowMapper) {
+        return jdbcTemplate.query(sql, params, rowMapper).stream().findFirst();
+    }
+
+    private int calculateTop2Rate(List<Integer> recentRanks) {
+        if (recentRanks == null || recentRanks.isEmpty()) {
+            return 0;
+        }
+
+        long top2Count =
+                recentRanks.stream().filter(rank -> rank != null && rank <= 2).count();
+        return (int) Math.round((double) top2Count * 100.0d / recentRanks.size());
+    }
+
+    private static long getLong(ResultSet rs, String column) throws SQLException {
+        Number value = (Number) rs.getObject(column);
+        return value == null ? 0L : value.longValue();
+    }
+
+    private static int getInt(ResultSet rs, String column) throws SQLException {
+        Number value = (Number) rs.getObject(column);
+        return value == null ? 0 : value.intValue();
+    }
+
+    private static LocalDateTime getLocalDateTime(ResultSet rs, String column) throws SQLException {
+        Timestamp value = rs.getTimestamp(column);
+        return value == null ? null : value.toLocalDateTime();
+    }
+
+    public record MemberRankRow(Long memberId, String nickname, String tier, long score, long rank, long totalCount) {}
+
+    public record BattleSummary(long battleMatchCount, int top2Rate, long scoreDeltaTotal) {}
+
+    public record BattleTrendRow(LocalDateTime occurredAt, long delta) {}
+
+    public record NearbyRankingRow(long rank, Long memberId, String nickname, String tier, long score) {}
+
+    public record TierSourceRow(String tier, long score) {}
+}

--- a/src/main/java/com/back/domain/ranking/dashboard/service/RankingDashboardService.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/service/RankingDashboardService.java
@@ -1,0 +1,276 @@
+package com.back.domain.ranking.dashboard.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.ranking.dashboard.dto.RankingDashboardResponse;
+import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryRepository;
+import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryRepository.BattleSummary;
+import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryRepository.BattleTrendRow;
+import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryRepository.MemberRankRow;
+import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryRepository.TierSourceRow;
+import com.back.global.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RankingDashboardService {
+
+    private static final int TREND_LIMIT = 7;
+    private static final int TOP2_WINDOW_SIZE = 20;
+    private static final int NEARBY_RANKING_RADIUS = 2;
+
+    private static final List<TierCut> TIER_CUTS = List.of(
+            new TierCut("BRONZE_5", 900),
+            new TierCut("BRONZE_4", 1060),
+            new TierCut("BRONZE_3", 1120),
+            new TierCut("BRONZE_2", 1180),
+            new TierCut("BRONZE_1", 1240),
+            new TierCut("SILVER_5", 1300),
+            new TierCut("SILVER_4", 1360),
+            new TierCut("SILVER_3", 1420),
+            new TierCut("SILVER_2", 1480),
+            new TierCut("SILVER_1", 1540),
+            new TierCut("GOLD_5", 1600),
+            new TierCut("GOLD_4", 1660),
+            new TierCut("GOLD_3", 1720),
+            new TierCut("GOLD_2", 1780),
+            new TierCut("GOLD_1", 1840),
+            new TierCut("PLATINUM_5", 1900),
+            new TierCut("PLATINUM_4", 1960),
+            new TierCut("PLATINUM_3", 2020),
+            new TierCut("PLATINUM_2", 2080),
+            new TierCut("PLATINUM_1", 2140),
+            new TierCut("DIAMOND_5", 2200),
+            new TierCut("DIAMOND_4", 2260),
+            new TierCut("DIAMOND_3", 2320),
+            new TierCut("DIAMOND_2", 2380),
+            new TierCut("DIAMOND_1", 2440),
+            new TierCut("MASTER_4", 2500),
+            new TierCut("MASTER_3", 2575),
+            new TierCut("MASTER_2", 2650),
+            new TierCut("MASTER_1", 2725),
+            new TierCut("GOD", Long.MAX_VALUE));
+
+    private final RankingDashboardQueryRepository queryRepository;
+
+    @Transactional(readOnly = true)
+    public RankingDashboardResponse getMyDashboard(Long memberId) {
+        if (memberId == null || memberId <= 0) {
+            throw new ServiceException("MEMBER_400", "Valid member id is required.");
+        }
+
+        MemberRankRow member = queryRepository
+                .findMemberRank(memberId)
+                .orElseThrow(() -> new ServiceException("MEMBER_404", "Member not found."));
+
+        LocalDateTime now = LocalDateTime.now();
+        String currentTier = displayTier(member.tier(), member.score());
+        String nextTier = resolveNextTier(currentTier);
+        BattleSummary battleSummary = queryRepository.findBattleSummary(memberId, TOP2_WINDOW_SIZE);
+
+        RankingDashboardResponse.Profile profile = new RankingDashboardResponse.Profile(
+                member.memberId(),
+                member.nickname(),
+                currentTier,
+                member.rank(),
+                calculatePercentile(member.rank(), member.totalCount()),
+                member.score(),
+                nextTier,
+                battleSummary.battleMatchCount(),
+                battleSummary.top2Rate(),
+                battleSummary.scoreDeltaTotal());
+
+        return new RankingDashboardResponse(
+                profile,
+                buildScoreTrend(memberId, member.score(), now),
+                buildGateProgress(memberId, member.score(), nextTier, battleSummary.top2Rate()),
+                buildNearbyRanking(memberId),
+                buildTierDistribution(currentTier),
+                queryRepository.findTagStats(memberId),
+                queryRepository.findReviewSummary(memberId, now));
+    }
+
+    private List<RankingDashboardResponse.ScoreTrendPoint> buildScoreTrend(
+            Long memberId, long currentScore, LocalDateTime now) {
+        List<BattleTrendRow> recentRows = queryRepository.findRecentBattleTrends(memberId, TREND_LIMIT);
+        if (recentRows.isEmpty()) {
+            return List.of(new RankingDashboardResponse.ScoreTrendPoint("NOW", now, currentScore, 0));
+        }
+
+        List<BattleTrendRow> chronologicalRows = new ArrayList<>(recentRows);
+        Collections.reverse(chronologicalRows);
+
+        long recentDeltaSum =
+                chronologicalRows.stream().mapToLong(BattleTrendRow::delta).sum();
+        long runningScore = currentScore - recentDeltaSum;
+        LocalDate today = now.toLocalDate();
+
+        List<RankingDashboardResponse.ScoreTrendPoint> points = new ArrayList<>(chronologicalRows.size());
+        for (int i = 0; i < chronologicalRows.size(); i++) {
+            BattleTrendRow row = chronologicalRows.get(i);
+            runningScore += row.delta();
+            LocalDateTime occurredAt = row.occurredAt() == null ? now : row.occurredAt();
+            boolean latestPoint = i == chronologicalRows.size() - 1;
+            points.add(new RankingDashboardResponse.ScoreTrendPoint(
+                    latestPoint ? "NOW" : buildDayLabel(occurredAt, today), occurredAt, runningScore, row.delta()));
+        }
+
+        return points;
+    }
+
+    private List<RankingDashboardResponse.GateProgress> buildGateProgress(
+            Long memberId, long currentScore, String nextTier, int top2Rate) {
+        long scoreTarget = nextTier == null || "GOD".equals(nextTier) ? currentScore : resolveTierTarget(nextTier);
+        List<RankingDashboardResponse.GateProgress> gates = new ArrayList<>();
+        gates.add(new RankingDashboardResponse.GateProgress(
+                "SCORE", "\uBC30\uD2C0 \uB808\uC774\uD305", currentScore, scoreTarget, ""));
+
+        if (nextTier == null) {
+            return gates;
+        }
+
+        Map<Integer, Long> solvedCounts = new HashMap<>();
+        if (isTierBetween(nextTier, "GOLD_5", "GOLD_1")) {
+            gates.add(buildSolvedGate(memberId, solvedCounts, 1400, 12));
+        } else if (isTierBetween(nextTier, "PLATINUM_5", "PLATINUM_1")) {
+            gates.add(buildSolvedGate(memberId, solvedCounts, 1700, 20));
+            gates.add(buildSolvedGate(memberId, solvedCounts, 2000, 6));
+        } else if (isTierBetween(nextTier, "DIAMOND_5", "DIAMOND_1")) {
+            gates.add(buildSolvedGate(memberId, solvedCounts, 2000, 30));
+            gates.add(buildSolvedGate(memberId, solvedCounts, 2300, 8));
+            gates.add(new RankingDashboardResponse.GateProgress("RECENT_TOP2", "Top2", top2Rate, 55, "%"));
+        } else if (isTierBetween(nextTier, "MASTER_4", "MASTER_1")) {
+            gates.add(buildSolvedGate(memberId, solvedCounts, 2000, 60));
+            gates.add(buildSolvedGate(memberId, solvedCounts, 2300, 18));
+            gates.add(new RankingDashboardResponse.GateProgress("RECENT_TOP2", "Top2", top2Rate, 65, "%"));
+        }
+
+        return gates;
+    }
+
+    private RankingDashboardResponse.GateProgress buildSolvedGate(
+            Long memberId, Map<Integer, Long> solvedCounts, int difficultyRating, long target) {
+        long current = solvedCounts.computeIfAbsent(
+                difficultyRating, rating -> queryRepository.countSolvedAtLeast(memberId, rating));
+        return new RankingDashboardResponse.GateProgress(
+                "SOLVED_" + difficultyRating, difficultyRating + "+", current, target, "");
+    }
+
+    private List<RankingDashboardResponse.NearbyRanking> buildNearbyRanking(Long memberId) {
+        return queryRepository.findNearbyRanking(memberId, NEARBY_RANKING_RADIUS).stream()
+                .map(row -> new RankingDashboardResponse.NearbyRanking(
+                        row.rank(),
+                        row.memberId(),
+                        row.nickname(),
+                        displayTier(row.tier(), row.score()),
+                        row.score(),
+                        row.memberId().equals(memberId)))
+                .toList();
+    }
+
+    private List<RankingDashboardResponse.TierDistribution> buildTierDistribution(String myTier) {
+        List<TierSourceRow> rows = queryRepository.findTierSources();
+        long totalCount = rows.size();
+        Map<String, Long> tierCounts = new LinkedHashMap<>();
+        rows.forEach(row -> tierCounts.merge(displayTier(row.tier(), row.score()), 1L, Long::sum));
+
+        return tierCounts.entrySet().stream()
+                .sorted(Comparator.comparingInt(entry -> tierOrder(entry.getKey())))
+                .map(entry -> new RankingDashboardResponse.TierDistribution(
+                        entry.getKey(),
+                        entry.getValue(),
+                        totalCount == 0 ? 0.0d : round1((double) entry.getValue() * 100.0d / totalCount),
+                        entry.getKey().equals(myTier)))
+                .toList();
+    }
+
+    private String displayTier(String rawTier, long score) {
+        if (rawTier != null && !rawTier.isBlank()) {
+            String normalizedTier = rawTier.trim();
+            if ("UNRANKED".equals(normalizedTier) || tierOrder(normalizedTier) >= 0) {
+                return normalizedTier;
+            }
+        }
+        return deriveTierFromScore(score);
+    }
+
+    private String deriveTierFromScore(long score) {
+        String tier = "BRONZE_5";
+        for (TierCut tierCut : TIER_CUTS) {
+            if ("GOD".equals(tierCut.tier())) {
+                continue;
+            }
+            if (score >= tierCut.minScore()) {
+                tier = tierCut.tier();
+            }
+        }
+        return tier;
+    }
+
+    private String resolveNextTier(String currentTier) {
+        if ("UNRANKED".equals(currentTier)) {
+            return "BRONZE_5";
+        }
+
+        int currentOrder = tierOrder(currentTier);
+        if (currentOrder < 0 || currentOrder >= TIER_CUTS.size() - 1) {
+            return null;
+        }
+        return TIER_CUTS.get(currentOrder + 1).tier();
+    }
+
+    private long resolveTierTarget(String tier) {
+        return TIER_CUTS.stream()
+                .filter(tierCut -> tierCut.tier().equals(tier))
+                .findFirst()
+                .map(TierCut::minScore)
+                .orElse(0L);
+    }
+
+    private boolean isTierBetween(String tier, String startInclusive, String endInclusive) {
+        int targetOrder = tierOrder(tier);
+        int startOrder = tierOrder(startInclusive);
+        int endOrder = tierOrder(endInclusive);
+        return targetOrder >= startOrder && targetOrder <= endOrder;
+    }
+
+    private int tierOrder(String tier) {
+        for (int i = 0; i < TIER_CUTS.size(); i++) {
+            if (TIER_CUTS.get(i).tier().equals(tier)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private double calculatePercentile(long rank, long totalCount) {
+        if (rank <= 0 || totalCount <= 0) {
+            return 0.0d;
+        }
+        return round1((double) rank * 100.0d / totalCount);
+    }
+
+    private String buildDayLabel(LocalDateTime occurredAt, LocalDate today) {
+        long days = ChronoUnit.DAYS.between(occurredAt.toLocalDate(), today);
+        return "D-" + Math.max(days, 0);
+    }
+
+    private double round1(double value) {
+        return Math.round(value * 10.0d) / 10.0d;
+    }
+
+    private record TierCut(String tier, long minScore) {}
+}

--- a/src/test/java/com/back/domain/ranking/dashboard/controller/RankingDashboardControllerTest.java
+++ b/src/test/java/com/back/domain/ranking/dashboard/controller/RankingDashboardControllerTest.java
@@ -1,0 +1,237 @@
+package com.back.domain.ranking.dashboard.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.global.IntegrationTestBase;
+import com.back.global.jwt.JwtProvider;
+
+@AutoConfigureMockMvc
+@Transactional
+class RankingDashboardControllerTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("delete from submissions");
+        jdbcTemplate.update("delete from solo_submissions");
+        jdbcTemplate.update("delete from battle_participants");
+        jdbcTemplate.update("delete from battle_rooms");
+        jdbcTemplate.update("delete from review_schedule");
+        jdbcTemplate.update("delete from member_problem_first_solves");
+        jdbcTemplate.update("delete from member_rating_profiles");
+        jdbcTemplate.update("delete from problem_tag_connect");
+        jdbcTemplate.update("delete from problem_language_profiles");
+        jdbcTemplate.update("delete from problem_translations");
+        jdbcTemplate.update("delete from test_cases");
+        jdbcTemplate.update("delete from tags");
+        jdbcTemplate.update("delete from problems");
+        jdbcTemplate.update("delete from members");
+    }
+
+    @Test
+    @DisplayName("dashboard returns raw JSON and current DB aggregates")
+    void getMyDashboard_success() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        Long rank1 = insertMember("rank1@example.com", "rank1", 1700, "GOLD_4");
+        Long rank2 = insertMember("rank2@example.com", "rank2", 1600, "GOLD_5");
+        Long me = insertMember("me@example.com", "me", 1580, "SILVER_1");
+        Long rank4 = insertMember("rank4@example.com", "rank4", 1400, "SILVER_4");
+        Long rank5 = insertMember("rank5@example.com", "rank5", 1200, "BRONZE_2");
+
+        Long problem1500 = insertProblem("P1500", "DP Basic", 1500);
+        Long problem2100 = insertProblem("P2100", "DP Hard", 2100);
+        Long dpTag = insertTag("DP");
+        insertProblemTag(problem1500, dpTag);
+        insertProblemTag(problem2100, dpTag);
+
+        Long oldRoom = insertFinishedRoom(problem1500, now.minusDays(6));
+        Long recentRoom = insertFinishedRoom(problem2100, now.minusDays(1));
+        insertParticipant(oldRoom, me, "SOLVED", 1, 20, now.minusDays(6).plusMinutes(10));
+        insertParticipant(recentRoom, me, "TIMEOUT", 3, -5, now.minusDays(1).plusMinutes(10));
+
+        insertSubmission(oldRoom, me, problem1500, "AC", now.minusDays(6).plusMinutes(5));
+        insertSubmission(oldRoom, me, problem1500, "WA", now.minusDays(6).plusMinutes(6));
+        insertSubmission(recentRoom, me, problem2100, "AC", now.minusDays(1).plusMinutes(5));
+        insertReview(me, problem1500, now.minusDays(2), now.minusMinutes(1));
+        insertReview(me, problem2100, now.minusDays(1), now.plusDays(3));
+
+        mockMvc.perform(get("/api/v1/rankings/me/dashboard").cookie(accessToken(me, "me")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").doesNotExist())
+                .andExpect(jsonPath("$.profile.memberId").value(me))
+                .andExpect(jsonPath("$.profile.nickname").value("me"))
+                .andExpect(jsonPath("$.profile.tier").value("SILVER_1"))
+                .andExpect(jsonPath("$.profile.rank").value(3))
+                .andExpect(jsonPath("$.profile.percentile").value(60.0))
+                .andExpect(jsonPath("$.profile.score").value(1580))
+                .andExpect(jsonPath("$.profile.nextTier").value("GOLD_5"))
+                .andExpect(jsonPath("$.profile.battleMatchCount").value(2))
+                .andExpect(jsonPath("$.profile.top2Rate").value(50))
+                .andExpect(jsonPath("$.profile.scoreDeltaTotal").value(15))
+                .andExpect(jsonPath("$.scoreTrend", hasSize(2)))
+                .andExpect(jsonPath("$.scoreTrend[0].label").value("D-6"))
+                .andExpect(jsonPath("$.scoreTrend[0].score").value(1585))
+                .andExpect(jsonPath("$.scoreTrend[0].delta").value(20))
+                .andExpect(jsonPath("$.scoreTrend[1].label").value("NOW"))
+                .andExpect(jsonPath("$.scoreTrend[1].score").value(1580))
+                .andExpect(jsonPath("$.scoreTrend[1].delta").value(-5))
+                .andExpect(jsonPath("$.gateProgress[0].key").value("SCORE"))
+                .andExpect(jsonPath("$.gateProgress[0].current").value(1580))
+                .andExpect(jsonPath("$.gateProgress[0].target").value(1600))
+                .andExpect(jsonPath("$.gateProgress[1].key").value("SOLVED_1400"))
+                .andExpect(jsonPath("$.gateProgress[1].current").value(2))
+                .andExpect(jsonPath("$.gateProgress[1].target").value(12))
+                .andExpect(jsonPath("$.nearbyRanking", hasSize(5)))
+                .andExpect(jsonPath("$.nearbyRanking[0].memberId").value(rank1))
+                .andExpect(jsonPath("$.nearbyRanking[1].memberId").value(rank2))
+                .andExpect(jsonPath("$.nearbyRanking[2].memberId").value(me))
+                .andExpect(jsonPath("$.nearbyRanking[2].isMe").value(true))
+                .andExpect(jsonPath("$.nearbyRanking[3].memberId").value(rank4))
+                .andExpect(jsonPath("$.nearbyRanking[4].memberId").value(rank5))
+                .andExpect(jsonPath("$.tierDistribution[2].tier").value("SILVER_1"))
+                .andExpect(jsonPath("$.tierDistribution[2].percentage").value(20.0))
+                .andExpect(jsonPath("$.tierDistribution[2].isMyTier").value(true))
+                .andExpect(jsonPath("$.tagStats[0].tag").value("DP"))
+                .andExpect(jsonPath("$.tagStats[0].solvedCount").value(2))
+                .andExpect(jsonPath("$.tagStats[0].submissionCount").value(3))
+                .andExpect(jsonPath("$.tagStats[0].accuracy").value(67))
+                .andExpect(jsonPath("$.reviewSummary.dueTodayCount").value(1))
+                .andExpect(jsonPath("$.reviewSummary.upcomingCount").value(1));
+    }
+
+    @Test
+    @DisplayName("dashboard returns empty arrays and zero values for a user without history")
+    void getMyDashboard_emptyUser() throws Exception {
+        Long me = insertMember("empty@example.com", "empty", 0, null);
+
+        mockMvc.perform(get("/api/v1/rankings/me/dashboard").cookie(accessToken(me, "empty")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").doesNotExist())
+                .andExpect(jsonPath("$.profile.memberId").value(me))
+                .andExpect(jsonPath("$.profile.tier").value("BRONZE_5"))
+                .andExpect(jsonPath("$.profile.rank").value(1))
+                .andExpect(jsonPath("$.profile.percentile").value(100.0))
+                .andExpect(jsonPath("$.profile.battleMatchCount").value(0))
+                .andExpect(jsonPath("$.profile.top2Rate").value(0))
+                .andExpect(jsonPath("$.scoreTrend", hasSize(1)))
+                .andExpect(jsonPath("$.scoreTrend[0].label").value("NOW"))
+                .andExpect(jsonPath("$.scoreTrend[0].score").value(0))
+                .andExpect(jsonPath("$.scoreTrend[0].delta").value(0))
+                .andExpect(jsonPath("$.gateProgress[0].key").value("SCORE"))
+                .andExpect(jsonPath("$.gateProgress[0].target").value(1060))
+                .andExpect(jsonPath("$.nearbyRanking", hasSize(1)))
+                .andExpect(jsonPath("$.nearbyRanking[0].isMe").value(true))
+                .andExpect(jsonPath("$.tierDistribution[0].tier").value("BRONZE_5"))
+                .andExpect(jsonPath("$.tierDistribution[0].isMyTier").value(true))
+                .andExpect(jsonPath("$.tagStats", hasSize(0)))
+                .andExpect(jsonPath("$.reviewSummary.dueTodayCount").value(0))
+                .andExpect(jsonPath("$.reviewSummary.upcomingCount").value(0));
+    }
+
+    private MockCookie accessToken(Long memberId, String nickname) {
+        return new MockCookie(
+                "accessToken", jwtProvider.createToken(memberId, nickname + "@example.com", nickname, "ROLE_USER"));
+    }
+
+    private Long insertMember(String email, String nickname, long score, String tier) {
+        return jdbcTemplate.queryForObject("""
+                insert into members (id, email, nickname, password, score, tier, role, created_at)
+                values (nextval('member_id_seq'), ?, ?, 'password', ?, ?, 'USER', now())
+                returning id
+                """, Long.class, email, nickname, score, tier);
+    }
+
+    private Long insertProblem(String sourceProblemId, String title, int difficultyRating) {
+        return jdbcTemplate.queryForObject("""
+                insert into problems (
+                    id, source_problem_id, title, content, difficulty, difficulty_rating,
+                    time_limit_ms, memory_limit_mb, input_mode, judge_type, created_at
+                )
+                values (
+                    nextval('problem_id_seq'), ?, ?, 'content', 'MEDIUM', ?,
+                    1000, 256, 'STDIO', 'EXACT', now()
+                )
+                returning id
+                """, Long.class, sourceProblemId, title, difficultyRating);
+    }
+
+    private Long insertTag(String name) {
+        return jdbcTemplate.queryForObject(
+                "insert into tags (id, name, created_at) values (nextval('tag_id_seq'), ?, now()) returning id",
+                Long.class,
+                name);
+    }
+
+    private void insertProblemTag(Long problemId, Long tagId) {
+        jdbcTemplate.update(
+                "insert into problem_tag_connect (id, problem_id, tag_id, created_at) "
+                        + "values (nextval('problem_tag_id_seq'), ?, ?, now())",
+                problemId,
+                tagId);
+    }
+
+    private Long insertFinishedRoom(Long problemId, LocalDateTime occurredAt) {
+        return jdbcTemplate.queryForObject(
+                """
+                insert into battle_rooms (
+                    id, version, problem_id, status, max_players, timer_end, started_at, created_at
+                )
+                values (nextval('battle_room_id_seq'), 0, ?, 'FINISHED', 4, ?, ?, ?)
+                returning id
+                """, Long.class, problemId, occurredAt.plusMinutes(30), occurredAt, occurredAt);
+    }
+
+    private void insertParticipant(
+            Long roomId, Long memberId, String status, int finalRank, long scoreDelta, LocalDateTime finishTime) {
+        jdbcTemplate.update("""
+                insert into battle_participants (
+                    id, room_id, user_id, status, final_rank, score_delta,
+                    finish_time, is_result_checked, created_at
+                )
+                values (nextval('participant_id_seq'), ?, ?, ?, ?, ?, ?, true, ?)
+                """, roomId, memberId, status, finalRank, scoreDelta, finishTime, finishTime);
+    }
+
+    private void insertSubmission(
+            Long roomId, Long memberId, Long problemId, String result, LocalDateTime submittedAt) {
+        jdbcTemplate.update("""
+                insert into submissions (
+                    id, room_id, user_id, problem_id, code, language,
+                    result, passed_count, total_count, created_at
+                )
+                values (nextval('submission_id_seq'), ?, ?, ?, 'code', 'java', ?, 1, 1, ?)
+                """, roomId, memberId, problemId, result, submittedAt);
+    }
+
+    private void insertReview(Long memberId, Long problemId, LocalDateTime solvedAt, LocalDateTime nextReviewAt) {
+        jdbcTemplate.update("""
+                insert into review_schedule (
+                    id, user_id, problem_id, solved_at, next_review_at, review_count, created_at
+                )
+                values (nextval('review_schedule_id_seq'), ?, ?, ?, ?, 1, now())
+                """, memberId, problemId, solvedAt, nextReviewAt);
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #178 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #178 

---
<html>
<body>
<h1>[feat] 메인 홈 랭킹 대시보드 API 및 집계 로직 구현</h1>

<h3>개요</h3>
<p>이번 PR은 메인 홈에서 사용할 <strong>내 랭킹 대시보드 조회 API</strong>를 추가한 작업입니다.</p>
<p>기존에는 회원의 현재 랭킹, 점수 추이, 근처 랭킹, 티어 분포, 태그별 풀이 통계, 복습 예정 현황 같은 정보를 한 번에 내려주는 전용 API가 없었습니다. 이번 PR에서는 <code>GET /api/v1/rankings/me/dashboard</code> 엔드포인트를 추가하고, 여러 테이블에 흩어진 데이터를 JDBC 집계 쿼리로 조합해 프론트가 바로 메인 대시보드 UI를 그릴 수 있는 응답 구조를 만들었습니다.</p>
<p>또한 제출 이력 기준으로 문제 난이도/태그 통계를 계산할 수 있도록 <code>Submission</code> 엔티티에 <code>problem</code> 연관관계를 추가해, 배틀방 기반 제출에서도 문제 정보 집계가 자연스럽게 이어지도록 보완했습니다.</p>

<hr>

<h2>기존 코드 대비 변경점</h2>

<table>
<tr><th>구분</th><th>기존</th><th>변경 후</th></tr>
<tr>
<td>메인 홈 랭킹 API</td>
<td>전용 API 없음</td>
<td><code>GET /api/v1/rankings/me/dashboard</code> 추가</td>
</tr>
<tr>
<td>랭킹 집계 방식</td>
<td>대시보드용 통합 집계 없음</td>
<td>JDBC 기반 집계 쿼리로 프로필/추이/주변 랭킹/티어 분포/태그/복습 요약 구성</td>
</tr>
<tr>
<td>현재 사용자 식별</td>
<td>별도 대시보드 진입점 없음</td>
<td><code>Rq.getActor()</code> 기준 로그인 사용자 전용 조회</td>
</tr>
<tr>
<td>점수 추이</td>
<td>메인 홈용 시계열 응답 없음</td>
<td>최근 완료 배틀의 <code>score_delta</code>를 바탕으로 <code>D-n</code> / <code>NOW</code> 포인트 생성</td>
</tr>
<tr>
<td>티어 진척도</td>
<td>다음 티어 기준 목표치 계산 없음</td>
<td>점수 / 난이도별 solved 수 / 최근 Top2 비율을 조합한 gateProgress 제공</td>
</tr>
<tr>
<td>태그 통계</td>
<td>메인 홈용 태그별 제출/정답률 집계 없음</td>
<td>태그별 solvedCount / submissionCount / accuracy 집계 제공</td>
</tr>
<tr>
<td>복습 요약</td>
<td>메인 홈에서 due/upcoming 요약 없음</td>
<td><code>review_schedule</code> 기준 <code>dueTodayCount</code>, <code>upcomingCount</code> 제공</td>
</tr>
<tr>
<td>제출-문제 연결</td>
<td><code>Submission</code>에 직접 <code>problem</code> 연관관계 없음</td>
<td><code>Submission.problem</code> 추가, 배틀 제출 생성 시 problem 연결</td>
</tr>
<tr>
<td>검증</td>
<td>대시보드 API 테스트 없음</td>
<td>실DB 집계 기준 통합 테스트 추가</td>
</tr>
</table>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) 내 랭킹 대시보드 조회 API 추가</h3>
<p><code>RankingDashboardController</code>를 추가하고 아래 엔드포인트를 구현했습니다.</p>

<pre><code class="language-text">GET /api/v1/rankings/me/dashboard
</code></pre>

<p>이 API는 로그인 사용자 전용 조회 API입니다.</p>

<pre><code class="language-java">@GetMapping("/me/dashboard")
public RankingDashboardResponse getMyDashboard() {
    Member actor = rq.getActor();
    if (actor == null || actor.getId() == null) {
        throw new ServiceException("MEMBER_401", "Login is required.");
    }

    return rankingDashboardService.getMyDashboard(actor.getId());
}
</code></pre>

<p>즉, 클라이언트가 별도 memberId를 넘기는 구조가 아니라 현재 인증된 사용자의 대시보드만 조회합니다.</p>

<h3>2) 메인 홈 전용 응답 DTO 추가</h3>
<p>응답은 메인 홈 대시보드 화면에서 필요한 영역을 한 번에 표현할 수 있도록 <code>RankingDashboardResponse</code> record로 구성했습니다.</p>

<p>최상위 응답 구조는 아래와 같습니다.</p>
<ul>
<li><code>profile</code> : 내 기본 랭킹/티어 요약</li>
<li><code>scoreTrend</code> : 최근 점수 추이</li>
<li><code>gateProgress</code> : 다음 티어 진척도</li>
<li><code>nearbyRanking</code> : 내 주변 순위</li>
<li><code>tierDistribution</code> : 전체 티어 분포</li>
<li><code>tagStats</code> : 태그별 풀이/제출 통계</li>
<li><code>reviewSummary</code> : 복습 예정 요약</li>
</ul>

<p>특히 <code>profile</code>에는 아래 핵심 필드를 담았습니다.</p>
<ul>
<li><code>memberId</code>, <code>nickname</code></li>
<li><code>tier</code>, <code>rank</code>, <code>percentile</code>, <code>score</code></li>
<li><code>nextTier</code></li>
<li><code>battleMatchCount</code>, <code>top2Rate</code>, <code>scoreDeltaTotal</code></li>
</ul>

<h3>3) 집계 전용 JDBC QueryRepository 추가</h3>
<p>이번 API는 한 엔티티에서 바로 읽을 수 있는 구조가 아니라, 회원/배틀/제출/태그/복습 데이터를 조합해야 합니다. 그래서 JPA 엔티티 그래프 대신 <code>NamedParameterJdbcTemplate</code> 기반의 <code>RankingDashboardQueryRepository</code>를 새로 추가했습니다.</p>

<p>주요 메서드는 아래와 같습니다.</p>
<ul>
<li><code>findMemberRank(memberId)</code> : 현재 사용자 랭킹과 전체 인원 수 조회</li>
<li><code>findBattleSummary(memberId, top2WindowSize)</code> : 배틀 수, 최근 Top2 비율, 점수 증감 합계 조회</li>
<li><code>findRecentBattleTrends(memberId, limit)</code> : 최근 배틀 점수 변화 조회</li>
<li><code>countSolvedAtLeast(memberId, difficultyRating)</code> : 특정 난이도 이상 solved 문제 수 조회</li>
<li><code>findNearbyRanking(memberId, radius)</code> : 내 주변 순위 조회</li>
<li><code>findTierSources()</code> : 전체 회원 티어/점수 소스 조회</li>
<li><code>findTagStats(memberId)</code> : 태그별 제출/정답률 집계</li>
<li><code>findReviewSummary(memberId, now)</code> : 복습 due/upcoming 집계</li>
</ul>

<p>즉, 서비스 계층은 이 QueryRepository가 만든 집계 결과를 조합해서 최종 대시보드 응답을 만드는 구조입니다.</p>

<h3>4) 현재 랭킹 조회는 window function 기반으로 계산</h3>
<p>현재 사용자 랭킹은 <code>members</code> 전체를 점수 내림차순으로 정렬한 뒤, window function으로 계산합니다.</p>

<pre><code class="language-sql">row_number() over (order by coalesce(m.score, 0) desc, m.id asc) as rank_no,
count(*) over () as total_count
</code></pre>

<p>즉, 아래 기준을 사용합니다.</p>
<ul>
<li>점수 높은 순 우선</li>
<li>동점이면 <code>member.id</code> 오름차순</li>
<li>동시에 전체 사용자 수(<code>total_count</code>)도 함께 조회</li>
</ul>

<p>서비스에서는 이를 바탕으로 <code>rank</code>와 <code>percentile</code>을 계산합니다.</p>

<pre><code class="language-java">return round1((double) rank * 100.0d / totalCount);
</code></pre>

<p>즉, 현재 구현의 percentile은 “상위 몇 %”가 아니라 <strong>전체 중 내 rank 비율</strong>을 1자리 반올림한 값입니다.</p>

<h3>5) 프로필 영역 집계</h3>
<p><code>profile</code>은 단순 회원 기본 정보가 아니라 배틀 통계를 함께 묶은 요약 카드 역할을 합니다.</p>

<p>구성 방식은 아래와 같습니다.</p>
<ul>
<li><code>memberId</code>, <code>nickname</code>, <code>score</code> : 현재 회원 정보</li>
<li><code>tier</code> : raw tier가 유효하면 그대로 사용, 없거나 비정상이면 score 기반으로 계산</li>
<li><code>rank</code>, <code>percentile</code> : 전체 회원 기준 랭킹 집계</li>
<li><code>nextTier</code> : 현재 티어 바로 다음 티어 계산</li>
<li><code>battleMatchCount</code> : FINISHED 배틀 참여 횟수</li>
<li><code>top2Rate</code> : 최근 N경기 중 2등 이내 비율</li>
<li><code>scoreDeltaTotal</code> : 완료 배틀의 점수 증감 누적</li>
</ul>

<p>즉, 메인 홈 상단에서 “내 위치와 최근 배틀 성과”를 한 번에 보여주는 프로필 요약입니다.</p>

<h3>6) scoreTrend는 최근 배틀 delta 기반으로 재구성</h3>
<p>점수 추이는 최근 완료된 배틀 기록을 단순 나열하는 방식이 아니라, <strong>현재 점수에서 최근 delta 총합을 역산한 뒤 시계열 score를 다시 만들어내는 방식</strong>으로 구현했습니다.</p>

<pre><code class="language-java">long recentDeltaSum = chronologicalRows.stream().mapToLong(BattleTrendRow::delta).sum();
long runningScore = currentScore - recentDeltaSum;
</code></pre>

<p>그 뒤 오래된 기록부터 순서대로 delta를 누적해서 각 시점의 score를 계산합니다.</p>

<p>응답 규칙은 아래와 같습니다.</p>
<ul>
<li>최근 기록이 없으면 <code>NOW</code> 1개만 반환</li>
<li>최근 기록이 있으면 오래된 순으로 정렬해서 포인트 구성</li>
<li>마지막 포인트 label은 항상 <code>NOW</code></li>
<li>그 이전 포인트는 <code>D-6</code>, <code>D-1</code> 형태로 표시</li>
</ul>

<p>즉, 프론트는 이 값을 그대로 선형 그래프나 미니 차트에 사용할 수 있습니다.</p>

<h3>7) gateProgress는 다음 티어 기준 목표로 계산</h3>
<p>이번 PR에서 중요한 부분 중 하나는 단순 점수만 내려주는 것이 아니라, <strong>다음 티어를 향해 어떤 조건이 얼마나 남았는지</strong>를 함께 계산한다는 점입니다.</p>

<p>모든 사용자에게 기본으로 들어가는 gate는 아래입니다.</p>

<pre><code class="language-java">new GateProgress("SCORE", "배틀 레이팅", currentScore, scoreTarget, "")
</code></pre>

<p>그리고 다음 티어 구간에 따라 추가 목표를 다르게 붙입니다.</p>

<ul>
<li><strong>GOLD_5 ~ GOLD_1 진입 구간</strong>
<ul></ul>
</li>
</ul>
<pre><code class="language-text">1400+ solved 12개
</code></pre>

<ul>
<li><strong>PLATINUM_5 ~ PLATINUM_1 진입 구간</strong></li>
</ul>
<pre><code class="language-text">1700+ solved 20개
2000+ solved 6개
</code></pre>

<ul>
<li><strong>DIAMOND_5 ~ DIAMOND_1 진입 구간</strong></li>
</ul>
<pre><code class="language-text">2000+ solved 30개
2300+ solved 8개
최근 Top2 55%
</code></pre>

<ul>
<li><strong>MASTER_4 ~ MASTER_1 진입 구간</strong></li>
</ul>
<pre><code class="language-text">2000+ solved 60개
2300+ solved 18개
최근 Top2 65%
</code></pre>

<p>즉, 메인 홈에서 “다음 티어까지 점수만 부족한지, 난이도 높은 문제 풀이 수가 부족한지, 최근 배틀 성적이 부족한지”를 동시에 보여줄 수 있습니다.</p>

<h3>8) solved gate는 AC 기준 distinct problem 수로 계산</h3>
<p>난이도별 solved 수는 단순 제출 횟수가 아니라, <strong>AC를 받은 distinct problem 수</strong>를 기준으로 집계합니다.</p>

<pre><code class="language-sql">count(distinct coalesce(s.problem_id, br.problem_id)) as solved_count
</code></pre>

<p>또한 문제 ID는 아래 우선순위로 가져옵니다.</p>
<ul>
<li><code>submissions.problem_id</code>가 있으면 그것 사용</li>
<li>없으면 <code>battle_rooms.problem_id</code> 사용</li>
</ul>

<p>즉, 배틀 기반 제출과 직접 문제 연결 제출을 모두 같은 solved 기준으로 해석할 수 있도록 맞췄습니다.</p>

<h3>9) nearbyRanking은 내 주변 반경 2칸을 반환</h3>
<p>내 주변 순위는 전체 랭킹에서 내 순위를 중심으로 앞뒤 2명씩 조회합니다.</p>

<pre><code class="language-java">private static final int NEARBY_RANKING_RADIUS = 2;
</code></pre>

<p>즉, 기본적으로 최대 5명을 내려줍니다.</p>
<ul>
<li>내 위 2명</li>
<li>나</li>
<li>내 아래 2명</li>
</ul>

<p>응답에는 <code>isMe</code> 플래그를 함께 넣어서 프론트가 현재 사용자를 강조 표시할 수 있게 했습니다.</p>

<h3>10) tierDistribution은 전체 회원 기준 비율을 계산</h3>
<p>티어 분포는 <code>members</code> 전체를 읽어 각 사용자의 표시용 tier를 구한 뒤, 티어별 인원 수와 비율을 계산합니다.</p>

<p>표시용 tier는 아래 규칙을 따릅니다.</p>
<ul>
<li>raw tier가 정상 값이면 그대로 사용</li>
<li>raw tier가 비어 있거나 유효하지 않으면 score 기준으로 tier 유도</li>
<li>정렬은 BRONZE_5부터 GOD까지 정의된 tier order 기준</li>
</ul>

<p>비율은 전체 회원 수 대비 1자리 반올림한 percentage로 내려줍니다.</p>

<pre><code class="language-java">round1((double) count * 100.0d / totalCount)
</code></pre>

<p>그리고 현재 사용자 tier와 일치하는 항목에는 <code>isMyTier=true</code>를 넣습니다.</p>

<h3>11) tagStats는 태그별 solved / submissions / accuracy를 계산</h3>
<p>태그 통계는 <code>submissions</code>와 <code>problem_tag_connect</code>, <code>tags</code>를 조인해 계산합니다.</p>

<p>응답 필드는 아래 의미를 가집니다.</p>
<ul>
<li><code>tag</code> : 태그명</li>
<li><code>solvedCount</code> : 해당 태그 문제 중 AC로 푼 distinct 문제 수</li>
<li><code>submissionCount</code> : 해당 태그 문제에 대한 총 제출 수</li>
<li><code>accuracy</code> : AC 제출 수 / 전체 제출 수 비율(반올림 정수)</li>
</ul>

<p>정렬 기준은 아래와 같습니다.</p>
<ul>
<li>solvedCount 내림차순</li>
<li>submissionCount 내림차순</li>
<li>tag 이름 오름차순</li>
</ul>

<p>즉, 메인 홈에서 “내가 어떤 태그를 많이 풀고 있는지, 어느 태그에서 정답률이 어떤지”를 바로 노출할 수 있습니다.</p>

<h3>12) reviewSummary는 due / upcoming 복습 수를 요약</h3>
<p>복습 요약은 <code>review_schedule</code> 테이블을 기준으로, 현재 시각보다 이전/같은 복습과 이후 복습을 나눠 집계합니다.</p>

<pre><code class="language-sql">sum(case when next_review_at <= :now then 1 else 0 end) as due_today_count,
sum(case when next_review_at > :now then 1 else 0 end) as upcoming_count
</code></pre>

<p>즉, 메인 홈에서 아래 2가지를 간단히 보여줄 수 있습니다.</p>
<ul>
<li>오늘 바로 복습해야 하는 문제 수</li>
<li>앞으로 예정된 복습 수</li>
</ul>

<h3>13) tier 계산 로직을 서비스에 명시적으로 추가</h3>
<p>회원의 raw tier 값을 그대로 신뢰하지 않고, 필요 시 score 기반 티어 유도 로직을 사용하도록 했습니다.</p>

<p>현재 구현에는 BRONZE_5부터 GOD까지 티어 컷을 서비스 내부 상수로 두고 있습니다.</p>

<pre><code class="language-java">new TierCut("BRONZE_5", 900)
...
new TierCut("MASTER_1", 2725)
new TierCut("GOD", Long.MAX_VALUE)
</code></pre>

<p>즉, raw tier가 없거나 비정상인 사용자도 score만 있으면 메인 홈에 표시할 tier를 안정적으로 계산할 수 있습니다.</p>

<h3>14) Submission 엔티티에 problem 연관관계 추가</h3>
<p>이번 PR에서 API만 추가된 것이 아니라, 대시보드 집계를 안정적으로 하기 위해 <code>Submission</code> 엔티티에도 변경이 들어갔습니다.</p>

<pre><code class="language-java">@ManyToOne(fetch = FetchType.LAZY)
@JoinColumn(name = "problem_id")
private Problem problem;
</code></pre>

<p>그리고 제출 생성 시점에 배틀방이 있으면 그 방의 문제를 submission에도 연결하도록 했습니다.</p>

<pre><code class="language-java">submission.problem = battleRoom != null ? battleRoom.getProblem() : null;
</code></pre>

<p>이 변경으로 인해 아래 집계가 더 자연스럽게 연결됩니다.</p>
<ul>
<li>difficulty_rating 기준 solved 수 집계</li>
<li>태그별 통계 집계</li>
<li>submission 자체 problem_id가 있는 경우와 battle_room 문제를 참조하는 경우를 함께 처리</li>
</ul>

<p>즉, 대시보드용 문제/태그 집계 기반을 Submission 레벨에서도 보강한 것입니다.</p>

<h3>15) 응답은 공통 wrapper 없이 raw JSON 형태로 반환</h3>
<p>테스트에서도 명시적으로 확인하듯, 이 API는 기존 일부 응답처럼 <code>resultCode</code> wrapper를 두지 않고 raw JSON 자체를 반환합니다.</p>

<pre><code class="language-java">.andExpect(jsonPath("$.resultCode").doesNotExist())
</code></pre>

<p>즉, 프론트는 바로 <code>profile</code>, <code>scoreTrend</code>, <code>gateProgress</code> 등을 최상위 필드로 읽으면 됩니다.</p>

<h3>16) 통합 테스트 추가</h3>
<p><code>RankingDashboardControllerTest</code>를 추가해 실제 DB 적재 데이터를 기준으로 응답 JSON이 기대대로 내려오는지 검증했습니다.</p>

<p>주요 시나리오는 아래 2가지입니다.</p>

<ul>
<li><strong>히스토리가 있는 사용자</strong>
<ul></ul>
</li>
</ul>
<pre><code class="language-text">- 회원 5명 랭킹 데이터 생성
- 문제 2개, 태그 1개 생성
- 완료 배틀 2개, 참가 기록 2개 생성
- 제출 3개 생성 (AC/WA 포함)
- review_schedule 2개 생성
- 응답에서 profile / scoreTrend / gateProgress / nearbyRanking / tierDistribution / tagStats / reviewSummary 검증
</code></pre>

<ul>
<li><strong>이력이 없는 사용자</strong></li>
</ul>
<pre><code class="language-text">- score=0, tier=null 인 사용자 생성
- BRONZE_5 유도
- NOW 1포인트 scoreTrend
- gateProgress SCORE만 존재
- nearbyRanking 1건
- 빈 tagStats / 0 reviewSummary 검증
</code></pre>

<p>즉, 단순 컨트롤러 목 테스트가 아니라 실제 집계 쿼리와 응답 계산이 함께 맞는지 확인하는 통합 테스트를 추가했습니다.</p>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">GET /api/v1/rankings/me/dashboard
      ↓
RankingDashboardController
  - 현재 로그인 사용자 확인
  - 미로그인 시 MEMBER_401
      ↓
RankingDashboardService.getMyDashboard(memberId)
      ↓
1. 회원 랭킹/전체 인원 수 조회
2. 현재 tier / nextTier 계산
3. 배틀 요약 집계
4. 최근 점수 추이 생성
5. 다음 티어 gateProgress 계산
6. 주변 랭킹 조회
7. 전체 티어 분포 계산
8. 태그별 제출/풀이 통계 조회
9. 복습 due/upcoming 요약 조회
      ↓
RankingDashboardResponse 반환
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>메인 홈에서 필요한 랭킹/성장/복습 정보를 단일 API로 조회할 수 있습니다.</li>
<li>프론트는 여러 API를 조합하지 않고 한 응답으로 대시보드 UI를 구성할 수 있습니다.</li>
<li>배틀 이력, 문제 난이도, 태그, 복습 스케줄이 하나의 사용자 관점 대시보드로 연결됩니다.</li>
<li><code>Submission.problem</code> 연관관계 추가로 이후 문제/태그 기반 통계 확장도 더 자연스러워집니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li><code>GET /api/v1/rankings/me/dashboard</code> 호출 시 로그인 사용자 기준으로만 응답이 내려오는지 확인</li>
<li><code>profile</code>의 rank / percentile / nextTier / top2Rate / scoreDeltaTotal 계산이 기대한 기준과 맞는지 확인</li>
<li><code>scoreTrend</code>가 현재 score 기준으로 역산된 시계열 값으로 내려오는지 확인</li>
<li><code>gateProgress</code>가 다음 티어 구간별 규칙에 맞게 생성되는지 확인</li>
<li><code>tagStats</code>와 <code>reviewSummary</code>가 실제 메인 홈 카드 요구사항과 맞는지 확인</li>
<li><code>Submission.problem</code> 추가가 기존 제출 생성 흐름과 충돌하지 않는지 확인</li>
</ol>
</body>
</html>


