### PR TITLE
fix: RankingDashboardControllerTest CI 실패 수정

### DIFF
--- a/src/test/java/com/back/domain/ranking/dashboard/controller/RankingDashboardControllerTest.java
+++ b/src/test/java/com/back/domain/ranking/dashboard/controller/RankingDashboardControllerTest.java
@@ -229,9 +229,9 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
     private void insertReview(Long memberId, Long problemId, LocalDateTime solvedAt, LocalDateTime nextReviewAt) {
         jdbcTemplate.update("""
                 insert into review_schedule (
-                    id, user_id, problem_id, solved_at, next_review_at, review_count, created_at
+                    id, user_id, problem_id, solved_at, next_review_at, review_count, is_review_required, created_at
                 )
-                values (nextval('review_schedule_id_seq'), ?, ?, ?, ?, 1, now())
+                values (nextval('review_schedule_id_seq'), ?, ?, ?, ?, 1, true, now())
                 """, memberId, problemId, solvedAt, nextReviewAt);
     }
 }


### PR DESCRIPTION
## 변경 사항
- `RankingDashboardControllerTest`의 `insertReview` SQL에 `is_review_required` 컬럼/값 추가
- `review_schedule`의 NOT NULL 제약(`is_review_required`)과 테스트 데이터 정합성 맞춤

## 원인
- 엔티티/스키마에는 `is_review_required`가 필수인데 테스트 SQL이 해당 컬럼을 누락해서 `DataIntegrityViolationException` 발생

## 검증
- `./gradlew test --tests 'com.back.domain.ranking.dashboard.controller.RankingDashboardControllerTest'`
