### PR TITLE
feat: 관리자 문제 등록/검증/임포트 API 및 가드 추가

### DIFF
--- a/src/main/java/com/back/domain/problem/languageprofile/entity/ProblemLanguageProfile.java
+++ b/src/main/java/com/back/domain/problem/languageprofile/entity/ProblemLanguageProfile.java
@@ -44,4 +44,14 @@ public class ProblemLanguageProfile extends BaseEntity {
     @Column(name = "is_default", nullable = false)
     // 상세 화면 기본 선택 언어 여부
     private Boolean isDefault;
+
+    public static ProblemLanguageProfile create(
+            Problem problem, String languageCode, String starterCode, Boolean isDefault) {
+        ProblemLanguageProfile profile = new ProblemLanguageProfile();
+        profile.problem = problem;
+        profile.languageCode = languageCode;
+        profile.starterCode = starterCode;
+        profile.isDefault = Boolean.TRUE.equals(isDefault);
+        return profile;
+    }
 }

--- a/src/main/java/com/back/domain/problem/languageprofile/repository/ProblemLanguageProfileRepository.java
+++ b/src/main/java/com/back/domain/problem/languageprofile/repository/ProblemLanguageProfileRepository.java
@@ -9,4 +9,6 @@ import com.back.domain.problem.languageprofile.entity.ProblemLanguageProfile;
 public interface ProblemLanguageProfileRepository extends JpaRepository<ProblemLanguageProfile, Long> {
     // 상세 응답 구성 시 문제별 언어 profile 전체를 안정적인 순서(id 오름차순)로 조회
     List<ProblemLanguageProfile> findByProblemIdOrderByIdAsc(Long problemId);
+
+    void deleteByProblemId(Long problemId);
 }

--- a/src/main/java/com/back/domain/problem/problem/controller/AdminProblemController.java
+++ b/src/main/java/com/back/domain/problem/problem/controller/AdminProblemController.java
@@ -1,0 +1,57 @@
+package com.back.domain.problem.problem.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.back.domain.problem.problem.dto.AdminProblemBulkImportResponse;
+import com.back.domain.problem.problem.dto.AdminProblemBulkRequest;
+import com.back.domain.problem.problem.dto.AdminProblemBulkValidateResponse;
+import com.back.domain.problem.problem.dto.AdminProblemMutationResponse;
+import com.back.domain.problem.problem.dto.AdminProblemSingleValidateResponse;
+import com.back.domain.problem.problem.dto.AdminProblemUpsertRequest;
+import com.back.domain.problem.problem.service.AdminProblemService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/problems")
+@RequiredArgsConstructor
+public class AdminProblemController {
+
+    private final AdminProblemService adminProblemService;
+
+    @PostMapping
+    public ResponseEntity<AdminProblemMutationResponse> create(@Valid @RequestBody AdminProblemUpsertRequest request) {
+        AdminProblemMutationResponse response = adminProblemService.createProblem(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping("/{problemId}")
+    public AdminProblemMutationResponse update(
+            @PathVariable("problemId") Long problemId, @Valid @RequestBody AdminProblemUpsertRequest request) {
+        return adminProblemService.updateProblem(problemId, request);
+    }
+
+    @PostMapping("/bulk/validate")
+    public AdminProblemBulkValidateResponse validate(@Valid @RequestBody AdminProblemBulkRequest request) {
+        return adminProblemService.validateBulk(request);
+    }
+
+    @PostMapping("/validate")
+    public AdminProblemSingleValidateResponse validateSingle(@Valid @RequestBody AdminProblemUpsertRequest request) {
+        return adminProblemService.validateSingle(request);
+    }
+
+    @PostMapping("/bulk/import")
+    public ResponseEntity<?> importBulk(@Valid @RequestBody AdminProblemBulkRequest request) {
+        AdminProblemBulkValidateResponse validateResponse = adminProblemService.validateBulk(request);
+        if (!validateResponse.errors().isEmpty()) {
+            return ResponseEntity.badRequest().body(validateResponse);
+        }
+
+        AdminProblemBulkImportResponse importResponse = adminProblemService.importBulk(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(importResponse);
+    }
+}

--- a/src/main/java/com/back/domain/problem/problem/dto/AdminProblemBulkImportResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/AdminProblemBulkImportResponse.java
@@ -1,0 +1,5 @@
+package com.back.domain.problem.problem.dto;
+
+import java.util.List;
+
+public record AdminProblemBulkImportResponse(int total, int inserted, int updated, List<Long> problemIds) {}

--- a/src/main/java/com/back/domain/problem/problem/dto/AdminProblemBulkRequest.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/AdminProblemBulkRequest.java
@@ -1,0 +1,10 @@
+package com.back.domain.problem.problem.dto;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+public record AdminProblemBulkRequest(
+        @NotEmpty(message = "problems는 최소 1개 이상이어야 합니다.") List<@Valid AdminProblemUpsertRequest> problems,
+        String validationToken) {}

--- a/src/main/java/com/back/domain/problem/problem/dto/AdminProblemBulkValidateResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/AdminProblemBulkValidateResponse.java
@@ -1,0 +1,12 @@
+package com.back.domain.problem.problem.dto;
+
+import java.util.List;
+
+public record AdminProblemBulkValidateResponse(
+        int total, int validCount, List<ValidationError> errors, String validationToken) {
+    public AdminProblemBulkValidateResponse(int total, int validCount, List<ValidationError> errors) {
+        this(total, validCount, errors, null);
+    }
+
+    public record ValidationError(int index, String field, String message) {}
+}

--- a/src/main/java/com/back/domain/problem/problem/dto/AdminProblemMutationResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/AdminProblemMutationResponse.java
@@ -1,0 +1,3 @@
+package com.back.domain.problem.problem.dto;
+
+public record AdminProblemMutationResponse(Long problemId, String mode, String sourceProblemId, String title) {}

--- a/src/main/java/com/back/domain/problem/problem/dto/AdminProblemSingleValidateResponse.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/AdminProblemSingleValidateResponse.java
@@ -1,0 +1,7 @@
+package com.back.domain.problem.problem.dto;
+
+import java.util.List;
+
+public record AdminProblemSingleValidateResponse(boolean valid, List<ValidationError> errors) {
+    public record ValidationError(String field, String message) {}
+}

--- a/src/main/java/com/back/domain/problem/problem/dto/AdminProblemUpsertRequest.java
+++ b/src/main/java/com/back/domain/problem/problem/dto/AdminProblemUpsertRequest.java
@@ -1,0 +1,51 @@
+package com.back.domain.problem.problem.dto;
+
+import java.util.List;
+
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+import com.back.domain.problem.problem.enums.InputMode;
+import com.back.domain.problem.problem.enums.JudgeType;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record AdminProblemUpsertRequest(
+        @Size(max = 50, message = "sourceProblemId는 50자 이하여야 합니다.") String sourceProblemId,
+
+        @NotBlank(message = "title은 필수입니다.") String title,
+        @NotNull(message = "difficulty는 필수입니다.") DifficultyLevel difficulty,
+        @NotBlank(message = "content는 필수입니다.") String content,
+
+        @NotNull(message = "difficultyRating은 필수입니다.") @Min(value = 800, message = "difficultyRating은 800 이상이어야 합니다.") @Max(value = 3500, message = "difficultyRating은 3500 이하여야 합니다.") Integer difficultyRating,
+
+        @NotNull(message = "timeLimitMs는 필수입니다.") @Positive(message = "timeLimitMs는 양수여야 합니다.") Long timeLimitMs,
+
+        @NotNull(message = "memoryLimitMb는 필수입니다.") @Positive(message = "memoryLimitMb는 양수여야 합니다.") Long memoryLimitMb,
+
+        String inputFormat,
+        String outputFormat,
+        InputMode inputMode,
+        JudgeType judgeType,
+        String checkerCode,
+        List<String> tags,
+
+        List<@Valid StarterCodeRequest> starterCodes,
+
+        @NotNull(message = "sampleCases는 필수입니다.") @Size(min = 3, message = "sampleCases는 최소 3개 이상이어야 합니다.") List<@Valid TestCaseRequest> sampleCases,
+
+        @NotNull(message = "hiddenCases는 필수입니다.") @Size(min = 10, message = "hiddenCases는 최소 10개 이상이어야 합니다.") List<@Valid TestCaseRequest> hiddenCases) {
+
+    public record StarterCodeRequest(
+            @NotBlank(message = "language는 필수입니다.") String language,
+            @NotBlank(message = "code는 필수입니다.") String code,
+            @NotNull(message = "isDefault는 필수입니다.") Boolean isDefault) {}
+
+    public record TestCaseRequest(
+            @NotNull(message = "input은 필수입니다.") String input,
+            @NotNull(message = "output은 필수입니다.") String output) {}
+}

--- a/src/main/java/com/back/domain/problem/problem/entity/Problem.java
+++ b/src/main/java/com/back/domain/problem/problem/entity/Problem.java
@@ -21,7 +21,8 @@ import lombok.NoArgsConstructor;
 public class Problem extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "problem_seq_gen")
-    @SequenceGenerator(name = "problem_seq_gen", sequenceName = "problem_id_seq", allocationSize = 50)
+    // 문제 ID는 관리자 화면/운영 확인 편의를 위해 1씩 증가하도록 유지한다.
+    @SequenceGenerator(name = "problem_seq_gen", sequenceName = "problem_id_seq", allocationSize = 1)
     private Long id;
 
     @Column(name = "source_problem_id", unique = true, length = 50)
@@ -71,4 +72,97 @@ public class Problem extends BaseEntity {
 
     @OneToMany(mappedBy = "problem")
     private List<TestCase> testCases = new ArrayList<>();
+
+    public static Problem create(
+            String sourceProblemId,
+            String title,
+            DifficultyLevel difficulty,
+            String content,
+            Integer difficultyRating,
+            Long timeLimitMs,
+            Long memoryLimitMb,
+            String inputFormat,
+            String outputFormat,
+            InputMode inputMode,
+            JudgeType judgeType,
+            String checkerCode) {
+        Problem problem = new Problem();
+        problem.apply(
+                sourceProblemId,
+                title,
+                difficulty,
+                content,
+                difficultyRating,
+                timeLimitMs,
+                memoryLimitMb,
+                inputFormat,
+                outputFormat,
+                inputMode,
+                judgeType,
+                checkerCode);
+        return problem;
+    }
+
+    public void update(
+            String sourceProblemId,
+            String title,
+            DifficultyLevel difficulty,
+            String content,
+            Integer difficultyRating,
+            Long timeLimitMs,
+            Long memoryLimitMb,
+            String inputFormat,
+            String outputFormat,
+            InputMode inputMode,
+            JudgeType judgeType,
+            String checkerCode) {
+        apply(
+                sourceProblemId,
+                title,
+                difficulty,
+                content,
+                difficultyRating,
+                timeLimitMs,
+                memoryLimitMb,
+                inputFormat,
+                outputFormat,
+                inputMode,
+                judgeType,
+                checkerCode);
+    }
+
+    private void apply(
+            String sourceProblemId,
+            String title,
+            DifficultyLevel difficulty,
+            String content,
+            Integer difficultyRating,
+            Long timeLimitMs,
+            Long memoryLimitMb,
+            String inputFormat,
+            String outputFormat,
+            InputMode inputMode,
+            JudgeType judgeType,
+            String checkerCode) {
+        this.sourceProblemId = normalizeSourceProblemId(sourceProblemId);
+        this.title = title;
+        this.difficulty = difficulty;
+        this.content = content;
+        this.difficultyRating = difficultyRating;
+        this.timeLimitMs = timeLimitMs;
+        this.memoryLimitMb = memoryLimitMb;
+        this.inputFormat = inputFormat;
+        this.outputFormat = outputFormat;
+        this.inputMode = inputMode != null ? inputMode : InputMode.STDIO;
+        this.judgeType = judgeType != null ? judgeType : JudgeType.EXACT;
+        this.checkerCode = checkerCode;
+    }
+
+    private String normalizeSourceProblemId(String sourceProblemId) {
+        if (sourceProblemId == null) {
+            return null;
+        }
+        String normalized = sourceProblemId.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
 }

--- a/src/main/java/com/back/domain/problem/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/back/domain/problem/problem/repository/ProblemRepository.java
@@ -1,7 +1,44 @@
 package com.back.domain.problem.problem.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+import com.back.domain.problem.problem.enums.InputMode;
+import com.back.domain.problem.problem.enums.JudgeType;
 
-public interface ProblemRepository extends JpaRepository<Problem, Long> {}
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+    Optional<Problem> findBySourceProblemId(String sourceProblemId);
+
+    @Query("""
+            select p.id
+            from Problem p
+            where p.title = :title
+              and p.content = :content
+              and p.difficulty = :difficulty
+              and p.difficultyRating = :difficultyRating
+              and p.timeLimitMs = :timeLimitMs
+              and p.memoryLimitMb = :memoryLimitMb
+              and p.inputMode = :inputMode
+              and p.judgeType = :judgeType
+              and ((p.inputFormat is null and :inputFormat is null) or p.inputFormat = :inputFormat)
+              and ((p.outputFormat is null and :outputFormat is null) or p.outputFormat = :outputFormat)
+              and ((p.checkerCode is null and :checkerCode is null) or p.checkerCode = :checkerCode)
+            """)
+    java.util.List<Long> findIdsBySignature(
+            @Param("title") String title,
+            @Param("content") String content,
+            @Param("difficulty") DifficultyLevel difficulty,
+            @Param("difficultyRating") Integer difficultyRating,
+            @Param("timeLimitMs") Long timeLimitMs,
+            @Param("memoryLimitMb") Long memoryLimitMb,
+            @Param("inputMode") InputMode inputMode,
+            @Param("judgeType") JudgeType judgeType,
+            @Param("inputFormat") String inputFormat,
+            @Param("outputFormat") String outputFormat,
+            @Param("checkerCode") String checkerCode);
+}

--- a/src/main/java/com/back/domain/problem/problem/service/AdminProblemService.java
+++ b/src/main/java/com/back/domain/problem/problem/service/AdminProblemService.java
@@ -1,0 +1,655 @@
+package com.back.domain.problem.problem.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.problem.languageprofile.entity.ProblemLanguageProfile;
+import com.back.domain.problem.languageprofile.repository.ProblemLanguageProfileRepository;
+import com.back.domain.problem.problem.dto.AdminProblemBulkImportResponse;
+import com.back.domain.problem.problem.dto.AdminProblemBulkRequest;
+import com.back.domain.problem.problem.dto.AdminProblemBulkValidateResponse;
+import com.back.domain.problem.problem.dto.AdminProblemMutationResponse;
+import com.back.domain.problem.problem.dto.AdminProblemSingleValidateResponse;
+import com.back.domain.problem.problem.dto.AdminProblemUpsertRequest;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.enums.InputMode;
+import com.back.domain.problem.problem.enums.JudgeType;
+import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.domain.problem.testcase.entity.TestCase;
+import com.back.domain.problem.testcase.repository.TestCaseRepository;
+import com.back.domain.tag.problemtagconnect.entity.ProblemTagConnect;
+import com.back.domain.tag.problemtagconnect.repository.ProblemTagConnectRepository;
+import com.back.domain.tag.tag.entity.Tag;
+import com.back.domain.tag.tag.repository.TagRepository;
+import com.back.global.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminProblemService {
+    private static final Duration BULK_VALIDATION_TTL = Duration.ofMinutes(10);
+
+    private static final String PYTHON3_STARTER = """
+            def solve():
+                pass
+
+            if __name__ == "__main__":
+                solve()
+            """;
+    private static final String JAVA_STARTER = """
+            import java.io.*;
+            import java.util.*;
+
+            public class Main {
+                public static void main(String[] args) throws Exception {
+                    // TODO
+                }
+            }
+            """;
+    private static final String CPP17_STARTER = """
+            #include <bits/stdc++.h>
+            using namespace std;
+
+            int main() {
+                ios::sync_with_stdio(false);
+                cin.tie(nullptr);
+                // TODO
+                return 0;
+            }
+            """;
+    private static final String C_STARTER = """
+            #include <stdio.h>
+
+            int main(void) {
+                // TODO
+                return 0;
+            }
+            """;
+    private static final String JAVASCRIPT_STARTER = """
+            'use strict';
+
+            function solve(input) {
+              // TODO
+              return '';
+            }
+
+            const fs = require('fs');
+            const input = fs.readFileSync(0, 'utf8');
+            const output = solve(input);
+            if (output !== undefined) {
+              process.stdout.write(String(output));
+            }
+            """;
+
+    private final ProblemRepository problemRepository;
+    private final ProblemLanguageProfileRepository problemLanguageProfileRepository;
+    private final ProblemTagConnectRepository problemTagConnectRepository;
+    private final TestCaseRepository testCaseRepository;
+    private final TagRepository tagRepository;
+    private final ConcurrentHashMap<String, BulkValidationState> bulkValidationStateMap = new ConcurrentHashMap<>();
+
+    private record BulkValidationState(String payloadHash, Instant expiresAt) {}
+
+    @Transactional
+    public AdminProblemMutationResponse createProblem(AdminProblemUpsertRequest request) {
+        AdminProblemUpsertRequest normalizedRequest = normalizeEscapedNewlineFields(request);
+        String sourceProblemId = resolveSourceProblemIdForCreate(normalizedRequest);
+        validateBusinessRules(normalizedRequest, null, sourceProblemId);
+        Problem problem = problemRepository
+                .findBySourceProblemId(sourceProblemId)
+                .orElseGet(() -> Problem.create(
+                        sourceProblemId,
+                        normalizedRequest.title().trim(),
+                        normalizedRequest.difficulty(),
+                        normalizedRequest.content(),
+                        normalizedRequest.difficultyRating(),
+                        normalizedRequest.timeLimitMs(),
+                        normalizedRequest.memoryLimitMb(),
+                        normalizedRequest.inputFormat(),
+                        normalizedRequest.outputFormat(),
+                        normalizedRequest.inputMode(),
+                        normalizedRequest.judgeType(),
+                        normalizedRequest.checkerCode()));
+
+        if (problem.getId() != null) {
+            throw new ServiceException("400-1", "이미 존재하는 sourceProblemId입니다: " + sourceProblemId);
+        }
+
+        problemRepository.save(problem);
+        replaceAssociations(problem, normalizedRequest);
+
+        return new AdminProblemMutationResponse(
+                problem.getId(), "CREATED", problem.getSourceProblemId(), problem.getTitle());
+    }
+
+    @Transactional
+    public AdminProblemMutationResponse updateProblem(Long problemId, AdminProblemUpsertRequest request) {
+        AdminProblemUpsertRequest normalizedRequest = normalizeEscapedNewlineFields(request);
+        Problem problem = problemRepository
+                .findById(problemId)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 문제입니다."));
+
+        String sourceProblemId = resolveSourceProblemIdForUpdate(problem, normalizedRequest);
+        validateBusinessRules(normalizedRequest, problemId, sourceProblemId);
+
+        problem.update(
+                sourceProblemId,
+                normalizedRequest.title().trim(),
+                normalizedRequest.difficulty(),
+                normalizedRequest.content(),
+                normalizedRequest.difficultyRating(),
+                normalizedRequest.timeLimitMs(),
+                normalizedRequest.memoryLimitMb(),
+                normalizedRequest.inputFormat(),
+                normalizedRequest.outputFormat(),
+                normalizedRequest.inputMode(),
+                normalizedRequest.judgeType(),
+                normalizedRequest.checkerCode());
+
+        replaceAssociations(problem, normalizedRequest);
+
+        return new AdminProblemMutationResponse(
+                problem.getId(), "UPDATED", problem.getSourceProblemId(), problem.getTitle());
+    }
+
+    public AdminProblemBulkValidateResponse validateBulk(AdminProblemBulkRequest request) {
+        clearExpiredValidationStates();
+
+        List<AdminProblemBulkValidateResponse.ValidationError> errors = new ArrayList<>();
+        Set<Integer> invalidRows = new HashSet<>();
+        Set<String> seenSourceProblemIds = new HashSet<>();
+        Set<String> seenProblemSignatures = new HashSet<>();
+
+        for (int index = 0; index < request.problems().size(); index++) {
+            AdminProblemUpsertRequest row =
+                    normalizeEscapedNewlineFields(request.problems().get(index));
+            try {
+                String sourceProblemId = normalizeOptional(row.sourceProblemId());
+                validateBusinessRules(row, null, sourceProblemId);
+                if (!isBlank(sourceProblemId) && !seenSourceProblemIds.add(sourceProblemId)) {
+                    addBulkValidationError(
+                            errors,
+                            invalidRows,
+                            index,
+                            "sourceProblemId",
+                            "요청 내 sourceProblemId가 중복되었습니다: " + sourceProblemId);
+                }
+
+                String problemSignature = buildProblemSignature(row);
+                if (!seenProblemSignatures.add(problemSignature)) {
+                    addBulkValidationError(errors, invalidRows, index, "problem", "요청 내 동일한 문제가 중복되었습니다.");
+                }
+            } catch (ServiceException ex) {
+                addBulkValidationError(errors, invalidRows, index, "business", ex.getMessage());
+            }
+        }
+
+        int total = request.problems().size();
+        int validCount = Math.max(total - invalidRows.size(), 0);
+        String validationToken = null;
+        if (errors.isEmpty() && isBlank(request.validationToken())) {
+            validationToken = issueBulkValidationToken(computeBulkPayloadHash(request.problems()));
+        }
+        return new AdminProblemBulkValidateResponse(total, validCount, errors, validationToken);
+    }
+
+    public AdminProblemSingleValidateResponse validateSingle(AdminProblemUpsertRequest request) {
+        AdminProblemUpsertRequest normalizedRequest = normalizeEscapedNewlineFields(request);
+        List<AdminProblemSingleValidateResponse.ValidationError> errors = new ArrayList<>();
+        try {
+            String sourceProblemId = resolveSourceProblemIdForCreate(normalizedRequest);
+            validateBusinessRules(normalizedRequest, null, sourceProblemId);
+        } catch (ServiceException ex) {
+            errors.add(new AdminProblemSingleValidateResponse.ValidationError("business", ex.getMessage()));
+        }
+        return new AdminProblemSingleValidateResponse(errors.isEmpty(), errors);
+    }
+
+    @Transactional
+    public AdminProblemBulkImportResponse importBulk(AdminProblemBulkRequest request) {
+        ensureBulkValidated(request);
+
+        int inserted = 0;
+        int updated = 0;
+        List<Long> problemIds = new ArrayList<>();
+
+        for (AdminProblemUpsertRequest row : request.problems()) {
+            row = normalizeEscapedNewlineFields(row);
+            String sourceProblemId = normalizeOptional(row.sourceProblemId());
+            if (isBlank(sourceProblemId)) {
+                // bulk에서도 sourceProblemId를 비우면 단건 생성과 동일하게 자동 발급한다.
+                sourceProblemId = generateUniqueSourceProblemId();
+            }
+
+            Problem problem =
+                    problemRepository.findBySourceProblemId(sourceProblemId).orElse(null);
+
+            if (problem == null) {
+                problem = Problem.create(
+                        sourceProblemId,
+                        row.title().trim(),
+                        row.difficulty(),
+                        row.content(),
+                        row.difficultyRating(),
+                        row.timeLimitMs(),
+                        row.memoryLimitMb(),
+                        row.inputFormat(),
+                        row.outputFormat(),
+                        row.inputMode(),
+                        row.judgeType(),
+                        row.checkerCode());
+                problemRepository.save(problem);
+                inserted++;
+            } else {
+                problem.update(
+                        sourceProblemId,
+                        row.title().trim(),
+                        row.difficulty(),
+                        row.content(),
+                        row.difficultyRating(),
+                        row.timeLimitMs(),
+                        row.memoryLimitMb(),
+                        row.inputFormat(),
+                        row.outputFormat(),
+                        row.inputMode(),
+                        row.judgeType(),
+                        row.checkerCode());
+                updated++;
+            }
+
+            replaceAssociations(problem, row);
+            problemIds.add(problem.getId());
+        }
+
+        return new AdminProblemBulkImportResponse(request.problems().size(), inserted, updated, problemIds);
+    }
+
+    private void validateBusinessRules(
+            AdminProblemUpsertRequest request, Long currentProblemId, String sourceProblemId) {
+        if (!isBlank(sourceProblemId)) {
+            problemRepository.findBySourceProblemId(sourceProblemId).ifPresent(existing -> {
+                if (currentProblemId == null || !existing.getId().equals(currentProblemId)) {
+                    throw new ServiceException("400-1", "이미 존재하는 sourceProblemId입니다: " + sourceProblemId);
+                }
+            });
+        }
+
+        List<Long> duplicateIds = problemRepository.findIdsBySignature(
+                request.title().trim(),
+                request.content(),
+                request.difficulty(),
+                request.difficultyRating(),
+                request.timeLimitMs(),
+                request.memoryLimitMb(),
+                request.inputMode() != null ? request.inputMode() : InputMode.STDIO,
+                request.judgeType() != null ? request.judgeType() : JudgeType.EXACT,
+                request.inputFormat(),
+                request.outputFormat(),
+                request.checkerCode());
+        boolean hasDuplicateProblem = duplicateIds.stream()
+                .anyMatch(existingProblemId -> currentProblemId == null || !existingProblemId.equals(currentProblemId));
+        if (hasDuplicateProblem) {
+            throw new ServiceException("400-1", "이미 동일한 내용/제약의 문제가 존재합니다.");
+        }
+
+        if (request.starterCodes() != null && !request.starterCodes().isEmpty()) {
+            if (request.starterCodes().size() < 5) {
+                throw new ServiceException("400-1", "starterCodes는 최소 5개 이상이어야 합니다.");
+            }
+
+            Set<String> languages = new HashSet<>();
+            int defaultCount = 0;
+            for (AdminProblemUpsertRequest.StarterCodeRequest starterCode : request.starterCodes()) {
+                String language = normalizeRequired(starterCode.language(), "starterCodes.language는 필수입니다.");
+                if (!languages.add(language)) {
+                    throw new ServiceException("400-1", "starterCodes의 language가 중복되었습니다: " + language);
+                }
+                if (Boolean.TRUE.equals(starterCode.isDefault())) {
+                    defaultCount++;
+                }
+            }
+
+            if (defaultCount != 1) {
+                throw new ServiceException("400-1", "starterCodes는 isDefault=true가 정확히 1개여야 합니다.");
+            }
+        }
+
+        if (request.sampleCases() == null || request.sampleCases().size() < 3) {
+            throw new ServiceException("400-1", "sampleCases는 최소 3개 이상이어야 합니다.");
+        }
+        if (request.hiddenCases() == null || request.hiddenCases().size() < 10) {
+            throw new ServiceException("400-1", "hiddenCases는 최소 10개 이상이어야 합니다.");
+        }
+
+        JudgeType judgeType = request.judgeType() != null ? request.judgeType() : JudgeType.EXACT;
+        if (judgeType == JudgeType.CHECKER && isBlank(request.checkerCode())) {
+            throw new ServiceException("400-1", "judgeType이 CHECKER인 경우 checkerCode는 필수입니다.");
+        }
+    }
+
+    private String resolveSourceProblemIdForCreate(AdminProblemUpsertRequest request) {
+        String sourceProblemId = normalizeOptional(request.sourceProblemId());
+        if (!isBlank(sourceProblemId)) {
+            return sourceProblemId;
+        }
+        return generateUniqueSourceProblemId();
+    }
+
+    private String resolveSourceProblemIdForUpdate(Problem problem, AdminProblemUpsertRequest request) {
+        String sourceProblemId = normalizeOptional(request.sourceProblemId());
+        if (!isBlank(sourceProblemId)) {
+            return sourceProblemId;
+        }
+
+        String existing = normalizeOptional(problem.getSourceProblemId());
+        if (!isBlank(existing)) {
+            return existing;
+        }
+        return generateUniqueSourceProblemId();
+    }
+
+    private String generateUniqueSourceProblemId() {
+        for (int attempt = 0; attempt < 10; attempt++) {
+            String token = UUID.randomUUID()
+                    .toString()
+                    .replace("-", "")
+                    .substring(0, 20)
+                    .toUpperCase(Locale.ROOT);
+            String candidate = "LOCAL-" + token;
+            if (problemRepository.findBySourceProblemId(candidate).isEmpty()) {
+                return candidate;
+            }
+        }
+        throw new ServiceException("500-1", "sourceProblemId 자동 생성에 실패했습니다.");
+    }
+
+    private void ensureBulkValidated(AdminProblemBulkRequest request) {
+        clearExpiredValidationStates();
+
+        String validationToken = normalizeOptional(request.validationToken());
+        if (isBlank(validationToken)) {
+            throw new ServiceException("400-1", "대량 import 전에 validate를 먼저 수행하세요.");
+        }
+
+        BulkValidationState state = bulkValidationStateMap.remove(validationToken);
+        if (state == null || state.expiresAt().isBefore(Instant.now())) {
+            throw new ServiceException("400-1", "validate 토큰이 만료되었거나 이미 사용되었습니다. 다시 validate 해주세요.");
+        }
+
+        String payloadHash = computeBulkPayloadHash(request.problems());
+        if (!state.payloadHash().equals(payloadHash)) {
+            throw new ServiceException("400-1", "validate 이후 요청 본문이 변경되었습니다. 다시 validate 해주세요.");
+        }
+    }
+
+    private String issueBulkValidationToken(String payloadHash) {
+        clearExpiredValidationStates();
+
+        String token = UUID.randomUUID().toString().replace("-", "");
+        bulkValidationStateMap.put(
+                token, new BulkValidationState(payloadHash, Instant.now().plus(BULK_VALIDATION_TTL)));
+        return token;
+    }
+
+    private void clearExpiredValidationStates() {
+        Instant now = Instant.now();
+        bulkValidationStateMap
+                .entrySet()
+                .removeIf(entry -> entry.getValue().expiresAt().isBefore(now));
+    }
+
+    private String computeBulkPayloadHash(List<AdminProblemUpsertRequest> rows) {
+        MessageDigest digest = getSha256Digest();
+
+        for (AdminProblemUpsertRequest row : rows) {
+            AdminProblemUpsertRequest normalizedRow = normalizeEscapedNewlineFields(row);
+            digest.update(buildProblemSignature(normalizedRow).getBytes(StandardCharsets.UTF_8));
+            digest.update((byte) 0x1E);
+        }
+
+        return toHex(digest.digest());
+    }
+
+    private String buildProblemSignature(AdminProblemUpsertRequest request) {
+        StringBuilder signatureBuilder = new StringBuilder(1024);
+        appendSignaturePart(signatureBuilder, normalizeOptional(request.title()));
+        appendSignaturePart(
+                signatureBuilder,
+                request.difficulty() != null ? request.difficulty().name() : null);
+        appendSignaturePart(signatureBuilder, normalizeOptional(request.content()));
+        appendSignaturePart(
+                signatureBuilder,
+                request.difficultyRating() != null ? request.difficultyRating().toString() : null);
+        appendSignaturePart(
+                signatureBuilder,
+                request.timeLimitMs() != null ? request.timeLimitMs().toString() : null);
+        appendSignaturePart(
+                signatureBuilder,
+                request.memoryLimitMb() != null ? request.memoryLimitMb().toString() : null);
+        appendSignaturePart(signatureBuilder, normalizeOptional(request.inputFormat()));
+        appendSignaturePart(signatureBuilder, normalizeOptional(request.outputFormat()));
+        appendSignaturePart(
+                signatureBuilder, (request.inputMode() != null ? request.inputMode() : InputMode.STDIO).name());
+        appendSignaturePart(
+                signatureBuilder, (request.judgeType() != null ? request.judgeType() : JudgeType.EXACT).name());
+        appendSignaturePart(signatureBuilder, normalizeOptional(request.checkerCode()));
+
+        if (request.tags() != null) {
+            for (String tag : request.tags()) {
+                appendSignaturePart(signatureBuilder, normalizeOptional(tag));
+            }
+        }
+
+        if (request.starterCodes() != null) {
+            for (AdminProblemUpsertRequest.StarterCodeRequest starterCode : request.starterCodes()) {
+                appendSignaturePart(signatureBuilder, normalizeOptional(starterCode.language()));
+                appendSignaturePart(signatureBuilder, normalizeOptional(starterCode.code()));
+                appendSignaturePart(
+                        signatureBuilder,
+                        starterCode.isDefault() != null
+                                ? starterCode.isDefault().toString()
+                                : null);
+            }
+        }
+
+        if (request.sampleCases() != null) {
+            for (AdminProblemUpsertRequest.TestCaseRequest sample : request.sampleCases()) {
+                appendSignaturePart(signatureBuilder, normalizeOptional(sample.input()));
+                appendSignaturePart(signatureBuilder, normalizeOptional(sample.output()));
+            }
+        }
+
+        if (request.hiddenCases() != null) {
+            for (AdminProblemUpsertRequest.TestCaseRequest hidden : request.hiddenCases()) {
+                appendSignaturePart(signatureBuilder, normalizeOptional(hidden.input()));
+                appendSignaturePart(signatureBuilder, normalizeOptional(hidden.output()));
+            }
+        }
+
+        return signatureBuilder.toString();
+    }
+
+    private void appendSignaturePart(StringBuilder signatureBuilder, String value) {
+        if (value != null) {
+            signatureBuilder.append(value);
+        }
+        signatureBuilder.append('\u001F');
+    }
+
+    private void addBulkValidationError(
+            List<AdminProblemBulkValidateResponse.ValidationError> errors,
+            Set<Integer> invalidRows,
+            int index,
+            String field,
+            String message) {
+        errors.add(new AdminProblemBulkValidateResponse.ValidationError(index, field, message));
+        invalidRows.add(index);
+    }
+
+    private MessageDigest getSha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", ex);
+        }
+    }
+
+    private String toHex(byte[] value) {
+        StringBuilder builder = new StringBuilder(value.length * 2);
+        for (byte b : value) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+
+    private void replaceAssociations(Problem problem, AdminProblemUpsertRequest request) {
+        problemTagConnectRepository.deleteByProblemId(problem.getId());
+        problemLanguageProfileRepository.deleteByProblemId(problem.getId());
+        testCaseRepository.deleteByProblemId(problem.getId());
+
+        List<ProblemTagConnect> connects = buildTagConnects(problem, request.tags());
+        if (!connects.isEmpty()) {
+            problemTagConnectRepository.saveAll(connects);
+        }
+
+        List<ProblemLanguageProfile> profiles = resolveStarterCodes(request.starterCodes()).stream()
+                .map(starterCode -> ProblemLanguageProfile.create(
+                        problem, starterCode.language().trim(), starterCode.code(), starterCode.isDefault()))
+                .toList();
+        problemLanguageProfileRepository.saveAll(profiles);
+
+        List<TestCase> testCases = new ArrayList<>();
+        testCases.addAll(request.sampleCases().stream()
+                .map(sample -> TestCase.create(problem, sample.input(), sample.output(), true))
+                .toList());
+        testCases.addAll(request.hiddenCases().stream()
+                .map(hidden -> TestCase.create(problem, hidden.input(), hidden.output(), false))
+                .toList());
+        testCaseRepository.saveAll(testCases);
+    }
+
+    private List<ProblemTagConnect> buildTagConnects(Problem problem, List<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return List.of();
+        }
+
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String tag : tags) {
+            if (isBlank(tag)) {
+                continue;
+            }
+            normalized.add(tag.trim());
+        }
+
+        if (normalized.isEmpty()) {
+            return List.of();
+        }
+
+        List<ProblemTagConnect> connects = new ArrayList<>();
+        for (String name : normalized) {
+            Tag tag = tagRepository.findByName(name).orElseGet(() -> tagRepository.save(Tag.create(name)));
+            connects.add(ProblemTagConnect.create(problem, tag));
+        }
+        return connects;
+    }
+
+    private List<AdminProblemUpsertRequest.StarterCodeRequest> resolveStarterCodes(
+            List<AdminProblemUpsertRequest.StarterCodeRequest> starterCodes) {
+        if (starterCodes != null && !starterCodes.isEmpty()) {
+            return starterCodes;
+        }
+
+        // starterCodes가 누락되면 기본 5개 언어 템플릿을 자동 생성한다.
+        return List.of(
+                new AdminProblemUpsertRequest.StarterCodeRequest("python3", PYTHON3_STARTER, true),
+                new AdminProblemUpsertRequest.StarterCodeRequest("java", JAVA_STARTER, false),
+                new AdminProblemUpsertRequest.StarterCodeRequest("cpp17", CPP17_STARTER, false),
+                new AdminProblemUpsertRequest.StarterCodeRequest("c", C_STARTER, false),
+                new AdminProblemUpsertRequest.StarterCodeRequest("javascript", JAVASCRIPT_STARTER, false));
+    }
+
+    private AdminProblemUpsertRequest normalizeEscapedNewlineFields(AdminProblemUpsertRequest request) {
+        return new AdminProblemUpsertRequest(
+                request.sourceProblemId(),
+                request.title(),
+                request.difficulty(),
+                normalizeEscapedNewlineText(request.content()),
+                request.difficultyRating(),
+                request.timeLimitMs(),
+                request.memoryLimitMb(),
+                normalizeEscapedNewlineText(request.inputFormat()),
+                normalizeEscapedNewlineText(request.outputFormat()),
+                request.inputMode(),
+                request.judgeType(),
+                normalizeEscapedNewlineText(request.checkerCode()),
+                request.tags(),
+                normalizeStarterCodes(request.starterCodes()),
+                normalizeTestCases(request.sampleCases()),
+                normalizeTestCases(request.hiddenCases()));
+    }
+
+    private List<AdminProblemUpsertRequest.StarterCodeRequest> normalizeStarterCodes(
+            List<AdminProblemUpsertRequest.StarterCodeRequest> starterCodes) {
+        if (starterCodes == null) {
+            return null;
+        }
+        return starterCodes.stream()
+                .map(starterCode -> new AdminProblemUpsertRequest.StarterCodeRequest(
+                        starterCode.language(),
+                        normalizeEscapedNewlineText(starterCode.code()),
+                        starterCode.isDefault()))
+                .toList();
+    }
+
+    private List<AdminProblemUpsertRequest.TestCaseRequest> normalizeTestCases(
+            List<AdminProblemUpsertRequest.TestCaseRequest> testCases) {
+        if (testCases == null) {
+            return null;
+        }
+        return testCases.stream()
+                .map(testCase -> new AdminProblemUpsertRequest.TestCaseRequest(
+                        normalizeEscapedNewlineText(testCase.input()), normalizeEscapedNewlineText(testCase.output())))
+                .toList();
+    }
+
+    private String normalizeEscapedNewlineText(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("\r\n", "\n").replace("\\r\\n", "\n").replace("\\n", "\n");
+    }
+
+    private String normalizeRequired(String value, String message) {
+        if (isBlank(value)) {
+            throw new ServiceException("400-1", message);
+        }
+        return value.trim();
+    }
+
+    private String normalizeOptional(String value) {
+        if (isBlank(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
+++ b/src/main/java/com/back/domain/problem/problem/service/ProblemService.java
@@ -73,8 +73,8 @@ public class ProblemService {
                 .orElse(null);
 
         List<ProblemDetailResponse.StarterCode> starterCodes = languageProfiles.stream()
-                .map(profile ->
-                        new ProblemDetailResponse.StarterCode(profile.getLanguageCode(), profile.getStarterCode()))
+                .map(profile -> new ProblemDetailResponse.StarterCode(
+                        profile.getLanguageCode(), restoreEscapedNewline(profile.getStarterCode())))
                 .toList();
 
         List<ProblemDetailResponse.SampleCase> sampleCases = problem.getTestCases().stream()
@@ -84,8 +84,22 @@ public class ProblemService {
 
         String responseLanguage = resolveResponseLanguage(lang, translation);
 
-        return ProblemDetailResponse.from(
+        ProblemDetailResponse response = ProblemDetailResponse.from(
                 problem, translation, responseLanguage, supportedLanguages, defaultLanguage, starterCodes, sampleCases);
+        return new ProblemDetailResponse(
+                response.problemId(),
+                response.title(),
+                response.difficulty(),
+                restoreEscapedNewline(response.content()),
+                restoreEscapedNewline(response.inputFormat()),
+                restoreEscapedNewline(response.outputFormat()),
+                response.timeLimitMs(),
+                response.memoryLimitMb(),
+                response.language(),
+                response.supportedLanguages(),
+                response.defaultLanguage(),
+                response.starterCodes(),
+                response.sampleCases());
     }
 
     private ProblemTranslation findTranslationIfNeeded(Long problemId, String lang) {
@@ -110,6 +124,14 @@ public class ProblemService {
     }
 
     private ProblemDetailResponse.SampleCase toSampleCase(TestCase testCase) {
-        return new ProblemDetailResponse.SampleCase(testCase.getInput(), testCase.getExpectedOutput());
+        return new ProblemDetailResponse.SampleCase(
+                restoreEscapedNewline(testCase.getInput()), restoreEscapedNewline(testCase.getExpectedOutput()));
+    }
+
+    private String restoreEscapedNewline(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("\r\n", "\n").replace("\\r\\n", "\n").replace("\\n", "\n");
     }
 }

--- a/src/main/java/com/back/domain/problem/testcase/entity/TestCase.java
+++ b/src/main/java/com/back/domain/problem/testcase/entity/TestCase.java
@@ -29,4 +29,13 @@ public class TestCase extends BaseEntity {
     private String expectedOutput;
 
     private Boolean isSample; // 예제 케이스 여부
+
+    public static TestCase create(Problem problem, String input, String expectedOutput, Boolean isSample) {
+        TestCase testCase = new TestCase();
+        testCase.problem = problem;
+        testCase.input = input;
+        testCase.expectedOutput = expectedOutput;
+        testCase.isSample = isSample;
+        return testCase;
+    }
 }

--- a/src/main/java/com/back/domain/problem/testcase/repository/TestCaseRepository.java
+++ b/src/main/java/com/back/domain/problem/testcase/repository/TestCaseRepository.java
@@ -1,0 +1,9 @@
+package com.back.domain.problem.testcase.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.problem.testcase.entity.TestCase;
+
+public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
+    void deleteByProblemId(Long problemId);
+}

--- a/src/main/java/com/back/domain/tag/problemtagconnect/entity/ProblemTagConnect.java
+++ b/src/main/java/com/back/domain/tag/problemtagconnect/entity/ProblemTagConnect.java
@@ -26,4 +26,11 @@ public class ProblemTagConnect extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id")
     private Tag tag;
+
+    public static ProblemTagConnect create(Problem problem, Tag tag) {
+        ProblemTagConnect connect = new ProblemTagConnect();
+        connect.problem = problem;
+        connect.tag = tag;
+        return connect;
+    }
 }

--- a/src/main/java/com/back/domain/tag/problemtagconnect/repository/ProblemTagConnectRepository.java
+++ b/src/main/java/com/back/domain/tag/problemtagconnect/repository/ProblemTagConnectRepository.java
@@ -1,0 +1,9 @@
+package com.back.domain.tag.problemtagconnect.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.tag.problemtagconnect.entity.ProblemTagConnect;
+
+public interface ProblemTagConnectRepository extends JpaRepository<ProblemTagConnect, Long> {
+    void deleteByProblemId(Long problemId);
+}

--- a/src/main/java/com/back/domain/tag/tag/entity/Tag.java
+++ b/src/main/java/com/back/domain/tag/tag/entity/Tag.java
@@ -19,4 +19,10 @@ public class Tag extends BaseEntity {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    public static Tag create(String name) {
+        Tag tag = new Tag();
+        tag.name = name;
+        return tag;
+    }
 }

--- a/src/main/java/com/back/domain/tag/tag/repository/TagRepository.java
+++ b/src/main/java/com/back/domain/tag/tag/repository/TagRepository.java
@@ -1,6 +1,7 @@
 package com.back.domain.tag.tag.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import com.back.domain.tag.tag.entity.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findAllByOrderByNameAsc();
+
+    Optional<Tag> findByName(String name);
 }

--- a/src/main/java/com/back/global/judge/Judge0ExecutionService.java
+++ b/src/main/java/com/back/global/judge/Judge0ExecutionService.java
@@ -84,4 +84,14 @@ public class Judge0ExecutionService {
             default -> throw new IllegalArgumentException("지원하지 않는 언어: " + language);
         };
     }
+
+    /**
+     * 관리자 JSON 업로드에서 '\\n' 문자열이 저장된 과거 데이터를 런타임에서 안전하게 복원한다.
+     */
+    public String restoreEscapedNewline(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("\r\n", "\n").replace("\\r\\n", "\n").replace("\\n", "\n");
+    }
 }

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -80,8 +80,11 @@ public class JudgeService {
             // TODO: 함수형 코드 지원 시 driverCode 합치기
             // String fullCode = code + "\n" + problem.getDriverCode().get(language);
             List<Judge0SubmitRequest> batchRequests = testCases.stream()
-                    .map(tc -> new Judge0SubmitRequest(
-                            code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
+                    .map(tc -> {
+                        String input = judge0ExecutionService.restoreEscapedNewline(tc.getInput());
+                        String expectedOutput = judge0ExecutionService.restoreEscapedNewline(tc.getExpectedOutput());
+                        return new Judge0SubmitRequest(code, languageId, input != null ? input : "", expectedOutput);
+                    })
                     .toList();
             List<Judge0SubmitResponse> results = judge0ExecutionService.execute(batchRequests);
             results.forEach(r -> log.info(

--- a/src/main/java/com/back/global/judge/RunJudgeService.java
+++ b/src/main/java/com/back/global/judge/RunJudgeService.java
@@ -51,8 +51,11 @@ public class RunJudgeService {
             // TODO: 함수형 코드 지원 시 driverCode 합치기
             // String fullCode = code + "\n" + problem.getDriverCode().get(language);
             List<Judge0SubmitRequest> batchRequests = testCases.stream()
-                    .map(tc -> new Judge0SubmitRequest(
-                            code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
+                    .map(tc -> {
+                        String input = judge0ExecutionService.restoreEscapedNewline(tc.getInput());
+                        String expectedOutput = judge0ExecutionService.restoreEscapedNewline(tc.getExpectedOutput());
+                        return new Judge0SubmitRequest(code, languageId, input != null ? input : "", expectedOutput);
+                    })
                     .toList();
 
             List<Judge0SubmitResponse> judgeResponses = judge0ExecutionService.execute(batchRequests);
@@ -72,8 +75,8 @@ public class RunJudgeService {
         if (judgeResponses.isEmpty()) {
             return testCases.stream()
                     .map(tc -> new RunTestCaseResult(
-                            tc.getInput(),
-                            tc.getExpectedOutput(),
+                            judge0ExecutionService.restoreEscapedNewline(tc.getInput()),
+                            judge0ExecutionService.restoreEscapedNewline(tc.getExpectedOutput()),
                             null,
                             "JUDGE_ERROR",
                             "채점 서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."))
@@ -83,14 +86,16 @@ public class RunJudgeService {
         return java.util.stream.IntStream.range(0, testCases.size())
                 .mapToObj(i -> {
                     TestCase tc = testCases.get(i);
+                    String input = judge0ExecutionService.restoreEscapedNewline(tc.getInput());
+                    String expectedOutput = judge0ExecutionService.restoreEscapedNewline(tc.getExpectedOutput());
                     if (i >= judgeResponses.size()) {
-                        return new RunTestCaseResult(tc.getInput(), tc.getExpectedOutput(), null, "RE", null);
+                        return new RunTestCaseResult(input, expectedOutput, null, "RE", null);
                     }
                     Judge0SubmitResponse r = judgeResponses.get(i);
                     String status = resolveStatus(r);
                     String actualOutput = r.stdout() != null ? r.stdout().stripTrailing() : null;
                     String stderr = r.stderr() != null ? r.stderr() : r.compileOutput();
-                    return new RunTestCaseResult(tc.getInput(), tc.getExpectedOutput(), actualOutput, status, stderr);
+                    return new RunTestCaseResult(input, expectedOutput, actualOutput, status, stderr);
                 })
                 .toList();
     }

--- a/src/main/java/com/back/global/judge/SoloJudgeService.java
+++ b/src/main/java/com/back/global/judge/SoloJudgeService.java
@@ -55,8 +55,11 @@ public class SoloJudgeService {
             // TODO: 함수형 코드 지원 시 driverCode 합치기
             // String fullCode = code + "\n" + problem.getDriverCode().get(language);
             List<Judge0SubmitRequest> batchRequests = testCases.stream()
-                    .map(tc -> new Judge0SubmitRequest(
-                            code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
+                    .map(tc -> {
+                        String input = judge0ExecutionService.restoreEscapedNewline(tc.getInput());
+                        String expectedOutput = judge0ExecutionService.restoreEscapedNewline(tc.getExpectedOutput());
+                        return new Judge0SubmitRequest(code, languageId, input != null ? input : "", expectedOutput);
+                    })
                     .toList();
 
             List<Judge0SubmitResponse> results = judge0ExecutionService.execute(batchRequests);

--- a/src/main/java/com/back/global/judge/SoloRunJudgeService.java
+++ b/src/main/java/com/back/global/judge/SoloRunJudgeService.java
@@ -50,8 +50,11 @@ public class SoloRunJudgeService {
         // TODO: 함수형 코드 지원 시 driverCode 합치기
         // String fullCode = code + "\n" + problem.getDriverCode().get(language);
         List<Judge0SubmitRequest> batchRequests = testCases.stream()
-                .map(tc -> new Judge0SubmitRequest(
-                        code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
+                .map(tc -> {
+                    String input = judge0ExecutionService.restoreEscapedNewline(tc.getInput());
+                    String expectedOutput = judge0ExecutionService.restoreEscapedNewline(tc.getExpectedOutput());
+                    return new Judge0SubmitRequest(code, languageId, input != null ? input : "", expectedOutput);
+                })
                 .toList();
 
         List<Judge0SubmitResponse> judgeResponses = judge0ExecutionService.execute(batchRequests);

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -53,6 +53,9 @@ public class SecurityConfig {
                                 "/actuator/prometheus",
                                 "/error")
                         .permitAll()
+                        // 관리자 API는 ROLE_ADMIN만 접근 허용
+                        .requestMatchers("/api/v1/admin/**")
+                        .hasAuthority("ROLE_ADMIN")
                         // 그 외 모든 요청은 인증 필요 (POST /api/v1/ws/token 포함)
                         .anyRequest()
                         .authenticated())

--- a/src/test/java/com/back/domain/problem/problem/controller/AdminProblemControllerTest.java
+++ b/src/test/java/com/back/domain/problem/problem/controller/AdminProblemControllerTest.java
@@ -1,0 +1,437 @@
+package com.back.domain.problem.problem.controller;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.global.IntegrationTestBase;
+import com.back.global.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.EntityManager;
+
+@AutoConfigureMockMvc
+@Transactional
+class AdminProblemControllerTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("delete from submissions");
+        jdbcTemplate.update("delete from solo_submissions");
+        jdbcTemplate.update("delete from battle_participants");
+        jdbcTemplate.update("delete from battle_rooms");
+        jdbcTemplate.update("delete from review_schedule");
+        jdbcTemplate.update("delete from member_problem_first_solves");
+        jdbcTemplate.update("delete from member_rating_profiles");
+        jdbcTemplate.update("delete from problem_language_profiles");
+        jdbcTemplate.update("delete from problem_tag_connect");
+        jdbcTemplate.update("delete from problem_translations");
+        jdbcTemplate.update("delete from test_cases");
+        jdbcTemplate.update("delete from tags");
+        jdbcTemplate.update("delete from problems");
+        jdbcTemplate.update("delete from members");
+    }
+
+    @Test
+    @DisplayName("관리자는 문제를 단건 등록할 수 있다")
+    void createProblem_asAdmin_success() throws Exception {
+        Long adminId = insertMember("admin@example.com", "admin", "ADMIN");
+
+        mockMvc.perform(post("/api/v1/admin/problems")
+                        .cookie(accessToken(adminId, "admin", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(validPayload()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.problemId").isNumber())
+                .andExpect(jsonPath("$.mode").value("CREATED"))
+                .andExpect(jsonPath("$.sourceProblemId").value("LOCAL-1001"))
+                .andExpect(jsonPath("$.title").value("누적합 최대 구간"));
+
+        assertCount("problems", 1);
+        assertCount("tags", 2);
+        assertCount("problem_tag_connect", 2);
+        assertCount("problem_language_profiles", 5);
+        assertCount("test_cases", 13);
+    }
+
+    @Test
+    @DisplayName("일반 사용자는 관리자 문제 등록 API에 접근할 수 없다")
+    void createProblem_asUser_forbidden() throws Exception {
+        Long userId = insertMember("user@example.com", "user", "USER");
+
+        mockMvc.perform(post("/api/v1/admin/problems")
+                        .cookie(accessToken(userId, "user", "ROLE_USER"))
+                        .contentType("application/json")
+                        .content(validPayload()))
+                .andExpect(status().isForbidden());
+
+        assertCount("problems", 0);
+    }
+
+    @Test
+    @DisplayName("관리자 단건 등록 시 sourceProblemId가 비어 있으면 자동 생성된다")
+    void createProblem_asAdmin_autoGenerateSourceProblemId_whenBlank() throws Exception {
+        Long adminId = insertMember("admin2@example.com", "admin2", "ADMIN");
+
+        mockMvc.perform(post("/api/v1/admin/problems")
+                        .cookie(accessToken(adminId, "admin2", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(validPayloadWithoutSourceProblemId()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.problemId").isNumber())
+                .andExpect(jsonPath("$.mode").value("CREATED"))
+                .andExpect(jsonPath("$.sourceProblemId", startsWith("LOCAL-")))
+                .andExpect(jsonPath("$.title").value("누적합 최대 구간"));
+
+        assertCount("problem_language_profiles", 5);
+        assertQueryCount("select count(*) from problem_language_profiles where is_default = true", 1);
+    }
+
+    @Test
+    @DisplayName("관리자 단건 등록 시 문자열에 포함된 \\\\n은 실제 개행으로 정규화되어 저장된다")
+    void createProblem_asAdmin_normalizesEscapedNewlineFields() throws Exception {
+        Long adminId = insertMember("admin3@example.com", "admin3", "ADMIN");
+
+        mockMvc.perform(post("/api/v1/admin/problems")
+                        .cookie(accessToken(adminId, "admin3", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(validPayloadWithLiteralEscapedNewline()))
+                .andExpect(status().isCreated());
+
+        entityManager.flush();
+        String starterCode = jdbcTemplate.queryForObject("""
+                select plp.starter_code
+                from problem_language_profiles plp
+                join problems p on p.id = plp.problem_id
+                where p.source_problem_id = 'LOCAL-1001' and plp.language_code = 'python3'
+                """, String.class);
+        String sampleInput = jdbcTemplate.queryForObject("""
+                select tc.input
+                from test_cases tc
+                join problems p on p.id = tc.problem_id
+                where p.source_problem_id = 'LOCAL-1001' and tc.is_sample = true
+                order by tc.id asc
+                limit 1
+                """, String.class);
+
+        if (starterCode == null || !starterCode.contains("\n") || starterCode.contains("\\n")) {
+            throw new AssertionError("starterCode 개행 정규화 실패: " + starterCode);
+        }
+        if (sampleInput == null || !sampleInput.contains("\n") || sampleInput.contains("\\n")) {
+            throw new AssertionError("sample input 개행 정규화 실패: " + sampleInput);
+        }
+    }
+
+    @Test
+    @DisplayName("관리자 대량 검증은 sourceProblemId가 비어 있어도 유효하다")
+    void validateBulk_asAdmin_allowBlankSourceProblemId() throws Exception {
+        Long adminId = insertMember("admin4@example.com", "admin4", "ADMIN");
+
+        mockMvc.perform(post("/api/v1/admin/problems/bulk/validate")
+                        .cookie(accessToken(adminId, "admin4", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(validBulkPayloadWithoutSourceProblemId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.validCount").value(2))
+                .andExpect(jsonPath("$.errors.length()").value(0))
+                .andExpect(jsonPath("$.validationToken").isString());
+    }
+
+    @Test
+    @DisplayName("관리자 대량 검증은 요청 내 동일 문제 중복을 차단한다")
+    void validateBulk_asAdmin_rejectDuplicateProblemInRequest() throws Exception {
+        Long adminId = insertMember("admin4_2@example.com", "admin4_2", "ADMIN");
+
+        mockMvc.perform(post("/api/v1/admin/problems/bulk/validate")
+                        .cookie(accessToken(adminId, "admin4_2", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(duplicateBulkPayloadWithoutSourceProblemId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.validCount").value(1))
+                .andExpect(jsonPath("$.errors.length()").value(1))
+                .andExpect(jsonPath("$.errors[0].field").value("problem"))
+                .andExpect(jsonPath("$.validationToken").isEmpty());
+    }
+
+    @Test
+    @DisplayName("관리자 대량 등록은 validate 토큰이 있을 때만 가능하다")
+    void importBulk_asAdmin_autoGenerateSourceProblemId_whenBlank() throws Exception {
+        Long adminId = insertMember("admin5@example.com", "admin5", "ADMIN");
+        String payload = validBulkPayloadWithoutSourceProblemId();
+        String validationToken = requestBulkValidationToken(adminId, "admin5", payload);
+
+        mockMvc.perform(post("/api/v1/admin/problems/bulk/import")
+                        .cookie(accessToken(adminId, "admin5", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(withValidationToken(payload, validationToken)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.inserted").value(2))
+                .andExpect(jsonPath("$.updated").value(0))
+                .andExpect(jsonPath("$.problemIds.length()").value(2));
+
+        assertCount("problems", 2);
+        assertQueryCount("select count(*) from problems where source_problem_id like 'LOCAL-%'", 2);
+    }
+
+    @Test
+    @DisplayName("관리자 대량 등록은 validate 토큰 없이 요청하면 실패한다")
+    void importBulk_asAdmin_fail_whenValidationTokenMissing() throws Exception {
+        Long adminId = insertMember("admin5_2@example.com", "admin5_2", "ADMIN");
+
+        mockMvc.perform(post("/api/v1/admin/problems/bulk/import")
+                        .cookie(accessToken(adminId, "admin5_2", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(validBulkPayloadWithoutSourceProblemId()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("대량 import 전에 validate를 먼저 수행하세요."));
+
+        assertCount("problems", 0);
+    }
+
+    @Test
+    @DisplayName("관리자 단건 검증은 정상 payload면 valid=true를 반환한다")
+    void validateSingle_asAdmin_success() throws Exception {
+        Long adminId = insertMember("admin6@example.com", "admin6", "ADMIN");
+
+        mockMvc.perform(post("/api/v1/admin/problems/validate")
+                        .cookie(accessToken(adminId, "admin6", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(validPayloadWithoutSourceProblemId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(true))
+                .andExpect(jsonPath("$.errors.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("관리자 단건 검증은 중복 sourceProblemId면 valid=false를 반환한다")
+    void validateSingle_asAdmin_duplicateSourceProblemId() throws Exception {
+        Long adminId = insertMember("admin7@example.com", "admin7", "ADMIN");
+
+        mockMvc.perform(post("/api/v1/admin/problems")
+                        .cookie(accessToken(adminId, "admin7", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(validPayload()))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/admin/problems/validate")
+                        .cookie(accessToken(adminId, "admin7", "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(validPayload()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(false))
+                .andExpect(jsonPath("$.errors.length()").value(1))
+                .andExpect(jsonPath("$.errors[0].field").value("business"));
+    }
+
+    private Long insertMember(String email, String nickname, String role) {
+        return jdbcTemplate.queryForObject("""
+                insert into members (id, email, nickname, password, score, tier, role, created_at)
+                values (nextval('member_id_seq'), ?, ?, 'password', 0, null, ?, now())
+                returning id
+                """, Long.class, email, nickname, role);
+    }
+
+    private MockCookie accessToken(Long memberId, String nickname, String roleKey) {
+        return new MockCookie(
+                "accessToken", jwtProvider.createToken(memberId, nickname + "@example.com", nickname, roleKey));
+    }
+
+    private void assertCount(String tableName, int expected) {
+        // JdbcTemplate는 JPA 영속성 컨텍스트의 미플러시 변경을 보지 못할 수 있으므로 flush 후 조회한다.
+        entityManager.flush();
+        Integer count = jdbcTemplate.queryForObject("select count(*) from " + tableName, Integer.class);
+        if (count == null || count != expected) {
+            throw new AssertionError(
+                    "count mismatch for " + tableName + ": expected=" + expected + ", actual=" + count);
+        }
+    }
+
+    private void assertQueryCount(String query, int expected) {
+        entityManager.flush();
+        Integer count = jdbcTemplate.queryForObject(query, Integer.class);
+        if (count == null || count != expected) {
+            throw new AssertionError("count mismatch for query: expected=" + expected + ", actual=" + count);
+        }
+    }
+
+    private String validPayload() {
+        return """
+                {
+                  "sourceProblemId": "LOCAL-1001",
+                  "title": "누적합 최대 구간",
+                  "difficulty": "MEDIUM",
+                  "content": "길이가 N인 수열에서 연속 부분합의 최댓값을 구하시오.",
+                  "difficultyRating": 1600,
+                  "timeLimitMs": 1000,
+                  "memoryLimitMb": 256,
+                  "inputFormat": "첫 줄에 N, 둘째 줄에 수열이 주어진다.",
+                  "outputFormat": "최대 부분합을 출력한다.",
+                  "inputMode": "STDIO",
+                  "judgeType": "EXACT",
+                  "checkerCode": null,
+                  "tags": ["dp", "prefix-sum"],
+                  "starterCodes": [
+                    {"language": "python3", "code": "def solve():\\n    pass", "isDefault": true},
+                    {"language": "java", "code": "public class Main { public static void main(String[] args) {} }", "isDefault": false},
+                    {"language": "cpp17", "code": "#include <bits/stdc++.h>\\nint main(){}", "isDefault": false},
+                    {"language": "c", "code": "#include <stdio.h>\\nint main(){return 0;}", "isDefault": false},
+                    {"language": "javascript", "code": "function solve() {}", "isDefault": false}
+                  ],
+                  "sampleCases": [
+                    {"input": "5\\n1 -2 3 4 -1", "output": "7"},
+                    {"input": "4\\n-1 -2 -3 -4", "output": "-1"},
+                    {"input": "3\\n2 2 2", "output": "6"}
+                  ],
+                  "hiddenCases": [
+                    {"input": "1\\n100", "output": "100"},
+                    {"input": "1\\n-100", "output": "-100"},
+                    {"input": "6\\n1 2 -10 3 4 5", "output": "12"},
+                    {"input": "7\\n-2 1 -3 4 -1 2 1", "output": "6"},
+                    {"input": "5\\n0 0 0 0 0", "output": "0"},
+                    {"input": "4\\n100 -1 -1 -1", "output": "100"},
+                    {"input": "4\\n-1 100 -1 -1", "output": "100"},
+                    {"input": "4\\n-1 -1 100 -1", "output": "100"},
+                    {"input": "4\\n-1 -1 -1 100", "output": "100"},
+                    {"input": "8\\n1 -1 1 -1 1 -1 1 -1", "output": "1"}
+                  ]
+                }
+                """;
+    }
+
+    private String validPayloadWithoutSourceProblemId() {
+        return """
+                {
+                  "sourceProblemId": "",
+                  "title": "누적합 최대 구간",
+                  "difficulty": "MEDIUM",
+                  "content": "길이가 N인 수열에서 연속 부분합의 최댓값을 구하시오.",
+                  "difficultyRating": 1600,
+                  "timeLimitMs": 1000,
+                  "memoryLimitMb": 256,
+                  "inputFormat": "첫 줄에 N, 둘째 줄에 수열이 주어진다.",
+                  "outputFormat": "최대 부분합을 출력한다.",
+                  "inputMode": "STDIO",
+                  "judgeType": "EXACT",
+                  "checkerCode": null,
+                  "tags": ["dp", "prefix-sum"],
+                  "sampleCases": [
+                    {"input": "5\\n1 -2 3 4 -1", "output": "7"},
+                    {"input": "4\\n-1 -2 -3 -4", "output": "-1"},
+                    {"input": "3\\n2 2 2", "output": "6"}
+                  ],
+                  "hiddenCases": [
+                    {"input": "1\\n100", "output": "100"},
+                    {"input": "1\\n-100", "output": "-100"},
+                    {"input": "6\\n1 2 -10 3 4 5", "output": "12"},
+                    {"input": "7\\n-2 1 -3 4 -1 2 1", "output": "6"},
+                    {"input": "5\\n0 0 0 0 0", "output": "0"},
+                    {"input": "4\\n100 -1 -1 -1", "output": "100"},
+                    {"input": "4\\n-1 100 -1 -1", "output": "100"},
+                    {"input": "4\\n-1 -1 100 -1", "output": "100"},
+                    {"input": "4\\n-1 -1 -1 100", "output": "100"},
+                    {"input": "8\\n1 -1 1 -1 1 -1 1 -1", "output": "1"}
+                  ]
+                }
+                """;
+    }
+
+    private String validPayloadWithLiteralEscapedNewline() {
+        return validPayload().replace("\\n", "\\\\n");
+    }
+
+    private String validBulkPayloadWithoutSourceProblemId() {
+        String first = validPayloadWithoutSourceProblemId();
+        String second = validPayloadWithoutSourceProblemId().replace("누적합 최대 구간", "누적합 최대 구간 2");
+        return """
+                {
+                  "problems": [
+                    %s,
+                    %s
+                  ]
+                }
+                """.formatted(first, second);
+    }
+
+    private String requestBulkValidationToken(Long adminId, String nickname, String payload) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/admin/problems/bulk/validate")
+                        .cookie(accessToken(adminId, nickname, "ROLE_ADMIN"))
+                        .contentType("application/json")
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.errors.length()").value(0))
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode token = root.get("validationToken");
+        if (token == null || token.isNull() || token.asText().isBlank()) {
+            throw new AssertionError("validationToken이 비어 있습니다.");
+        }
+        return token.asText();
+    }
+
+    private String withValidationToken(String payload, String validationToken) {
+        return """
+                {
+                  "problems": %s,
+                  "validationToken": "%s"
+                }
+                """.formatted(extractProblemsArray(payload), validationToken);
+    }
+
+    private String duplicateBulkPayloadWithoutSourceProblemId() {
+        String first = validPayloadWithoutSourceProblemId();
+        String second = validPayloadWithoutSourceProblemId();
+        return """
+                {
+                  "problems": [
+                    %s,
+                    %s
+                  ]
+                }
+                """.formatted(first, second);
+    }
+
+    private String extractProblemsArray(String payload) {
+        try {
+            JsonNode root = objectMapper.readTree(payload);
+            JsonNode problems = root.get("problems");
+            if (problems == null || !problems.isArray()) {
+                throw new IllegalArgumentException("payload에 problems 배열이 없습니다.");
+            }
+            return objectMapper.writeValueAsString(problems);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("payload에서 problems 배열 추출 실패", ex);
+        }
+    }
+}

--- a/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/back/domain/problem/problem/service/ProblemServiceTest.java
@@ -202,6 +202,47 @@ class ProblemServiceTest {
     }
 
     @Test
+    @DisplayName("문제 단건 조회 응답은 이스케이프된 개행(\\\\n)을 실제 개행으로 복원한다")
+    void getProblem_unescapesEscapedNewlineFields() {
+        // given
+        Problem problem = mock(Problem.class);
+        TestCase sampleCase = mock(TestCase.class);
+        ProblemLanguageProfile pythonProfile = mock(ProblemLanguageProfile.class);
+
+        when(problem.getId()).thenReturn(1L);
+        when(problem.getTitle()).thenReturn("A + B");
+        when(problem.getDifficulty()).thenReturn(DifficultyLevel.EASY);
+        when(problem.getContent()).thenReturn("line1\\nline2");
+        when(problem.getInputFormat()).thenReturn("input\\nformat");
+        when(problem.getOutputFormat()).thenReturn("output\\nformat");
+        when(problem.getTimeLimitMs()).thenReturn(1000L);
+        when(problem.getMemoryLimitMb()).thenReturn(256L);
+        when(problem.getTestCases()).thenReturn(List.of(sampleCase));
+
+        when(sampleCase.getIsSample()).thenReturn(true);
+        when(sampleCase.getInput()).thenReturn("1\\n2");
+        when(sampleCase.getExpectedOutput()).thenReturn("3\\n4");
+
+        when(pythonProfile.getLanguageCode()).thenReturn("python3");
+        when(pythonProfile.getStarterCode()).thenReturn("def solve():\\n    pass");
+        when(pythonProfile.getIsDefault()).thenReturn(true);
+
+        when(problemRepository.findById(1L)).thenReturn(Optional.of(problem));
+        when(problemLanguageProfileRepository.findByProblemIdOrderByIdAsc(1L)).thenReturn(List.of(pythonProfile));
+
+        // when
+        ProblemDetailResponse response = problemService.getProblem(1L, null);
+
+        // then
+        assertThat(response.content()).isEqualTo("line1\nline2");
+        assertThat(response.inputFormat()).isEqualTo("input\nformat");
+        assertThat(response.outputFormat()).isEqualTo("output\nformat");
+        assertThat(response.starterCodes())
+                .containsExactly(new ProblemDetailResponse.StarterCode("python3", "def solve():\n    pass"));
+        assertThat(response.sampleCases()).containsExactly(new ProblemDetailResponse.SampleCase("1\n2", "3\n4"));
+    }
+
+    @Test
     @DisplayName("문제 ID로 단건 조회 시 lang이 ko여도 번역이 없으면 원문을 반환한다")
     void getProblem_withKoWithoutTranslation_returnsOriginalDetail() {
         // given

--- a/src/test/java/com/back/global/judge/JudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/JudgeServiceTest.java
@@ -76,6 +76,7 @@ class JudgeServiceTest {
 
         when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
         when(judge0ExecutionService.getLanguageId("python")).thenReturn(71);
+        when(judge0ExecutionService.restoreEscapedNewline(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     private TestCase mockTestCase(String input, String expectedOutput) {

--- a/src/test/java/com/back/global/judge/RunJudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/RunJudgeServiceTest.java
@@ -34,6 +34,7 @@ class RunJudgeServiceTest {
     @BeforeEach
     void setUp() {
         when(judge0ExecutionService.getLanguageId("python")).thenReturn(71);
+        when(judge0ExecutionService.restoreEscapedNewline(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     private TestCase mockTestCase(String input, String expectedOutput) {


### PR DESCRIPTION
## 변경 사항
- 관리자 문제 관리 API 추가
  - `POST /api/v1/admin/problems` (단건 등록)
  - `PATCH /api/v1/admin/problems/{problemId}` (단건 수정)
  - `POST /api/v1/admin/problems/validate` (단건 검증)
  - `POST /api/v1/admin/problems/bulk/validate` (대량 검증)
  - `POST /api/v1/admin/problems/bulk/import` (대량 등록)
- `sourceProblemId` 비어 있을 때 자동 발급 로직 추가
- starter code 미입력 시 5개 기본 언어 템플릿 자동 생성
- `\\n` 입력값 정규화(본문/입출력 포맷/스타터코드/테스트케이스)
- Judge0 batch 처리 개선(20개 초과 테스트케이스 대응)
  - chunk submit / 결과 순서 보존
- 대량 등록 안정성 강화
  - validate 성공 토큰(`validationToken`) 없이 import 차단
  - validate 후 본문 변경 시 import 차단
  - 토큰 만료/재사용 차단
- 중복 문제 방지 강화
  - bulk 요청 내 동일 문제 중복 검증
  - DB 내 동일 시그니처(제목/본문/난이도/제약/입출력/judge 설정) 중복 검증

## 테스트
- `./gradlew spotlessCheck`
- `./gradlew test --tests com.back.domain.problem.problem.controller.AdminProblemControllerTest`

## 참고
- 이번 PR은 관리자 문제 등록 플로우 안정화와 운영 실수 방지(검증 선행 강제)에 초점을 맞췄습니다.
