### PR TITLE
[feat] TodayReviewResponse에 totalCount 필드 추가

### DIFF
--- a/src/main/java/com/back/domain/review/reviewschedule/dto/TodayReviewResponse.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/dto/TodayReviewResponse.java
@@ -4,7 +4,11 @@ import java.util.List;
 
 import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
 
-public record TodayReviewResponse(List<ReviewItem> reviews) {
+public record TodayReviewResponse(int totalCount, List<ReviewItem> reviews) {
+
+    public TodayReviewResponse(List<ReviewItem> reviews) {
+        this(reviews.size(), reviews);
+    }
 
     public record ReviewItem(Long problemId, String problemTitle, int reviewCount) {
         public static ReviewItem from(ReviewSchedule schedule) {

--- a/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
@@ -48,6 +48,7 @@ class ReviewScheduleControllerTest {
         RsData<TodayReviewResponse> result = controller.getTodayReviews();
 
         assertThat(result.resultCode()).isEqualTo("200");
+        assertThat(result.data().totalCount()).isEqualTo(1);
         assertThat(result.data().reviews()).hasSize(1);
         assertThat(result.data().reviews().get(0).problemId()).isEqualTo(10L);
         assertThat(result.data().reviews().get(0).problemTitle()).isEqualTo("문제A");

--- a/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
@@ -123,6 +123,7 @@ class ReviewScheduleServiceTest {
 
         TodayReviewResponse response = reviewScheduleService.getTodayReviews(99L);
 
+        assertThat(response.totalCount()).isEqualTo(2);
         assertThat(response.reviews()).hasSize(2);
         assertThat(response.reviews().get(0).problemId()).isEqualTo(10L);
         assertThat(response.reviews().get(0).problemTitle()).isEqualTo("문제A");


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #184
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #184

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
오늘 복습할 문제 수를 reviews.size()에서 자동 산출하여 반환.
  서비스/컨트롤러 변경 없이 위임 생성자로 기존 호출 코드 유지.

---

## ✅ 주요 변경 사항
1) 예) 새로운 기능 추가
2) 
3) 

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
```bash
# 예) ./gradlew test --tests "com.back.domain.email.scheduler.DdayEmailSchedulerTest"
```

- [ ] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
