### PR TITLE
[Feat] 특정 문제에 대한 복습 스케줄 정보 받아오기 api

### DIFF
--- a/src/main/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleController.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.review.reviewschedule.dto.ReviewScheduleResponse;
 import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
 import com.back.domain.review.reviewschedule.service.ReviewScheduleService;
 import com.back.global.rq.Rq;
@@ -21,6 +22,16 @@ public class ReviewScheduleController {
 
     private final ReviewScheduleService reviewScheduleService;
     private final Rq rq;
+
+    @GetMapping
+    public RsData<ReviewScheduleResponse> getReviewSchedule(@RequestParam Long problemId) {
+        Member actor = rq.getActor();
+        if (actor == null) {
+            return RsData.of("401", "로그인이 필요합니다.");
+        }
+        ReviewScheduleResponse response = reviewScheduleService.getReviewSchedule(problemId, actor.getId());
+        return RsData.of("200", "복습 스케줄을 조회했습니다.", response);
+    }
 
     @GetMapping("/today")
     public RsData<TodayReviewResponse> getTodayReviews() {

--- a/src/main/java/com/back/domain/review/reviewschedule/dto/ReviewScheduleResponse.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/dto/ReviewScheduleResponse.java
@@ -1,0 +1,10 @@
+package com.back.domain.review.reviewschedule.dto;
+
+import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
+
+public record ReviewScheduleResponse(int reviewCount, boolean isReviewRequired) {
+
+    public static ReviewScheduleResponse from(ReviewSchedule schedule) {
+        return new ReviewScheduleResponse(schedule.getReviewCount(), schedule.isReviewRequired());
+    }
+}

--- a/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
@@ -33,7 +33,8 @@ public class ReviewScheduleService {
 
     @Transactional(readOnly = true)
     public ReviewScheduleResponse getReviewSchedule(Long problemId, Long memberId) {
-        return reviewScheduleRepository.findByMemberIdAndProblemId(memberId, problemId)
+        return reviewScheduleRepository
+                .findByMemberIdAndProblemId(memberId, problemId)
                 .map(ReviewScheduleResponse::from)
                 .orElse(null);
     }

--- a/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/service/ReviewScheduleService.java
@@ -10,6 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.review.reviewschedule.dto.ReviewScheduleResponse;
 import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
 import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
 import com.back.domain.review.reviewschedule.repository.ReviewScheduleRepository;
@@ -28,6 +29,13 @@ public class ReviewScheduleService {
         List<TodayReviewResponse.ReviewItem> items =
                 schedules.stream().map(TodayReviewResponse.ReviewItem::from).toList();
         return new TodayReviewResponse(items);
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewScheduleResponse getReviewSchedule(Long problemId, Long memberId) {
+        return reviewScheduleRepository.findByMemberIdAndProblemId(memberId, problemId)
+                .map(ReviewScheduleResponse::from)
+                .orElse(null);
     }
 
     @Transactional

--- a/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
@@ -79,7 +79,8 @@ class ReviewScheduleControllerTest {
         RsData<ReviewScheduleResponse> result = controller.getReviewSchedule(10L);
 
         assertThat(result.resultCode()).isEqualTo("401");
-        verify(reviewScheduleService, never()).getReviewSchedule(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+        verify(reviewScheduleService, never())
+                .getReviewSchedule(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
     }
 
     @Test

--- a/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.review.reviewschedule.dto.ReviewScheduleResponse;
 import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
 import com.back.domain.review.reviewschedule.service.ReviewScheduleService;
 import com.back.global.rq.Rq;
@@ -68,6 +69,47 @@ class ReviewScheduleControllerTest {
 
         assertThat(result.resultCode()).isEqualTo("200");
         assertThat(result.data().reviews()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("비로그인 상태에서 복습 스케줄 조회하면 401을 반환한다")
+    void getReviewSchedule_unauthenticated_returns401() {
+        when(rq.getActor()).thenReturn(null);
+
+        RsData<ReviewScheduleResponse> result = controller.getReviewSchedule(10L);
+
+        assertThat(result.resultCode()).isEqualTo("401");
+        verify(reviewScheduleService, never()).getReviewSchedule(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("스케줄이 존재하면 reviewCount와 isReviewRequired를 반환한다")
+    void getReviewSchedule_authenticated_returnsData() {
+        Member actor = Member.of(1L, "test@test.com", "tester");
+        ReviewScheduleResponse serviceResponse = new ReviewScheduleResponse(2, true);
+
+        when(rq.getActor()).thenReturn(actor);
+        when(reviewScheduleService.getReviewSchedule(10L, 1L)).thenReturn(serviceResponse);
+
+        RsData<ReviewScheduleResponse> result = controller.getReviewSchedule(10L);
+
+        assertThat(result.resultCode()).isEqualTo("200");
+        assertThat(result.data().reviewCount()).isEqualTo(2);
+        assertThat(result.data().isReviewRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("스케줄이 없으면 data가 null인 200을 반환한다")
+    void getReviewSchedule_authenticated_returnsNullData() {
+        Member actor = Member.of(1L, "test@test.com", "tester");
+
+        when(rq.getActor()).thenReturn(actor);
+        when(reviewScheduleService.getReviewSchedule(10L, 1L)).thenReturn(null);
+
+        RsData<ReviewScheduleResponse> result = controller.getReviewSchedule(10L);
+
+        assertThat(result.resultCode()).isEqualTo("200");
+        assertThat(result.data()).isNull();
     }
 
     @Test

--- a/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
@@ -167,8 +167,7 @@ class ReviewScheduleServiceTest {
     @DisplayName("복습 스케줄이 존재하면 reviewCount와 isReviewRequired를 반환한다")
     void getReviewSchedule_returnsScheduleData() {
         ReviewSchedule schedule = scheduleWithReviewCount(2);
-        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L))
-                .thenReturn(Optional.of(schedule));
+        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L)).thenReturn(Optional.of(schedule));
 
         ReviewScheduleResponse response = reviewScheduleService.getReviewSchedule(10L, 1L);
 
@@ -180,8 +179,7 @@ class ReviewScheduleServiceTest {
     @Test
     @DisplayName("복습 스케줄이 없으면 null을 반환한다")
     void getReviewSchedule_returnsNullWhenNotFound() {
-        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L))
-                .thenReturn(Optional.empty());
+        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L)).thenReturn(Optional.empty());
 
         ReviewScheduleResponse response = reviewScheduleService.getReviewSchedule(10L, 1L);
 

--- a/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.review.reviewschedule.dto.ReviewScheduleResponse;
 import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
 import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
 import com.back.domain.review.reviewschedule.repository.ReviewScheduleRepository;
@@ -160,6 +161,31 @@ class ReviewScheduleServiceTest {
 
         assertThatThrownBy(() -> reviewScheduleService.dismissReview(10L, 1L))
                 .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    @DisplayName("복습 스케줄이 존재하면 reviewCount와 isReviewRequired를 반환한다")
+    void getReviewSchedule_returnsScheduleData() {
+        ReviewSchedule schedule = scheduleWithReviewCount(2);
+        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L))
+                .thenReturn(Optional.of(schedule));
+
+        ReviewScheduleResponse response = reviewScheduleService.getReviewSchedule(10L, 1L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.reviewCount()).isEqualTo(2);
+        assertThat(response.isReviewRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("복습 스케줄이 없으면 null을 반환한다")
+    void getReviewSchedule_returnsNullWhenNotFound() {
+        when(reviewScheduleRepository.findByMemberIdAndProblemId(1L, 10L))
+                .thenReturn(Optional.empty());
+
+        ReviewScheduleResponse response = reviewScheduleService.getReviewSchedule(10L, 1L);
+
+        assertThat(response).isNull();
     }
 
     /**


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #186
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #186

---

## Summary

현재 로그인된 사용자와 특정 문제에 대한 복습 스케줄 데이터를 조회하는 API를 추가합니다.

프론트엔드에서 문제 상세 페이지 진입 시 해당 문제의 복습 상태를 확인하는 용도로 사용합니다.

### 변경 내용

- `GET /api/v1/review?problemId={id}` 엔드포인트 추가

- 스케줄이 존재하면 `reviewCount`, `isReviewRequired` 반환

- 스케줄이 없으면 `data: null` 반환 (404가 아닌 200 — 조회 자체는 성공)

### 변경 파일

| 파일 | 변경 내용 |

|---|---|

| `ReviewScheduleResponse.java` | 신규 DTO (`reviewCount`, `isReviewRequired`) |

| `ReviewScheduleService.java` | `getReviewSchedule(problemId, memberId)` 추가 |

| `ReviewScheduleController.java` | `GET /api/v1/review?problemId=` 엔드포인트 추가 |

### API 명세

GET /api/v1/review?problemId={id}

***스케줄 있음***

→ 200 { data: { reviewCount: 2, isReviewRequired: true } }

***스케줄 없음***

→ 200 { data: null }

***비로그인***

→ 401

## Test plan

- [x] `ReviewScheduleServiceTest` — 스케줄 있음 / 없음(null 반환) 2개 케이스

- [x] `ReviewScheduleControllerTest` — 401 / 200+데이터 / 200+null 3개 케이스

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
