### PR TITLE
[feat] battleroom의 participants 상태 실시간 동기화

### DIFF
--- a/src/main/java/com/back/domain/battle/battleroom/dto/JoinRoomResponse.java
+++ b/src/main/java/com/back/domain/battle/battleroom/dto/JoinRoomResponse.java
@@ -1,12 +1,19 @@
 package com.back.domain.battle.battleroom.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 
-public record JoinRoomResponse(Long roomId, String status, LocalDateTime timerEnd) {
+public record JoinRoomResponse(
+        Long roomId, String status, LocalDateTime timerEnd, List<RoomResponse.ParticipantInfo> participants) {
 
-    public static JoinRoomResponse from(BattleRoom room) {
-        return new JoinRoomResponse(room.getId(), room.getStatus().name(), room.getTimerEnd());
+    public static JoinRoomResponse from(BattleRoom room, List<BattleParticipant> participants) {
+        return new JoinRoomResponse(
+                room.getId(),
+                room.getStatus().name(),
+                room.getTimerEnd(),
+                participants.stream().map(RoomResponse.ParticipantInfo::from).toList());
     }
 }

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -80,6 +80,8 @@ public class BattleRoomService {
 
     @Transactional
     public JoinRoomResponse joinRoom(Long roomId, Long memberId) {
+        boolean publishPlaying = false;
+        String battleTimerEnd = null;
 
         // 1. BattleRoom 조회 (비관적 락으로 동시 joinRoom 직렬화)
         BattleRoom room = battleRoomRepository
@@ -110,6 +112,7 @@ public class BattleRoomService {
             }
             participant.join();
             battleParticipantRepository.save(participant);
+            publishPlaying = true;
         } else {
             throw new IllegalStateException("입장할 수 없는 참여자 상태입니다. 현재 상태: " + participant.getStatus());
         }
@@ -124,7 +127,8 @@ public class BattleRoomService {
             if (allPlaying) {
                 room.startBattle(Duration.ofMinutes(30));
                 battleRoomRepository.save(room);
-                String timerEnd = room.getTimerEnd().toString();
+                battleTimerEnd = room.getTimerEnd().toString();
+                String timerEnd = battleTimerEnd;
                 TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
@@ -147,7 +151,30 @@ public class BattleRoomService {
             }
         }
 
-        return JoinRoomResponse.from(room);
+        if (publishPlaying) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    try {
+                        publisher.publish(
+                                "/topic/room/" + roomId,
+                                Map.of(
+                                        "type",
+                                        "PARTICIPANT_STATUS_CHANGED",
+                                        "userId",
+                                        memberId,
+                                        "status",
+                                        BattleParticipantStatus.PLAYING.name()));
+                    } catch (Exception e) {
+                        log.error(
+                                "Failed to publish PARTICIPANT_STATUS_CHANGED(PLAYING) WebSocket roomId={}", roomId, e);
+                    }
+                }
+            });
+        }
+
+        List<BattleParticipant> allParticipantsForResponse = battleParticipantRepository.findByBattleRoom(room);
+        return JoinRoomResponse.from(room, allParticipantsForResponse);
     }
 
     @Transactional(readOnly = true)
@@ -194,19 +221,36 @@ public class BattleRoomService {
         boolean noActiveLeft = all.stream()
                 .noneMatch(p -> p.getStatus() == BattleParticipantStatus.PLAYING
                         || p.getStatus() == BattleParticipantStatus.ABANDONED);
+        log.debug("exitRoom activated at exitRoom id={} status={}", roomId, noActiveLeft);
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 try {
-                    publisher.publish("/topic/room/" + roomId, Map.of("type", "PARTICIPANT_LEFT", "userId", memberId));
+                    log.info(
+                            "exitRoom afterCommit start roomId={}, memberId={}, noActiveLeft={}",
+                            roomId,
+                            memberId,
+                            noActiveLeft);
+                    publisher.publish(
+                            "/topic/room/" + roomId,
+                            Map.of(
+                                    "type",
+                                    "PARTICIPANT_STATUS_CHANGED",
+                                    "userId",
+                                    memberId,
+                                    "status",
+                                    BattleParticipantStatus.QUIT.name()));
                 } catch (Exception e) {
-                    log.error("PARTICIPANT_LEFT WebSocket 전송 실패 roomId={}", roomId, e);
+                    log.error("Failed to publish PARTICIPANT_STATUS_CHANGED(QUIT) WebSocket roomId={}", roomId, e);
                 }
+                log.info("exitRoom afterCommit start roomId={}, noActiveLeft={}", roomId, noActiveLeft);
                 if (noActiveLeft) {
                     try {
+                        log.info("exitRoom immediate settle start roomId={}", roomId);
                         battleTimerStore.cancel(roomId);
                         battleResultService.settle(roomId);
+                        log.info("exitRoom immediate settle done roomId={}", roomId);
                     } catch (OptimisticLockException e) {
                         log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", roomId);
                     } catch (Exception e) {

--- a/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
+++ b/src/main/java/com/back/domain/battle/battleroom/service/BattleRoomService.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -21,7 +22,7 @@ import com.back.domain.battle.battleroom.dto.RoomResponse;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.battle.result.event.BattleSettlementRequestedEvent;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.problem.entity.Problem;
@@ -32,7 +33,6 @@ import com.back.global.websocket.BattleReconnectStore;
 import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,7 +49,7 @@ public class BattleRoomService {
     private final BattleCodeStore battleCodeStore;
     private final BattleReconnectStore reconnectStore;
     private final BattleTimerStore battleTimerStore;
-    private final BattleResultService battleResultService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public CreateRoomResponse createRoom(CreateRoomRequest request) {
@@ -93,18 +93,13 @@ public class BattleRoomService {
             throw new IllegalStateException("입장할 수 없는 상태의 방입니다. 현재 상태: " + room.getStatus());
         }
 
-        // 2. Member 조회
         Member member =
                 memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        // 3. BattleParticipant 조회
         BattleParticipant participant = battleParticipantRepository
                 .findByBattleRoomAndMember(room, member)
                 .orElseThrow(() -> new IllegalArgumentException("해당 방의 참여자가 아닙니다."));
 
-        // 4. 참여자 상태에 따라 분기
-        //    READY     → 최초 입장 (WAITING 상태 방)
-        //    ABANDONED → 재입장 (PLAYING 상태 방)
         if (participant.getStatus() == BattleParticipantStatus.READY
                 || participant.getStatus() == BattleParticipantStatus.ABANDONED) {
             if (participant.getStatus() == BattleParticipantStatus.ABANDONED) {
@@ -117,8 +112,6 @@ public class BattleRoomService {
             throw new IllegalStateException("입장할 수 없는 참여자 상태입니다. 현재 상태: " + participant.getStatus());
         }
 
-        // 5. 최초 입장 시에만 allPlaying 체크 → 전원 PLAYING이면 배틀 시작
-        //    재입장(PLAYING 방)은 이미 배틀이 시작된 상태이므로 체크하지 않음
         if (room.getStatus() == BattleRoomStatus.WAITING) {
             List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
             boolean allPlaying =
@@ -132,9 +125,6 @@ public class BattleRoomService {
                 TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
-                        // 커밋 후이므로 예외를 전파해도 트랜잭션 롤백이 불가능하고,
-                        // 클라이언트에게 500이 반환되어 DB는 성공했는데 실패로 인식하는 혼란을 유발함.
-                        // WebSocket은 실시간 알림 역할이므로 전송 실패가 치명적이지 않아 예외를 삼키고 로그만 남김.
                         try {
                             publisher.publish(
                                     "/topic/room/" + roomId, Map.of("type", "BATTLE_STARTED", "timerEnd", timerEnd));
@@ -205,8 +195,6 @@ public class BattleRoomService {
                 .findByBattleRoomAndMember(room, member)
                 .orElseThrow(() -> new ServiceException("403-1", "해당 방의 참여자가 아닙니다."));
 
-        // ABANDONED: WebSocket이 끊긴 상태에서 의도적 퇴장 — grace period 취소 후 QUIT 처리
-        // PLAYING: 정상 접속 상태에서 의도적 퇴장
         if (participant.getStatus() == BattleParticipantStatus.ABANDONED) {
             reconnectStore.cancelGracePeriod(memberId);
         } else if (participant.getStatus() != BattleParticipantStatus.PLAYING) {
@@ -216,22 +204,20 @@ public class BattleRoomService {
         participant.quit();
         battleParticipantRepository.save(participant);
 
-        // 남은 활성 참여자 (PLAYING or ABANDONED) 여부 확인
         List<BattleParticipant> all = battleParticipantRepository.findByBattleRoom(room);
         boolean noActiveLeft = all.stream()
                 .noneMatch(p -> p.getStatus() == BattleParticipantStatus.PLAYING
                         || p.getStatus() == BattleParticipantStatus.ABANDONED);
-        log.debug("exitRoom activated at exitRoom id={} status={}", roomId, noActiveLeft);
+
+        if (noActiveLeft) {
+            log.info("publish BattleSettlementRequestedEvent roomId={}, noActiveLeft={}", roomId, noActiveLeft);
+            eventPublisher.publishEvent(new BattleSettlementRequestedEvent(roomId));
+        }
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 try {
-                    log.info(
-                            "exitRoom afterCommit start roomId={}, memberId={}, noActiveLeft={}",
-                            roomId,
-                            memberId,
-                            noActiveLeft);
                     publisher.publish(
                             "/topic/room/" + roomId,
                             Map.of(
@@ -243,19 +229,6 @@ public class BattleRoomService {
                                     BattleParticipantStatus.QUIT.name()));
                 } catch (Exception e) {
                     log.error("Failed to publish PARTICIPANT_STATUS_CHANGED(QUIT) WebSocket roomId={}", roomId, e);
-                }
-                log.info("exitRoom afterCommit start roomId={}, noActiveLeft={}", roomId, noActiveLeft);
-                if (noActiveLeft) {
-                    try {
-                        log.info("exitRoom immediate settle start roomId={}", roomId);
-                        battleTimerStore.cancel(roomId);
-                        battleResultService.settle(roomId);
-                        log.info("exitRoom immediate settle done roomId={}", roomId);
-                    } catch (OptimisticLockException e) {
-                        log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", roomId);
-                    } catch (Exception e) {
-                        log.error("즉시 정산 실패 roomId={}", roomId, e);
-                    }
                 }
             }
         });

--- a/src/main/java/com/back/domain/battle/result/event/BattleSettlementRequestedEvent.java
+++ b/src/main/java/com/back/domain/battle/result/event/BattleSettlementRequestedEvent.java
@@ -1,3 +1,11 @@
 package com.back.domain.battle.result.event;
 
+/**
+ * Battle 정산 요청 이벤트.
+ *
+ * 이 이벤트는 트랜잭션 내부에서 발행되지만, 소비는 반드시
+ * {@code @TransactionalEventListener(phase = AFTER_COMMIT)} 로만 처리한다.
+ * 일반 {@code @EventListener} / {@code ApplicationListener} 로 소비하면
+ * 커밋 이전에 정산이 실행될 수 있으므로 금지한다.
+ */
 public record BattleSettlementRequestedEvent(Long roomId) {}

--- a/src/main/java/com/back/domain/battle/result/event/BattleSettlementRequestedEvent.java
+++ b/src/main/java/com/back/domain/battle/result/event/BattleSettlementRequestedEvent.java
@@ -1,0 +1,3 @@
+package com.back.domain.battle.result.event;
+
+public record BattleSettlementRequestedEvent(Long roomId) {}

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -60,6 +60,7 @@ public class BattleResultService {
 
     @Transactional
     public void settle(Long roomId) {
+        log.info("settle called roomId={}", roomId);
 
         // 1. BattleRoom 조회 + 중복 정산 방지
         BattleRoom room =
@@ -100,11 +101,15 @@ public class BattleResultService {
         int totalParticipants = sorted.size();
         for (BattleParticipant participant : sorted) {
             boolean isAC = participant.getStatus() == BattleParticipantStatus.SOLVED;
+            boolean isDisconnected = participant.getStatus() == BattleParticipantStatus.ABANDONED
+                    || participant.getStatus() == BattleParticipantStatus.QUIT;
             long scoreDelta = 0L;
             if (isAC && rank <= SCORE_TABLE.length) {
                 scoreDelta = SCORE_TABLE[rank - 1];
             }
-            if (totalParticipants >= 4 && rank == totalParticipants) {
+            if (isDisconnected) {
+                scoreDelta = LAST_PLACE_PENALTY;
+            } else if (totalParticipants >= 4 && rank == totalParticipants) {
                 scoreDelta = LAST_PLACE_PENALTY;
             }
 
@@ -146,6 +151,24 @@ public class BattleResultService {
 
                 // 방 채널 브로드캐스트 (방 내 구독자 및 관전자)
                 try {
+                    for (BattleParticipant p : participants) {
+                        if (p.getStatus() != BattleParticipantStatus.TIMEOUT) {
+                            continue;
+                        }
+                        try {
+                            publisher.publish(
+                                    "/topic/room/" + roomId,
+                                    Map.of(
+                                            "type", "PARTICIPANT_STATUS_CHANGED",
+                                            "userId", p.getMember().getId(),
+                                            "status", BattleParticipantStatus.TIMEOUT.name()));
+                        } catch (Exception inner) {
+                            log.error(
+                                    "Failed to publish PARTICIPANT_STATUS_CHANGED(TIMEOUT) WebSocket roomId={}",
+                                    roomId,
+                                    inner);
+                        }
+                    }
                     publisher.publish("/topic/room/" + roomId, Map.of("type", "BATTLE_FINISHED"));
                 } catch (Exception e) {
                     log.error("BATTLE_FINISHED WebSocket 전송 실패 roomId={}", roomId, e);

--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -201,6 +201,7 @@ public class BattleResultService {
                 }
             }
         });
+        log.info("settle end roomId={}", roomId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/back/domain/battle/result/service/BattleSettlementCoordinator.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleSettlementCoordinator.java
@@ -1,0 +1,25 @@
+package com.back.domain.battle.result.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.back.domain.battle.result.event.BattleSettlementRequestedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BattleSettlementCoordinator {
+
+    private final BattleSettlementExecutor battleSettlementExecutor;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onRequested(BattleSettlementRequestedEvent event) {
+        log.info("BattleSettlementCoordinator received roomId={}", event.roomId());
+
+        battleSettlementExecutor.settle(event.roomId());
+    }
+}

--- a/src/main/java/com/back/domain/battle/result/service/BattleSettlementCoordinator.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleSettlementCoordinator.java
@@ -16,6 +16,10 @@ public class BattleSettlementCoordinator {
 
     private final BattleSettlementExecutor battleSettlementExecutor;
 
+    /**
+     * {@link BattleSettlementRequestedEvent} 는 반드시 AFTER_COMMIT 에서만 소비한다.
+     * 이 규칙이 깨지면 커밋 이전 정산 실행으로 트랜잭션 경계가 꼬일 수 있다.
+     */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onRequested(BattleSettlementRequestedEvent event) {
         log.info("BattleSettlementCoordinator received roomId={}", event.roomId());

--- a/src/main/java/com/back/domain/battle/result/service/BattleSettlementExecutor.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleSettlementExecutor.java
@@ -1,0 +1,32 @@
+package com.back.domain.battle.result.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.global.websocket.BattleTimerStore;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BattleSettlementExecutor {
+
+    private final BattleResultService battleResultService;
+    private final BattleTimerStore battleTimerStore;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void settle(Long roomId) {
+        try {
+            log.info("BattleSettlementExecutor settle start roomId={}", roomId);
+            battleTimerStore.cancel(roomId);
+            battleResultService.settle(roomId);
+            log.info("BattleSettlementExecutor settle end roomId={}", roomId);
+        } catch (Exception e) {
+            log.error("BattleSettlementExecutor settle failed roomId={}", roomId, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/back/global/judge/BattleAcService.java
+++ b/src/main/java/com/back/global/judge/BattleAcService.java
@@ -1,0 +1,88 @@
+package com.back.global.judge;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.global.websocket.BattleTimerStore;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BattleAcService {
+
+    private final BattleParticipantRepository battleParticipantRepository;
+    private final BattleRoomRepository battleRoomRepository;
+    private final MemberRepository memberRepository;
+    private final BattleResultService battleResultService;
+    private final BattleTimerStore battleTimerStore;
+    private final WebSocketMessagePublisher publisher;
+
+    @Transactional
+    public void handleAc(Long roomId, Long memberId) {
+        BattleRoom room = battleRoomRepository
+                .findById(roomId)
+                .orElseThrow(() -> new IllegalStateException("BattleRoom not found: " + roomId));
+        Member member = memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new IllegalStateException("Member not found: " + memberId));
+
+        BattleParticipant participant = battleParticipantRepository
+                .findByBattleRoomAndMember(room, member)
+                .orElseThrow(() -> new IllegalStateException("Participant not found"));
+
+        participant.complete(LocalDateTime.now());
+        battleParticipantRepository.save(participant);
+
+        List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
+        long completedCount = allParticipants.stream()
+                .filter(p -> p.getStatus() == BattleParticipantStatus.SOLVED)
+                .count();
+        boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.SOLVED);
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                publisher.publish(
+                        "/topic/room/" + roomId,
+                        Map.of(
+                                "type",
+                                "PARTICIPANT_STATUS_CHANGED",
+                                "userId",
+                                memberId,
+                                "status",
+                                BattleParticipantStatus.SOLVED.name()));
+                publisher.publish(
+                        "/topic/room/" + roomId,
+                        Map.of("type", "PARTICIPANT_DONE", "userId", memberId, "rank", completedCount));
+            }
+        });
+
+        if (allFinished) {
+            battleTimerStore.cancel(roomId);
+            try {
+                battleResultService.settle(roomId);
+            } catch (OptimisticLockException e) {
+                log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", roomId);
+            }
+        }
+    }
+}

--- a/src/main/java/com/back/global/judge/BattleAcService.java
+++ b/src/main/java/com/back/global/judge/BattleAcService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -14,17 +15,13 @@ import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
 import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.battle.result.event.BattleSettlementRequestedEvent;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
-import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BattleAcService {
@@ -32,9 +29,8 @@ public class BattleAcService {
     private final BattleParticipantRepository battleParticipantRepository;
     private final BattleRoomRepository battleRoomRepository;
     private final MemberRepository memberRepository;
-    private final BattleResultService battleResultService;
-    private final BattleTimerStore battleTimerStore;
     private final WebSocketMessagePublisher publisher;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void handleAc(Long roomId, Long memberId) {
@@ -56,7 +52,13 @@ public class BattleAcService {
         long completedCount = allParticipants.stream()
                 .filter(p -> p.getStatus() == BattleParticipantStatus.SOLVED)
                 .count();
-        boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.SOLVED);
+        boolean noActiveLeft = allParticipants.stream()
+                .noneMatch(p -> p.getStatus() == BattleParticipantStatus.PLAYING
+                        || p.getStatus() == BattleParticipantStatus.ABANDONED);
+
+        if (noActiveLeft) {
+            eventPublisher.publishEvent(new BattleSettlementRequestedEvent(roomId));
+        }
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
@@ -75,14 +77,5 @@ public class BattleAcService {
                         Map.of("type", "PARTICIPANT_DONE", "userId", memberId, "rank", completedCount));
             }
         });
-
-        if (allFinished) {
-            battleTimerStore.cancel(roomId);
-            try {
-                battleResultService.settle(roomId);
-            } catch (OptimisticLockException e) {
-                log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", roomId);
-            }
-        }
     }
 }

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -1,6 +1,5 @@
 package com.back.global.judge;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -9,14 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
-import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
-import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
-import com.back.domain.battle.battleroom.entity.BattleRoom;
-import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
-import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.submission.entity.Submission;
 import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
@@ -24,10 +15,8 @@ import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.global.judge.dto.Judge0SubmitRequest;
 import com.back.global.judge.dto.Judge0SubmitResponse;
 import com.back.global.judge.event.JudgeRequestedEvent;
-import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,18 +27,9 @@ public class JudgeService {
 
     private final Judge0ExecutionService judge0ExecutionService;
     private final SubmissionRepository submissionRepository;
-    private final BattleParticipantRepository battleParticipantRepository;
-    private final BattleRoomRepository battleRoomRepository;
-    private final MemberRepository memberRepository;
-    private final BattleResultService battleResultService;
-    private final BattleTimerStore battleTimerStore;
+    private final BattleAcService battleAcService;
     private final WebSocketMessagePublisher publisher;
 
-    /**
-     * 트랜잭션 커밋 후 비동기 채점 실행.
-     * @TransactionalEventListener(AFTER_COMMIT) 으로 커밋 확정 후 실행이 보장되므로
-     * 이후 findById(submissionId) 호출 시 레코드가 반드시 존재한다.
-     */
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onJudgeRequested(JudgeRequestedEvent event) {
@@ -65,20 +45,15 @@ public class JudgeService {
     private void judge(
             Long submissionId, Long roomId, Long memberId, String code, String language, List<TestCase> testCases) {
 
-        // 문제에 있는 테스트 케이스의 총 개수
         int totalCount = testCases.size();
         SubmissionResult judgeResult;
         int passedCount = 0;
 
-        // 테스트케이스가 0개의 경우 WA처리
         if (totalCount == 0) {
             log.warn("Submission {} has no test cases, marking as WA", submissionId);
             judgeResult = SubmissionResult.WA;
         } else { // 테스트 케이스가 1개 이상의 경우
             int languageId = judge0ExecutionService.getLanguageId(language);
-
-            // TODO: 함수형 코드 지원 시 driverCode 합치기
-            // String fullCode = code + "\n" + problem.getDriverCode().get(language);
             List<Judge0SubmitRequest> batchRequests = testCases.stream()
                     .map(tc -> new Judge0SubmitRequest(
                             code, languageId, tc.getInput() != null ? tc.getInput() : "", tc.getExpectedOutput()))
@@ -91,23 +66,18 @@ public class JudgeService {
                     r.stderr(),
                     r.compileOutput(),
                     r.message()));
-            // 결과 집계
-            // 우선순위: CE(6) > RE(7~14) > TLE(5) > WA > AC(3)
-            //  passedCount = status.id == 3 인 케이스 수
             judgeResult = aggregateResult(results, totalCount);
             passedCount = (int) results.stream()
                     .filter(r -> r.status() != null && r.status().id() == 3)
                     .count();
         }
 
-        // 결과 저장 — @TransactionalEventListener(AFTER_COMMIT) 으로 커밋 확정 후 실행되므로 안전
         Submission submission = submissionRepository
                 .findById(submissionId)
                 .orElseThrow(() -> new IllegalStateException("Submission not found: " + submissionId));
         submission.applyJudgeResult(judgeResult, passedCount, totalCount);
         submissionRepository.save(submission);
 
-        // WebSocket: 제출 결과 브로드캐스트 (알림)
         publisher.publish(
                 "/topic/room/" + roomId,
                 Map.of(
@@ -117,63 +87,11 @@ public class JudgeService {
                         "passedCount", passedCount,
                         "totalCount", totalCount));
 
-        /*
-         * result != AC일 때
-         * SUBMISSION 브로드캐스트만 하고 끝. handleAc()가 호출되지 않으므로 participant 상태 변경 없음, 정산도 없음.
-         */
         if (judgeResult == SubmissionResult.AC) {
-            handleAc(roomId, memberId);
-        }
-        // SUBMISSION 브로드캐스트는 알림이고, AC일 때만 참여자 완료 처리 → 전원 완료 시 정산까지 연결
-    }
-
-    private void handleAc(Long roomId, Long memberId) {
-        BattleRoom room = battleRoomRepository
-                .findById(roomId)
-                .orElseThrow(() -> new IllegalStateException("BattleRoom not found: " + roomId));
-        Member member = memberRepository
-                .findById(memberId)
-                .orElseThrow(() -> new IllegalStateException("Member not found: " + memberId));
-
-        BattleParticipant participant = battleParticipantRepository
-                .findByBattleRoomAndMember(room, member)
-                .orElseThrow(() -> new IllegalStateException("Participant not found"));
-
-        /*
-         * status: PLAYING에서 SOLVED
-         * finishTime 기록
-         */
-        participant.complete(LocalDateTime.now());
-        battleParticipantRepository.save(participant);
-
-        List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);
-        long completedCount = allParticipants.stream()
-                .filter(p -> p.getStatus() == BattleParticipantStatus.SOLVED)
-                .count();
-        // PARTICIPANT_DONE 브로드캐스트
-        publisher.publish(
-                "/topic/room/" + roomId,
-                Map.of("type", "PARTICIPANT_DONE", "userId", memberId, "rank", completedCount));
-
-        /*
-         * 전원 SOLVED 체크
-         *     → 아직 남은 사람 있으면 종료
-         *     → 전원 완료면 타이머 취소 후 즉시 settle()
-         */
-        boolean allFinished = allParticipants.stream().allMatch(p -> p.getStatus() == BattleParticipantStatus.SOLVED);
-        if (allFinished) {
-            battleTimerStore.cancel(roomId);
-            try {
-                battleResultService.settle(roomId);
-            } catch (OptimisticLockException e) {
-                log.info("settle 낙관적 락 충돌 - 이미 정산 완료됨 roomId={}", roomId);
-            }
+            battleAcService.handleAc(roomId, memberId);
         }
     }
 
-    /**
-     * 우선순위: CE > RE > TLE > WA > AC
-     */
     private SubmissionResult aggregateResult(List<Judge0SubmitResponse> results, int totalCount) {
         if (results.isEmpty()) return SubmissionResult.JUDGE_ERROR;
 

--- a/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
+++ b/src/main/java/com/back/global/websocket/BattleDisconnectHandler.java
@@ -1,17 +1,21 @@
 package com.back.global.websocket;
 
 import java.security.Principal;
+import java.util.Map;
 
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
 import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.global.security.SecurityUser;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +27,7 @@ public class BattleDisconnectHandler {
 
     private final BattleParticipantRepository battleParticipantRepository;
     private final BattleReconnectStore reconnectStore;
+    private final WebSocketMessagePublisher publisher;
 
     /**
      * WebSocket 연결이 끊길 때 Spring이 자동으로 발생시키는 이벤트 처리.
@@ -57,13 +62,26 @@ public class BattleDisconnectHandler {
 
                     participant.abandon();
                     battleParticipantRepository.save(participant);
+                    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            publisher.publish(
+                                    "/topic/room/" + roomId,
+                                    Map.of(
+                                            "type",
+                                            "PARTICIPANT_STATUS_CHANGED",
+                                            "userId",
+                                            memberId,
+                                            "status",
+                                            BattleParticipantStatus.ABANDONED.name()));
+                            // PARTICIPANT_LEFT를 즉시 보내지 않고 15초 유예 기간 부여.
+                            // 새로고침 등 의도치 않은 끊김 시 재연결 기회를 준다.
+                            // 유예 기간 만료 후 미복귀 시 GracePeriodConsumer가 브로드캐스트.
+                            reconnectStore.startGracePeriod(memberId);
+                        }
+                    });
 
                     log.info("배틀 이탈 처리 - memberId={}, roomId={}, grace period 시작", memberId, roomId);
-
-                    // PARTICIPANT_LEFT를 즉시 보내지 않고 15초 유예 기간 부여.
-                    // 새로고침 등 의도치 않은 끊김 시 재연결 기회를 준다.
-                    // 유예 기간 만료 후 미복귀 시 GracePeriodConsumer가 브로드캐스트.
-                    reconnectStore.startGracePeriod(memberId);
                 });
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceExitRoomTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceExitRoomTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -27,7 +28,7 @@ import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepo
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.battle.result.event.BattleSettlementRequestedEvent;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.problem.repository.ProblemRepository;
@@ -47,7 +48,7 @@ class BattleRoomServiceExitRoomTest {
     private final BattleCodeStore battleCodeStore = mock(BattleCodeStore.class);
     private final BattleReconnectStore reconnectStore = mock(BattleReconnectStore.class);
     private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
-    private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
 
     private final BattleRoomService sut = new BattleRoomService(
             battleRoomRepository,
@@ -58,7 +59,7 @@ class BattleRoomServiceExitRoomTest {
             battleCodeStore,
             reconnectStore,
             battleTimerStore,
-            battleResultService);
+            eventPublisher);
 
     private static final Long ROOM_ID = 1L;
     private static final Long MEMBER_ID = 10L;
@@ -114,25 +115,25 @@ class BattleRoomServiceExitRoomTest {
     }
 
     @Test
-    @DisplayName("마지막 활성 참여자가 퇴장하면 즉시 정산한다")
-    void exitRoom_lastActiveParticipant_settlesImmediately() {
+    @DisplayName("마지막 활성 참여자가 퇴장하면 정산 요청 이벤트를 발행한다")
+    void exitRoom_lastActiveParticipant_publishesSettlementRequestedEvent() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = playingParticipant(room, member);
 
-        BattleParticipant exitedOther = mock(BattleParticipant.class);
-        when(exitedOther.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        BattleParticipant solvedOther = mock(BattleParticipant.class);
+        when(solvedOther.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
 
-        givenRoomMemberParticipant(room, member, participant, List.of(participant, exitedOther));
+        givenRoomMemberParticipant(room, member, participant, List.of(participant, solvedOther));
 
         withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
 
-        verify(battleResultService).settle(ROOM_ID);
+        verify(eventPublisher).publishEvent(new BattleSettlementRequestedEvent(ROOM_ID));
     }
 
     @Test
-    @DisplayName("활성 참여자가 남아있으면 퇴장해도 정산하지 않는다")
-    void exitRoom_activeParticipantRemains_doesNotSettle() {
+    @DisplayName("활성 참여자가 남아있으면 퇴장해도 정산 요청 이벤트를 발행하지 않는다")
+    void exitRoom_activeParticipantRemains_doesNotPublishSettlementRequestedEvent() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = playingParticipant(room, member);
@@ -144,12 +145,12 @@ class BattleRoomServiceExitRoomTest {
 
         withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
 
-        verify(battleResultService, never()).settle(any());
+        verify(eventPublisher, never()).publishEvent(any(BattleSettlementRequestedEvent.class));
     }
 
     @Test
-    @DisplayName("ABANDONED 참여자만 남아있으면 퇴장해도 정산하지 않는다")
-    void exitRoom_onlyAbandonedParticipantRemains_doesNotSettle() {
+    @DisplayName("ABANDONED 참여자가 남아있으면 퇴장해도 정산 요청 이벤트를 발행하지 않는다")
+    void exitRoom_onlyAbandonedParticipantRemains_doesNotPublishSettlementRequestedEvent() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = playingParticipant(room, member);
@@ -161,7 +162,7 @@ class BattleRoomServiceExitRoomTest {
 
         withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
 
-        verify(battleResultService, never()).settle(any());
+        verify(eventPublisher, never()).publishEvent(any(BattleSettlementRequestedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceExitRoomTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceExitRoomTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -63,40 +64,58 @@ class BattleRoomServiceExitRoomTest {
     private static final Long MEMBER_ID = 10L;
 
     @Test
-    @DisplayName("PLAYING 참여자가 퇴장하면 QUIT으로 변경되고 PARTICIPANT_LEFT가 브로드캐스트된다")
-    void exitRoom_PLAYING상태_정상퇴장() {
+    @DisplayName("PLAYING 참여자가 퇴장하면 QUIT 상태 이벤트를 브로드캐스트한다")
+    void exitRoom_playingParticipant_broadcastsQuitStatus() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = playingParticipant(room, member);
 
-        given_room_member_participant(room, member, participant, List.of(participant));
+        givenRoomMemberParticipant(room, member, participant, List.of(participant));
 
         withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
 
         assertThat(participant.getStatus()).isEqualTo(BattleParticipantStatus.QUIT);
-        verify(publisher).publish(eq("/topic/room/" + ROOM_ID), any());
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(Map.of(
+                                "type",
+                                "PARTICIPANT_STATUS_CHANGED",
+                                "userId",
+                                MEMBER_ID,
+                                "status",
+                                BattleParticipantStatus.QUIT.name())));
         verify(reconnectStore, never()).cancelGracePeriod(any());
     }
 
     @Test
-    @DisplayName("ABANDONED 참여자가 퇴장하면 cancelGracePeriod 후 QUIT으로 변경된다")
-    void exitRoom_ABANDONED상태_cancelGracePeriod_후_quit() {
+    @DisplayName("ABANDONED 참여자가 퇴장하면 grace period를 취소하고 QUIT 상태 이벤트를 브로드캐스트한다")
+    void exitRoom_abandonedParticipant_cancelsGraceAndBroadcastsQuitStatus() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = abandonedParticipant(room, member);
 
-        given_room_member_participant(room, member, participant, List.of(participant));
+        givenRoomMemberParticipant(room, member, participant, List.of(participant));
 
         withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
 
         verify(reconnectStore).cancelGracePeriod(MEMBER_ID);
         assertThat(participant.getStatus()).isEqualTo(BattleParticipantStatus.QUIT);
-        verify(publisher).publish(eq("/topic/room/" + ROOM_ID), any());
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(Map.of(
+                                "type",
+                                "PARTICIPANT_STATUS_CHANGED",
+                                "userId",
+                                MEMBER_ID,
+                                "status",
+                                BattleParticipantStatus.QUIT.name())));
     }
 
     @Test
-    @DisplayName("마지막 활성 참여자가 퇴장하면 즉시 정산된다")
-    void exitRoom_마지막활성참여자_즉시정산() {
+    @DisplayName("마지막 활성 참여자가 퇴장하면 즉시 정산한다")
+    void exitRoom_lastActiveParticipant_settlesImmediately() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = playingParticipant(room, member);
@@ -104,7 +123,7 @@ class BattleRoomServiceExitRoomTest {
         BattleParticipant exitedOther = mock(BattleParticipant.class);
         when(exitedOther.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
 
-        given_room_member_participant(room, member, participant, List.of(participant, exitedOther));
+        givenRoomMemberParticipant(room, member, participant, List.of(participant, exitedOther));
 
         withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
 
@@ -112,8 +131,8 @@ class BattleRoomServiceExitRoomTest {
     }
 
     @Test
-    @DisplayName("활성 참여자가 남아있으면 퇴장 시 정산하지 않는다")
-    void exitRoom_활성참여자_남아있으면_정산안함() {
+    @DisplayName("활성 참여자가 남아있으면 퇴장해도 정산하지 않는다")
+    void exitRoom_activeParticipantRemains_doesNotSettle() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = playingParticipant(room, member);
@@ -121,7 +140,7 @@ class BattleRoomServiceExitRoomTest {
         BattleParticipant activeOther = mock(BattleParticipant.class);
         when(activeOther.getStatus()).thenReturn(BattleParticipantStatus.PLAYING);
 
-        given_room_member_participant(room, member, participant, List.of(participant, activeOther));
+        givenRoomMemberParticipant(room, member, participant, List.of(participant, activeOther));
 
         withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
 
@@ -129,8 +148,8 @@ class BattleRoomServiceExitRoomTest {
     }
 
     @Test
-    @DisplayName("ABANDONED 참여자만 남아있는 상황에서 퇴장하면 정산되지 않는다")
-    void exitRoom_ABANDONED참여자_남아있으면_정산안함() {
+    @DisplayName("ABANDONED 참여자만 남아있으면 퇴장해도 정산하지 않는다")
+    void exitRoom_onlyAbandonedParticipantRemains_doesNotSettle() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = playingParticipant(room, member);
@@ -138,7 +157,7 @@ class BattleRoomServiceExitRoomTest {
         BattleParticipant abandonedOther = mock(BattleParticipant.class);
         when(abandonedOther.getStatus()).thenReturn(BattleParticipantStatus.ABANDONED);
 
-        given_room_member_participant(room, member, participant, List.of(participant, abandonedOther));
+        givenRoomMemberParticipant(room, member, participant, List.of(participant, abandonedOther));
 
         withAfterCommit(() -> sut.exitRoom(ROOM_ID, MEMBER_ID));
 
@@ -147,49 +166,41 @@ class BattleRoomServiceExitRoomTest {
 
     @Test
     @DisplayName("PLAYING 상태가 아닌 방에서 exitRoom 호출하면 예외가 발생한다")
-    void exitRoom_방이PLAYING아닐때_예외() {
+    void exitRoom_nonPlayingRoom_throws() {
         BattleRoom room = mock(BattleRoom.class);
         when(room.getStatus()).thenReturn(BattleRoomStatus.FINISHED);
         when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
 
-        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID))
-                .isInstanceOf(ServiceException.class)
-                .hasMessageContaining("진행 중인 방이 아닙니다.");
+        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID)).isInstanceOf(ServiceException.class);
     }
 
     @Test
-    @DisplayName("EXIT 상태 참여자가 exitRoom 호출하면 예외가 발생한다")
-    void exitRoom_EXIT상태_예외() {
+    @DisplayName("SOLVED 상태 참여자가 exitRoom 호출하면 예외가 발생한다")
+    void exitRoom_solvedParticipant_throws() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = BattleParticipant.create(room, member);
         participant.join();
         participant.complete(LocalDateTime.now());
 
-        given_room_member_participant(room, member, participant, List.of());
+        givenRoomMemberParticipant(room, member, participant, List.of());
 
-        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID))
-                .isInstanceOf(ServiceException.class)
-                .hasMessageContaining("퇴장할 수 없는 상태입니다.");
+        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID)).isInstanceOf(ServiceException.class);
     }
 
     @Test
     @DisplayName("QUIT 상태 참여자가 exitRoom 호출하면 예외가 발생한다")
-    void exitRoom_QUIT상태_예외() {
+    void exitRoom_quitParticipant_throws() {
         BattleRoom room = playingRoom();
         Member member = mockMember();
         BattleParticipant participant = BattleParticipant.create(room, member);
         participant.join();
         participant.quit();
 
-        given_room_member_participant(room, member, participant, List.of());
+        givenRoomMemberParticipant(room, member, participant, List.of());
 
-        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID))
-                .isInstanceOf(ServiceException.class)
-                .hasMessageContaining("퇴장할 수 없는 상태입니다.");
+        assertThatThrownBy(() -> sut.exitRoom(ROOM_ID, MEMBER_ID)).isInstanceOf(ServiceException.class);
     }
-
-    // ── helpers ────────────────────────────────────────────────────────────────
 
     private BattleRoom playingRoom() {
         BattleRoom room = mock(BattleRoom.class);
@@ -205,19 +216,19 @@ class BattleRoomServiceExitRoomTest {
     }
 
     private BattleParticipant playingParticipant(BattleRoom room, Member member) {
-        BattleParticipant p = BattleParticipant.create(room, member);
-        p.join();
-        return p;
+        BattleParticipant participant = BattleParticipant.create(room, member);
+        participant.join();
+        return participant;
     }
 
     private BattleParticipant abandonedParticipant(BattleRoom room, Member member) {
-        BattleParticipant p = BattleParticipant.create(room, member);
-        p.join();
-        p.abandon();
-        return p;
+        BattleParticipant participant = BattleParticipant.create(room, member);
+        participant.join();
+        participant.abandon();
+        return participant;
     }
 
-    private void given_room_member_participant(
+    private void givenRoomMemberParticipant(
             BattleRoom room, Member member, BattleParticipant participant, List<BattleParticipant> all) {
         when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
         when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
@@ -227,16 +238,12 @@ class BattleRoomServiceExitRoomTest {
         when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(all);
     }
 
-    /**
-     * TransactionSynchronizationManager.registerSynchronization()을 가로채
-     * afterCommit()을 즉시 실행한다. 단위 테스트에서 트랜잭션 없이 afterCommit 로직을 검증하기 위한 헬퍼.
-     */
     private void withAfterCommit(Runnable action) {
         try (MockedStatic<TransactionSynchronizationManager> tsm =
                 mockStatic(TransactionSynchronizationManager.class)) {
             tsm.when(() -> TransactionSynchronizationManager.registerSynchronization(any()))
-                    .thenAnswer(inv -> {
-                        inv.<TransactionSynchronization>getArgument(0).afterCommit();
+                    .thenAnswer(invocation -> {
+                        invocation.<TransactionSynchronization>getArgument(0).afterCommit();
                         return null;
                     });
             action.run();

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceGetRoomStateTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceGetRoomStateTest.java
@@ -12,13 +12,13 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
 import com.back.domain.battle.battleroom.dto.BattleRoomStateResponse;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.problem.entity.Problem;
 import com.back.domain.problem.problem.repository.ProblemRepository;
@@ -43,7 +43,7 @@ class BattleRoomServiceGetRoomStateTest {
             battleCodeStore,
             mock(BattleReconnectStore.class),
             mock(BattleTimerStore.class),
-            mock(BattleResultService.class));
+            mock(ApplicationEventPublisher.class));
 
     private static final Long ROOM_ID = 1L;
     private static final Long MEMBER_ID = 10L;

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceJoinRoomTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceJoinRoomTest.java
@@ -1,0 +1,205 @@
+package com.back.domain.battle.battleroom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.global.websocket.BattleCodeStore;
+import com.back.global.websocket.BattleReconnectStore;
+import com.back.global.websocket.BattleTimerStore;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
+
+class BattleRoomServiceJoinRoomTest {
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long MEMBER_ID = 10L;
+
+    private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final ProblemRepository problemRepository = mock(ProblemRepository.class);
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
+    private final BattleCodeStore battleCodeStore = mock(BattleCodeStore.class);
+    private final BattleReconnectStore reconnectStore = mock(BattleReconnectStore.class);
+    private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
+    private final BattleResultService battleResultService = mock(BattleResultService.class);
+
+    private final BattleRoomService sut = new BattleRoomService(
+            battleRoomRepository,
+            battleParticipantRepository,
+            problemRepository,
+            memberRepository,
+            publisher,
+            battleCodeStore,
+            reconnectStore,
+            battleTimerStore,
+            battleResultService);
+
+    @Test
+    @DisplayName("READY 참여자가 입장하면 PLAYING 상태 이벤트를 발행한다")
+    void joinRoom_readyParticipant_broadcastsPlayingStatus() {
+        BattleRoom room = waitingRoom();
+        Member member = member();
+        BattleParticipant participant = BattleParticipant.create(room, member);
+
+        stubCommon(room, member, participant);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant), List.of(participant));
+
+        JoinRoomResponse response = withAfterCommit(() -> sut.joinRoom(ROOM_ID, MEMBER_ID));
+
+        assertThat(participant.getStatus()).isEqualTo(BattleParticipantStatus.PLAYING);
+        assertThat(response.participants()).hasSize(1);
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(Map.of(
+                                "type",
+                                "PARTICIPANT_STATUS_CHANGED",
+                                "userId",
+                                MEMBER_ID,
+                                "status",
+                                BattleParticipantStatus.PLAYING.name())));
+    }
+
+    @Test
+    @DisplayName("ABANDONED 참여자가 재입장하면 grace period를 취소하고 PLAYING 상태 이벤트를 발행한다")
+    void joinRoom_abandonedParticipant_cancelsGracePeriodAndBroadcastsPlayingStatus() {
+        BattleRoom room = playingRoom();
+        Member member = member();
+        BattleParticipant participant = BattleParticipant.create(room, member);
+        participant.join();
+        participant.abandon();
+
+        stubCommon(room, member, participant);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant));
+
+        withAfterCommit(() -> sut.joinRoom(ROOM_ID, MEMBER_ID));
+
+        verify(reconnectStore).cancelGracePeriod(MEMBER_ID);
+        assertThat(participant.getStatus()).isEqualTo(BattleParticipantStatus.PLAYING);
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(Map.of(
+                                "type",
+                                "PARTICIPANT_STATUS_CHANGED",
+                                "userId",
+                                MEMBER_ID,
+                                "status",
+                                BattleParticipantStatus.PLAYING.name())));
+    }
+
+    @Test
+    @DisplayName("마지막 READY 참여자가 입장하면 PLAYING 상태 이벤트와 BATTLE_STARTED를 함께 발행한다")
+    void joinRoom_lastReadyParticipant_broadcastsPlayingStatusAndBattleStarted() {
+        BattleRoom room = waitingRoom();
+        Member me = member();
+        Member otherMember1 = mock(Member.class);
+        Member otherMember2 = mock(Member.class);
+        Member otherMember3 = mock(Member.class);
+        when(otherMember1.getNickname()).thenReturn("u1");
+        when(otherMember2.getNickname()).thenReturn("u2");
+        when(otherMember3.getNickname()).thenReturn("u3");
+
+        BattleParticipant mine = BattleParticipant.create(room, me);
+        BattleParticipant p1 = BattleParticipant.create(room, otherMember1);
+        BattleParticipant p2 = BattleParticipant.create(room, otherMember2);
+        BattleParticipant p3 = BattleParticipant.create(room, otherMember3);
+        p1.join();
+        p2.join();
+        p3.join();
+
+        stubCommon(room, me, mine);
+        when(battleParticipantRepository.findByBattleRoom(room))
+                .thenReturn(List.of(p1, p2, p3, mine), List.of(p1, p2, p3, mine));
+
+        withAfterCommit(() -> sut.joinRoom(ROOM_ID, MEMBER_ID));
+
+        verify(publisher, times(2)).publish(eq("/topic/room/" + ROOM_ID), any());
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(Map.of(
+                                "type",
+                                "PARTICIPANT_STATUS_CHANGED",
+                                "userId",
+                                MEMBER_ID,
+                                "status",
+                                BattleParticipantStatus.PLAYING.name())));
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(Map.of(
+                                "type",
+                                "BATTLE_STARTED",
+                                "timerEnd",
+                                room.getTimerEnd().toString())));
+        verify(battleTimerStore).schedule(ROOM_ID);
+    }
+
+    private void stubCommon(BattleRoom room, Member member, BattleParticipant participant) {
+        when(battleRoomRepository.findByIdWithLock(ROOM_ID)).thenReturn(Optional.of(room));
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+        when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
+                .thenReturn(Optional.of(participant));
+        when(battleParticipantRepository.save(any())).thenReturn(participant);
+    }
+
+    private BattleRoom waitingRoom() {
+        Problem problem = mock(Problem.class);
+        when(problem.getId()).thenReturn(100L);
+        return BattleRoom.create(problem, 4);
+    }
+
+    private BattleRoom playingRoom() {
+        BattleRoom room = waitingRoom();
+        room.startBattle(java.time.Duration.ofMinutes(30));
+        return room;
+    }
+
+    private Member member() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(MEMBER_ID);
+        when(member.getNickname()).thenReturn("user");
+        return member;
+    }
+
+    private <T> T withAfterCommit(Supplier<T> action) {
+        try (MockedStatic<TransactionSynchronizationManager> tsm =
+                mockStatic(TransactionSynchronizationManager.class)) {
+            tsm.when(() -> TransactionSynchronizationManager.registerSynchronization(any()))
+                    .thenAnswer(inv -> {
+                        inv.<TransactionSynchronization>getArgument(0).afterCommit();
+                        return null;
+                    });
+            return action.get();
+        }
+    }
+}

--- a/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceJoinRoomTest.java
+++ b/src/test/java/com/back/domain/battle/battleroom/service/BattleRoomServiceJoinRoomTest.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -26,7 +27,6 @@ import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepo
 import com.back.domain.battle.battleroom.dto.JoinRoomResponse;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.problem.entity.Problem;
@@ -49,7 +49,7 @@ class BattleRoomServiceJoinRoomTest {
     private final BattleCodeStore battleCodeStore = mock(BattleCodeStore.class);
     private final BattleReconnectStore reconnectStore = mock(BattleReconnectStore.class);
     private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
-    private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
 
     private final BattleRoomService sut = new BattleRoomService(
             battleRoomRepository,
@@ -60,7 +60,7 @@ class BattleRoomServiceJoinRoomTest {
             battleCodeStore,
             reconnectStore,
             battleTimerStore,
-            battleResultService);
+            eventPublisher);
 
     @Test
     @DisplayName("READY 참여자가 입장하면 PLAYING 상태 이벤트를 발행한다")

--- a/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
@@ -2,8 +2,12 @@ package com.back.domain.battle.result.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -12,9 +16,12 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
 import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
@@ -162,5 +169,67 @@ class BattleResultServiceTest {
 
         // then
         assertThat(response).isNull();
+    }
+
+    @Test
+    @DisplayName("정산 시 ABANDONED 참여자는 QUIT과 동일하게 감점된다")
+    void settle_abandonedParticipant_getsPenalty() {
+        BattleRoom room = mock(BattleRoom.class);
+        Problem problem = mock(Problem.class);
+        BattleParticipant participant = mock(BattleParticipant.class);
+        com.back.domain.member.member.entity.Member member = mock(com.back.domain.member.member.entity.Member.class);
+
+        when(battleRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        when(room.getProblem()).thenReturn(problem);
+        when(problem.getDifficultyRating()).thenReturn(1200);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant));
+        when(participant.getId()).thenReturn(11L);
+        when(participant.getStatus()).thenReturn(BattleParticipantStatus.ABANDONED);
+        when(participant.getMember()).thenReturn(member);
+
+        withAfterCommit(() -> battleResultService.settle(1L));
+
+        verify(participant).applyResult(1, -5L);
+        verify(member).applyScore(-5L);
+        verify(participant, never()).timeout();
+    }
+
+    @Test
+    @DisplayName("정산 시 QUIT 참여자는 감점된다")
+    void settle_quitParticipant_getsPenalty() {
+        BattleRoom room = mock(BattleRoom.class);
+        Problem problem = mock(Problem.class);
+        BattleParticipant participant = mock(BattleParticipant.class);
+        com.back.domain.member.member.entity.Member member = mock(com.back.domain.member.member.entity.Member.class);
+
+        when(battleRoomRepository.findById(2L)).thenReturn(Optional.of(room));
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        when(room.getProblem()).thenReturn(problem);
+        when(problem.getDifficultyRating()).thenReturn(1200);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant));
+        when(participant.getId()).thenReturn(22L);
+        when(participant.getStatus()).thenReturn(BattleParticipantStatus.QUIT);
+        when(participant.getMember()).thenReturn(member);
+
+        withAfterCommit(() -> battleResultService.settle(2L));
+
+        verify(participant).applyResult(1, -5L);
+        verify(member).applyScore(-5L);
+    }
+
+    private void withAfterCommit(Runnable action) {
+        try (MockedStatic<TransactionSynchronizationManager> mocked =
+                mockStatic(TransactionSynchronizationManager.class)) {
+            mocked.when(() -> TransactionSynchronizationManager.registerSynchronization(
+                            any(TransactionSynchronization.class)))
+                    .thenAnswer(invocation -> {
+                        TransactionSynchronization synchronization =
+                                invocation.getArgument(0, TransactionSynchronization.class);
+                        synchronization.afterCommit();
+                        return null;
+                    });
+            action.run();
+        }
     }
 }

--- a/src/test/java/com/back/domain/battle/result/service/BattleSettlementCoordinatorTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleSettlementCoordinatorTest.java
@@ -1,9 +1,15 @@
 package com.back.domain.battle.result.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.lang.reflect.Method;
+
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.back.domain.battle.result.event.BattleSettlementRequestedEvent;
 
@@ -17,5 +23,16 @@ class BattleSettlementCoordinatorTest {
         coordinator.onRequested(new BattleSettlementRequestedEvent(123L));
 
         verify(battleSettlementExecutor).settle(123L);
+    }
+
+    @Test
+    void onRequested_isBoundToAfterCommitPhase() throws NoSuchMethodException {
+        Method method =
+                BattleSettlementCoordinator.class.getMethod("onRequested", BattleSettlementRequestedEvent.class);
+
+        TransactionalEventListener annotation = method.getAnnotation(TransactionalEventListener.class);
+
+        assertNotNull(annotation);
+        assertEquals(TransactionPhase.AFTER_COMMIT, annotation.phase());
     }
 }

--- a/src/test/java/com/back/domain/battle/result/service/BattleSettlementCoordinatorTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleSettlementCoordinatorTest.java
@@ -1,0 +1,21 @@
+package com.back.domain.battle.result.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.battle.result.event.BattleSettlementRequestedEvent;
+
+class BattleSettlementCoordinatorTest {
+
+    private final BattleSettlementExecutor battleSettlementExecutor = mock(BattleSettlementExecutor.class);
+    private final BattleSettlementCoordinator coordinator = new BattleSettlementCoordinator(battleSettlementExecutor);
+
+    @Test
+    void onRequested_delegatesToExecutor() {
+        coordinator.onRequested(new BattleSettlementRequestedEvent(123L));
+
+        verify(battleSettlementExecutor).settle(123L);
+    }
+}

--- a/src/test/java/com/back/domain/battle/result/service/BattleSettlementExecutorTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleSettlementExecutorTest.java
@@ -1,0 +1,26 @@
+package com.back.domain.battle.result.service;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import com.back.global.websocket.BattleTimerStore;
+
+class BattleSettlementExecutorTest {
+
+    private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
+    private final BattleSettlementExecutor executor =
+            new BattleSettlementExecutor(battleResultService, battleTimerStore);
+
+    @Test
+    void settle_cancelsTimerBeforeDelegatingToBattleResultService() {
+        executor.settle(123L);
+
+        InOrder inOrder = inOrder(battleTimerStore, battleResultService);
+        inOrder.verify(battleTimerStore).cancel(123L);
+        inOrder.verify(battleResultService).settle(123L);
+    }
+}

--- a/src/test/java/com/back/global/judge/BattleAcServiceTest.java
+++ b/src/test/java/com/back/global/judge/BattleAcServiceTest.java
@@ -1,0 +1,153 @@
+package com.back.global.judge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.global.websocket.BattleTimerStore;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
+
+class BattleAcServiceTest {
+
+    private static final Long ROOM_ID = 10L;
+    private static final Long MEMBER_ID = 100L;
+
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+    private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
+    private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
+
+    private final BattleAcService battleAcService = new BattleAcService(
+            battleParticipantRepository,
+            battleRoomRepository,
+            memberRepository,
+            battleResultService,
+            battleTimerStore,
+            publisher);
+
+    @Test
+    @DisplayName("AC 처리 시 participant를 SOLVED로 저장하고 커밋 후 상태 이벤트와 완료 이벤트를 발행한다")
+    void handleAc_marksSolvedAndPublishesAfterCommit() {
+        BattleRoom room = mock(BattleRoom.class);
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(MEMBER_ID);
+
+        BattleParticipant participant = BattleParticipant.create(room, member);
+        participant.join();
+
+        BattleParticipant solvedOther = mock(BattleParticipant.class);
+        when(solvedOther.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+
+        when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+        when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
+                .thenReturn(Optional.of(participant));
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, solvedOther));
+
+        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));
+
+        assertThat(participant.getStatus()).isEqualTo(BattleParticipantStatus.SOLVED);
+        verify(battleParticipantRepository).save(participant);
+        verify(publisher, times(2)).publish(eq("/topic/room/" + ROOM_ID), any());
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(Map.of(
+                                "type",
+                                "PARTICIPANT_STATUS_CHANGED",
+                                "userId",
+                                MEMBER_ID,
+                                "status",
+                                BattleParticipantStatus.SOLVED.name())));
+        verify(publisher)
+                .publish(
+                        eq("/topic/room/" + ROOM_ID),
+                        eq(Map.of("type", "PARTICIPANT_DONE", "userId", MEMBER_ID, "rank", 2L)));
+    }
+
+    @Test
+    @DisplayName("전원이 SOLVED면 타이머를 취소하고 정산을 호출한다")
+    void handleAc_allFinished_cancelsTimerAndSettles() {
+        BattleRoom room = mock(BattleRoom.class);
+        Member member = mock(Member.class);
+
+        BattleParticipant participant = BattleParticipant.create(room, member);
+        participant.join();
+
+        BattleParticipant solvedOther = mock(BattleParticipant.class);
+        when(solvedOther.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+
+        when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+        when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
+                .thenReturn(Optional.of(participant));
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, solvedOther));
+
+        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));
+
+        verify(battleTimerStore).cancel(ROOM_ID);
+        verify(battleResultService).settle(ROOM_ID);
+    }
+
+    @Test
+    @DisplayName("미완료 참가자가 남아있으면 정산하지 않는다")
+    void handleAc_notAllFinished_doesNotSettle() {
+        BattleRoom room = mock(BattleRoom.class);
+        Member member = mock(Member.class);
+
+        BattleParticipant participant = BattleParticipant.create(room, member);
+        participant.join();
+
+        BattleParticipant playingOther = mock(BattleParticipant.class);
+        when(playingOther.getStatus()).thenReturn(BattleParticipantStatus.PLAYING);
+
+        when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+        when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
+                .thenReturn(Optional.of(participant));
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, playingOther));
+
+        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));
+
+        verify(battleResultService, never()).settle(any());
+        verify(battleTimerStore, never()).cancel(any());
+    }
+
+    private void withAfterCommit(Runnable action) {
+        try (MockedStatic<TransactionSynchronizationManager> tsm =
+                mockStatic(TransactionSynchronizationManager.class)) {
+            tsm.when(() -> TransactionSynchronizationManager.registerSynchronization(any()))
+                    .thenAnswer(inv -> {
+                        inv.<TransactionSynchronization>getArgument(0).afterCommit();
+                        return null;
+                    });
+            action.run();
+        }
+    }
+}

--- a/src/test/java/com/back/global/judge/BattleAcServiceTest.java
+++ b/src/test/java/com/back/global/judge/BattleAcServiceTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -25,10 +26,9 @@ import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
 import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.battle.result.event.BattleSettlementRequestedEvent;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
-import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 class BattleAcServiceTest {
@@ -39,17 +39,11 @@ class BattleAcServiceTest {
     private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
     private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
     private final MemberRepository memberRepository = mock(MemberRepository.class);
-    private final BattleResultService battleResultService = mock(BattleResultService.class);
-    private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
     private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
+    private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
 
     private final BattleAcService battleAcService = new BattleAcService(
-            battleParticipantRepository,
-            battleRoomRepository,
-            memberRepository,
-            battleResultService,
-            battleTimerStore,
-            publisher);
+            battleParticipantRepository, battleRoomRepository, memberRepository, publisher, eventPublisher);
 
     @Test
     @DisplayName("AC 처리 시 participant를 SOLVED로 저장하고 커밋 후 상태 이벤트와 완료 이벤트를 발행한다")
@@ -92,59 +86,57 @@ class BattleAcServiceTest {
     }
 
     @Test
-    @DisplayName("전원이 SOLVED면 타이머를 취소하고 정산을 호출한다")
-    void handleAc_allFinished_cancelsTimerAndSettles() {
+    @DisplayName("활성 참가자가 없으면 정산 요청 이벤트를 발행한다")
+    void handleAc_noActiveLeft_publishesSettlementRequestedEvent() {
         BattleRoom room = mock(BattleRoom.class);
         Member member = mock(Member.class);
 
         BattleParticipant participant = BattleParticipant.create(room, member);
         participant.join();
 
-        BattleParticipant solvedOther = mock(BattleParticipant.class);
-        when(solvedOther.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        BattleParticipant quitOther = mock(BattleParticipant.class);
+        when(quitOther.getStatus()).thenReturn(BattleParticipantStatus.QUIT);
 
         when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
         when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
         when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
                 .thenReturn(Optional.of(participant));
-        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, solvedOther));
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, quitOther));
 
         withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));
 
-        verify(battleTimerStore).cancel(ROOM_ID);
-        verify(battleResultService).settle(ROOM_ID);
+        verify(eventPublisher).publishEvent(new BattleSettlementRequestedEvent(ROOM_ID));
     }
 
     @Test
-    @DisplayName("미완료 참가자가 남아있으면 정산하지 않는다")
-    void handleAc_notAllFinished_doesNotSettle() {
+    @DisplayName("ABANDONED 참여자가 남아있으면 정산 요청 이벤트를 발행하지 않는다")
+    void handleAc_abandonedParticipantRemains_doesNotPublishSettlementRequestedEvent() {
         BattleRoom room = mock(BattleRoom.class);
         Member member = mock(Member.class);
 
         BattleParticipant participant = BattleParticipant.create(room, member);
         participant.join();
 
-        BattleParticipant playingOther = mock(BattleParticipant.class);
-        when(playingOther.getStatus()).thenReturn(BattleParticipantStatus.PLAYING);
+        BattleParticipant abandonedOther = mock(BattleParticipant.class);
+        when(abandonedOther.getStatus()).thenReturn(BattleParticipantStatus.ABANDONED);
 
         when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
         when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
         when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
                 .thenReturn(Optional.of(participant));
-        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, playingOther));
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, abandonedOther));
 
         withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));
 
-        verify(battleResultService, never()).settle(any());
-        verify(battleTimerStore, never()).cancel(any());
+        verify(eventPublisher, never()).publishEvent(any(BattleSettlementRequestedEvent.class));
     }
 
     private void withAfterCommit(Runnable action) {
         try (MockedStatic<TransactionSynchronizationManager> tsm =
                 mockStatic(TransactionSynchronizationManager.class)) {
             tsm.when(() -> TransactionSynchronizationManager.registerSynchronization(any()))
-                    .thenAnswer(inv -> {
-                        inv.<TransactionSynchronization>getArgument(0).afterCommit();
+                    .thenAnswer(invocation -> {
+                        invocation.<TransactionSynchronization>getArgument(0).afterCommit();
                         return null;
                     });
             action.run();

--- a/src/test/java/com/back/global/judge/JudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/JudgeServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -17,14 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
-import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
-import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
 import com.back.domain.battle.battleroom.entity.BattleRoom;
-import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
-import com.back.domain.battle.result.service.BattleResultService;
-import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.problem.submission.entity.Submission;
 import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
@@ -32,48 +24,28 @@ import com.back.domain.problem.testcase.entity.TestCase;
 import com.back.global.judge.dto.Judge0SubmitResponse;
 import com.back.global.judge.dto.Judge0SubmitResponse.Status;
 import com.back.global.judge.event.JudgeRequestedEvent;
-import com.back.global.websocket.BattleTimerStore;
 import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 class JudgeServiceTest {
-
-    private final Judge0ExecutionService judge0ExecutionService = mock(Judge0ExecutionService.class);
-    private final SubmissionRepository submissionRepository = mock(SubmissionRepository.class);
-    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
-    private final BattleRoomRepository battleRoomRepository = mock(BattleRoomRepository.class);
-    private final MemberRepository memberRepository = mock(MemberRepository.class);
-    private final BattleResultService battleResultService = mock(BattleResultService.class);
-    private final BattleTimerStore battleTimerStore = mock(BattleTimerStore.class);
-    private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
-
-    private final JudgeService judgeService = new JudgeService(
-            judge0ExecutionService,
-            submissionRepository,
-            battleParticipantRepository,
-            battleRoomRepository,
-            memberRepository,
-            battleResultService,
-            battleTimerStore,
-            publisher);
 
     private static final Long SUBMISSION_ID = 1L;
     private static final Long ROOM_ID = 10L;
     private static final Long MEMBER_ID = 100L;
 
-    private Submission submission;
-    private BattleRoom room;
-    private Member member;
-    private BattleParticipant participant;
+    private final Judge0ExecutionService judge0ExecutionService = mock(Judge0ExecutionService.class);
+    private final SubmissionRepository submissionRepository = mock(SubmissionRepository.class);
+    private final BattleAcService battleAcService = mock(BattleAcService.class);
+    private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
 
-    // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+    private final JudgeService judgeService =
+            new JudgeService(judge0ExecutionService, submissionRepository, battleAcService, publisher);
+
+    private Submission submission;
 
     @BeforeEach
     void setUp() {
-        submission = Submission.create(mock(BattleRoom.class), mock(Member.class), "code", "python");
-        room = mock(BattleRoom.class);
-        member = mock(Member.class);
-        participant = mock(BattleParticipant.class);
-
+        submission = Submission.create(
+                mock(BattleRoom.class), mock(com.back.domain.member.member.entity.Member.class), "code", "python");
         when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
         when(judge0ExecutionService.getLanguageId("python")).thenReturn(71);
     }
@@ -93,30 +65,15 @@ class JudgeServiceTest {
         when(judge0ExecutionService.execute(any())).thenReturn(List.of(responses));
     }
 
-    /** AC 흐름에서 필요한 handleAc() 관련 Mock 설정 */
-    private void stubHandleAc(List<BattleParticipant> allParticipants) {
-        when(battleRoomRepository.findById(ROOM_ID)).thenReturn(Optional.of(room));
-        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-        when(battleParticipantRepository.findByBattleRoomAndMember(room, member))
-                .thenReturn(Optional.of(participant));
-        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(allParticipants);
-    }
-
     private JudgeRequestedEvent event(List<TestCase> testCases) {
         return new JudgeRequestedEvent(SUBMISSION_ID, ROOM_ID, MEMBER_ID, "code", "python", testCases);
     }
-
-    // ── 채점 결과 저장 ─────────────────────────────────────────────────────────
 
     @Test
     @DisplayName("전체 통과 시 submission result가 AC로 저장된다")
     void judge_allPass_savedAsAc() {
         TestCase tc = mockTestCase("1 2", "3");
         stubJudge0(response(3, "3\n"));
-
-        BattleParticipant exitParticipant = mock(BattleParticipant.class);
-        when(exitParticipant.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
-        stubHandleAc(List.of(exitParticipant));
 
         judgeService.onJudgeRequested(event(List.of(tc)));
 
@@ -185,10 +142,10 @@ class JudgeServiceTest {
     }
 
     @Test
-    @DisplayName("Judge0 타임아웃 시 submission result가 JUDGE_ERROR로 저장된다")
+    @DisplayName("Judge0 응답이 비어있으면 submission result가 JUDGE_ERROR로 저장된다")
     void judge_judge0Timeout_savedAsJudgeError() {
         TestCase tc = mockTestCase("1 2", "3");
-        when(judge0ExecutionService.execute(any())).thenReturn(List.of()); // 타임아웃 → 빈 리스트
+        when(judge0ExecutionService.execute(any())).thenReturn(List.of());
 
         judgeService.onJudgeRequested(event(List.of(tc)));
 
@@ -196,84 +153,40 @@ class JudgeServiceTest {
         verify(submissionRepository).save(submission);
     }
 
-    // ── AC 처리 (handleAc) ────────────────────────────────────────────────────
+    @Test
+    @DisplayName("AC가 아니면 AC 후속 처리 서비스를 호출하지 않는다")
+    void judge_notAc_doesNotCallBattleAcService() {
+        TestCase tc = mockTestCase("1 2", "3");
+        stubJudge0(response(4, "5\n"));
+
+        judgeService.onJudgeRequested(event(List.of(tc)));
+
+        verify(battleAcService, never()).handleAc(any(), any());
+    }
 
     @Test
-    @DisplayName("AC이면 participant가 complete() 처리되고 저장된다")
-    void judge_ac_participantCompleted() {
+    @DisplayName("AC면 AC 후속 처리 서비스를 호출한다")
+    void judge_ac_callsBattleAcService() {
         TestCase tc = mockTestCase("1 2", "3");
         stubJudge0(response(3, "3\n"));
 
-        BattleParticipant exitParticipant = mock(BattleParticipant.class);
-        when(exitParticipant.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
-        stubHandleAc(List.of(exitParticipant));
-
         judgeService.onJudgeRequested(event(List.of(tc)));
 
-        verify(participant).complete(any());
-        verify(battleParticipantRepository).save(participant);
+        verify(battleAcService).handleAc(ROOM_ID, MEMBER_ID);
     }
 
     @Test
-    @DisplayName("AC가 아니면 participant 상태 변경이 없다")
-    void judge_notAc_participantNotChanged() {
-        TestCase tc = mockTestCase("1 2", "3");
-        stubJudge0(response(4, "5\n")); // WA
-
-        judgeService.onJudgeRequested(event(List.of(tc)));
-
-        verify(battleParticipantRepository, never()).save(any());
-        verify(battleResultService, never()).settle(any());
-    }
-
-    @Test
-    @DisplayName("AC이고 전원 완료 시 배틀 정산이 호출된다")
-    void judge_ac_allFinished_settlesCalled() {
-        TestCase tc = mockTestCase("1 2", "3");
-        stubJudge0(response(3, "3\n"));
-
-        BattleParticipant p1 = mock(BattleParticipant.class);
-        BattleParticipant p2 = mock(BattleParticipant.class);
-        when(p1.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
-        when(p2.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
-        stubHandleAc(List.of(p1, p2));
-
-        judgeService.onJudgeRequested(event(List.of(tc)));
-
-        verify(battleResultService).settle(ROOM_ID);
-    }
-
-    @Test
-    @DisplayName("AC이지만 아직 남은 참여자가 있으면 배틀 정산이 호출되지 않는다")
-    void judge_ac_notAllFinished_settlesNotCalled() {
-        TestCase tc = mockTestCase("1 2", "3");
-        stubJudge0(response(3, "3\n"));
-
-        BattleParticipant p1 = mock(BattleParticipant.class);
-        BattleParticipant p2 = mock(BattleParticipant.class);
-        when(p1.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
-        when(p2.getStatus()).thenReturn(BattleParticipantStatus.PLAYING);
-        stubHandleAc(List.of(p1, p2));
-
-        judgeService.onJudgeRequested(event(List.of(tc)));
-
-        verify(battleResultService, never()).settle(any());
-    }
-
-    // ── WebSocket 브로드캐스트 ─────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("채점 완료 후 SUBMISSION 타입으로 WebSocket 브로드캐스트된다")
+    @DisplayName("채점 완료 후 SUBMISSION 타입으로 WebSocket 브로드캐스트한다")
     void judge_broadcastsSubmissionResult() {
         TestCase tc = mockTestCase("1 2", "3");
-        stubJudge0(response(4, "5\n")); // WA
+        stubJudge0(response(4, "5\n"));
 
         judgeService.onJudgeRequested(event(List.of(tc)));
 
-        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<java.util.Map<String, Object>> captor = ArgumentCaptor.forClass(java.util.Map.class);
         verify(publisher).publish(eq("/topic/room/" + ROOM_ID), captor.capture());
 
-        Map<String, Object> message = captor.getValue();
+        java.util.Map<String, Object> message = captor.getValue();
         assertThat(message.get("type")).isEqualTo("SUBMISSION");
         assertThat(message.get("userId")).isEqualTo(MEMBER_ID);
         assertThat(message.get("result")).isEqualTo("WA");

--- a/src/test/java/com/back/global/websocket/BattleDisconnectHandlerTest.java
+++ b/src/test/java/com/back/global/websocket/BattleDisconnectHandlerTest.java
@@ -2,16 +2,21 @@ package com.back.global.websocket;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
@@ -20,14 +25,16 @@ import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepo
 import com.back.domain.battle.battleroom.entity.BattleRoom;
 import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.global.security.SecurityUser;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 class BattleDisconnectHandlerTest {
 
     private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
     private final BattleReconnectStore reconnectStore = mock(BattleReconnectStore.class);
+    private final WebSocketMessagePublisher publisher = mock(WebSocketMessagePublisher.class);
 
     private final BattleDisconnectHandler sut =
-            new BattleDisconnectHandler(battleParticipantRepository, reconnectStore);
+            new BattleDisconnectHandler(battleParticipantRepository, reconnectStore, publisher);
 
     private static final Long MEMBER_ID = 10L;
     private static final Long ROOM_ID = 1L;
@@ -48,12 +55,22 @@ class BattleDisconnectHandlerTest {
                         MEMBER_ID, BattleParticipantStatus.PLAYING, BattleRoomStatus.PLAYING))
                 .thenReturn(Optional.of(participant));
 
-        sut.handleDisconnect(event);
+        withAfterCommit(() -> sut.handleDisconnect(event));
 
         com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus status = participant.getStatus();
         org.assertj.core.api.Assertions.assertThat(status).isEqualTo(BattleParticipantStatus.ABANDONED);
         verify(reconnectStore).startGracePeriod(MEMBER_ID);
         verify(battleParticipantRepository).save(participant);
+        verify(publisher)
+                .publish(
+                        "/topic/room/" + ROOM_ID,
+                        Map.of(
+                                "type",
+                                "PARTICIPANT_STATUS_CHANGED",
+                                "userId",
+                                MEMBER_ID,
+                                "status",
+                                BattleParticipantStatus.ABANDONED.name()));
     }
 
     @Test
@@ -63,7 +80,7 @@ class BattleDisconnectHandlerTest {
         when(event.getUser()).thenReturn(null);
         when(event.getSessionId()).thenReturn("unauthenticated-session");
 
-        sut.handleDisconnect(event);
+        withAfterCommit(() -> sut.handleDisconnect(event));
 
         verify(battleParticipantRepository, never()).findPlayingParticipantByMemberId(any(), any(), any());
         verify(reconnectStore, never()).startGracePeriod(any());
@@ -96,5 +113,17 @@ class BattleDisconnectHandlerTest {
         SessionDisconnectEvent event = mock(SessionDisconnectEvent.class);
         when(event.getUser()).thenReturn(auth);
         return event;
+    }
+
+    private void withAfterCommit(Runnable action) {
+        try (MockedStatic<TransactionSynchronizationManager> tsm =
+                mockStatic(TransactionSynchronizationManager.class)) {
+            tsm.when(() -> TransactionSynchronizationManager.registerSynchronization(any()))
+                    .thenAnswer(inv -> {
+                        inv.<TransactionSynchronization>getArgument(0).afterCommit();
+                        return null;
+                    });
+            action.run();
+        }
     }
 }


### PR DESCRIPTION
# 리팩토링

**정리본**

1. `JudgeService`의 AC 처리 분리
- `handleAc()`를 `BattleAcService.java` 로 분리
- 이유:
    - `JudgeService.onJudgeRequested()`의 `@TransactionalEventListener(AFTER_COMMIT)`는 “원래 제출 이벤트 트랜잭션” 기준 after commit
    - 그런데 AC 처리 안에서도 participant 상태 저장 후 **그 저장의 커밋 기준 after commit**이 필요했음
    - 그래서 별도 `@Transactional` 서비스로 분리하고, 그 안에서 다시 `afterCommit`으로 WS 발행
1. `PARTICIPANT_STATUS_CHANGED` 추가
- 방 참가자 상태 공유용 공통 WS 이벤트 추가
- 참가자 화면과 관전자 화면이 같은 이벤트를 사용 가능
- 현재 상태 변화에 사용:
    - `PLAYING`
    - `ABANDONED`
    - `SOLVED`
    - `TIMEOUT`
    - `QUIT`
- `READY`는 방 생성 시 초기 상태라서 REST 응답으로만 전달
1. 점수 체계 조정
    - `SOLVED` 1/2/3등 점수는 기존 유지
    - `ABANDONED`, `QUIT`은 정산 시 `LAST_PLACE_PENALTY(-5)` 적용
    - 즉 “중도 이탈/복귀 실패”가 더 이상 무패널티처럼 남지 않음
2. `exitRoom()`과 grace period 이벤트 역할 분리
    - `exitRoom()`:
        - `PARTICIPANT_STATUS_CHANGED(status=QUIT)`만 발행
    - `GracePeriodConsumer`:
        - 그대로 `PARTICIPANT_LEFT` 사용
    - 의미 분리:
        - `PARTICIPANT_STATUS_CHANGED` = 상태 공유
        - `PARTICIPANT_LEFT` = grace period 만료 후 복귀 실패 알림

**추가로 같이 적어두면 좋은 포인트**

1. `afterCommit` 기준 정리
    - `joinRoom`, `exitRoom`, `BattleDisconnectHandler`, `BattleAcService`, `settle()` 쪽 상태/결과 WS는 가능한 한 커밋 후 발행으로 맞춤
    - 목적:
        - DB 반영과 WS 알림 불일치 줄이기
2. `BattleDisconnectHandler` 보강
    - disconnect 시 `ABANDONED` publish도 `afterCommit`
    - `startGracePeriod()`도 같은 `afterCommit`으로 이동
    - 즉:
        - DB에 `ABANDONED` 커밋 성공
        - 그 다음 상태 이벤트 발행 + grace 시작

**요약**

- `JudgeService`의 AC 후속 처리를 `BattleAcService`로 분리해, participant 상태 저장 트랜잭션 기준으로 `afterCommit` 이벤트를 보낼 수 있게 했다.
- `PARTICIPANT_STATUS_CHANGED` 이벤트를 추가해 방 참가자 상태(`PLAYING`, `ABANDONED`, `SOLVED`, `TIMEOUT`, `QUIT`)를 참가자/관전자에게 공통으로 전달하도록 했다.
- 정산 시 `ABANDONED`, `QUIT` 참가자는 `LAST_PLACE_PENALTY(-5)`를 받도록 점수 체계를 조정했다.
- `exitRoom()`은 `PARTICIPANT_STATUS_CHANGED(QUIT)`만 사용하고, `PARTICIPANT_LEFT`는 `GracePeriodConsumer`의 grace period 만료 알림 전용으로 역할을 분리했다.
- 주요 WebSocket 발행은 커밋 이후(`afterCommit`)에 실행되도록 정리해 DB 상태와 이벤트의 일관성을 높였다.

---

# battleroom의 participants 상태 실시간 동기화

**문제**

- `exitRoom()`에서 마지막 활성 참가자가 나가면 정산이 트리거되어야 했음
- 프론트상으로는 방 종료 흐름이 보였지만 DB의 `battle_rooms.status`는 `PLAYING`에서 `FINISHED`로 바뀌지 않았음

**원인**
초기 구조에서 `exitRoom()`은 트랜잭션 `afterCommit()` 안에서 직접 `battleResultService.settle(roomId)`를 호출하고 있었음.

이 구조를 이벤트 기반으로 바꾼 뒤에도 핵심 문제는 남아 있었는데,
정산 실행이 다음 흐름에서 일어났기 때문이다.

1. `exitRoom()` 트랜잭션 커밋
2. `@TransactionalEventListener(AFTER_COMMIT)`에서 정산 요청 수신
3. `BattleSettlementExecutor.settle()` 호출
4. 내부에서 `BattleResultService.settle()` 실행

겉보기엔 맞아 보였지만, 실제로는 이 실행기가 **새 JPA 트랜잭션을 확실히 열지 못한 상태**로 동작하고 있었다.

그 결과:

- `room.finish()`는 메모리상으론 `FINISHED`
- 하지만 실제 flush/commit 시점엔
    - `TransactionRequiredException: no transaction is in progress`
- 그래서 DB에는 반영되지 않고 `PLAYING`이 유지됨

**디버깅 과정에서 확인한 점**
로그로 다음을 확인했다.

- `BattleSettlementRequestedEvent`는 정상 발행됨
- `BattleSettlementCoordinator`도 정상 수신함
- `BattleSettlementExecutor`도 호출됨
- `BattleResultService.settle()`도 진입함
- 문제는 `settle()` 내부 DB 반영 시점에 트랜잭션이 없다는 점이었음

즉 문제는:

- 종료 조건 계산 문제도 아니고
- 이벤트 발행 누락도 아니고
- 정산 로직 자체가 안 타는 것도 아니고
- **정산 실행 시 트랜잭션 경계가 잘못된 것**이었다

**해결**
해결은 정산 실행기인 `BattleSettlementExecutor.java` 에서

```java
@Transactional(propagation = Propagation.REQUIRES_NEW)
```

를 적용한 것.

즉:

- `AFTER_COMMIT` 리스너가 정산 요청을 받으면
- `BattleSettlementExecutor`가 **항상 새 트랜잭션으로 정산을 시작**
- 그 안에서 `BattleResultService.settle()`가 실행되도록 보장

이후에는:

- `room.finish()`가 실제 DB에 반영되고
- `battle_rooms.status`가 `FINISHED`로 정상 변경됨

**함께 정리한 것**
원인 확인용으로 넣었던

- `EntityManager.flush()`
- 상세 디버그 로그
는 문제 원인 확인 후 제거해서 코드도 다시 깔끔하게 정리했다.

**최종 한 줄 요약**
원인은 **커밋 후 이벤트에서 실행된 정산 로직이 새 트랜잭션 없이 실행되어 DB 반영이 안 된 것**이고,

해결은 **정산 실행기 `BattleSettlementExecutor`를 `REQUIRES_NEW` 트랜잭션으로 분리해 `settle()`가 항상 독립 트랜잭션에서 커밋되도록 만든 것**이다.