### PR TITLE
[feat] 랭킹 대시보드 battleRating 기준 통일 및 응답 필드 보강

### DIFF
--- a/src/main/java/com/back/domain/ranking/dashboard/controller/RankingDashboardController.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/controller/RankingDashboardController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/rankings")
+// 로그인 사용자의 메인 홈 대시보드를 조회한다.
 public class RankingDashboardController {
 
     private final RankingDashboardService rankingDashboardService;

--- a/src/main/java/com/back/domain/ranking/dashboard/dto/RankingDashboardResponse.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/dto/RankingDashboardResponse.java
@@ -3,6 +3,7 @@ package com.back.domain.ranking.dashboard.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+// 메인 홈 랭킹 대시보드 응답 DTO다.
 public record RankingDashboardResponse(
         Profile profile,
         List<ScoreTrendPoint> scoreTrend,
@@ -19,9 +20,11 @@ public record RankingDashboardResponse(
             long rank,
             double percentile,
             long score,
+            long battleRating,
             String nextTier,
             long battleMatchCount,
             int top2Rate,
+            int top2SampleSize,
             long scoreDeltaTotal) {}
 
     public record ScoreTrendPoint(String label, LocalDateTime occurredAt, long score, long delta) {}

--- a/src/main/java/com/back/domain/ranking/dashboard/repository/RankingDashboardQueryRepository.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/repository/RankingDashboardQueryRepository.java
@@ -20,7 +20,9 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
+// 메인 홈 대시보드에 필요한 랭킹/배틀 집계 전용 조회를 모아둔다.
 public class RankingDashboardQueryRepository {
+    private static final long DEFAULT_BATTLE_RATING = 1000L;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -30,48 +32,51 @@ public class RankingDashboardQueryRepository {
                     select
                         m.id as member_id,
                         m.nickname,
-                        m.tier,
+                        mrp.tier,
                         coalesce(m.score, 0) as score,
-                        row_number() over (order by coalesce(m.score, 0) desc, m.id asc) as rank_no,
+                        coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating,
+                        row_number() over (order by coalesce(mrp.battle_rating, :defaultBattleRating) desc, m.id asc) as rank_no,
                         count(*) over () as total_count
                     from members m
+                    left join member_rating_profiles mrp on mrp.member_id = m.id
                 )
-                select member_id, nickname, tier, score, rank_no, total_count
+                select member_id, nickname, tier, score, battle_rating, rank_no, total_count
                 from ranked
                 where member_id = :memberId
                 """;
 
         return queryForOptional(
                 sql,
-                Map.of("memberId", memberId),
+                Map.of("memberId", memberId, "defaultBattleRating", DEFAULT_BATTLE_RATING),
                 (rs, rowNum) -> new MemberRankRow(
                         rs.getLong("member_id"),
                         rs.getString("nickname"),
                         rs.getString("tier"),
                         getLong(rs, "score"),
+                        getLong(rs, "battle_rating"),
                         getLong(rs, "rank_no"),
                         getLong(rs, "total_count")));
     }
 
     public BattleSummary findBattleSummary(Long memberId, int top2WindowSize) {
+        // 전체 완료 배틀 수는 누적 기준으로 유지한다.
         String summarySql = """
                 select
-                    count(*) as battle_match_count,
-                    coalesce(sum(bp.score_delta), 0) as score_delta_total
+                    count(*) as battle_match_count
                 from battle_participants bp
                 join battle_rooms br on br.id = bp.room_id
                 where bp.user_id = :memberId
                   and upper(br.status) = 'FINISHED'
                 """;
 
-        BattleSummary totalSummary = jdbcTemplate.queryForObject(
-                summarySql,
-                Map.of("memberId", memberId),
-                (rs, rowNum) ->
-                        new BattleSummary(getLong(rs, "battle_match_count"), 0, getLong(rs, "score_delta_total")));
+        Long battleMatchCount = jdbcTemplate.queryForObject(
+                summarySql, Map.of("memberId", memberId), (rs, rowNum) -> getLong(rs, "battle_match_count"));
 
-        String recentRanksSql = """
-                select bp.final_rank
+        // Top2 비율과 최근 변동 합계는 최근 완료 배틀 최대 20판 기준으로 계산한다.
+        String recentBattleWindowSql = """
+                select
+                    bp.final_rank,
+                    coalesce(bp.score_delta, 0) as score_delta
                 from battle_participants bp
                 join battle_rooms br on br.id = bp.room_id
                 where bp.user_id = :memberId
@@ -84,11 +89,18 @@ public class RankingDashboardQueryRepository {
 
         SqlParameterSource params =
                 new MapSqlParameterSource().addValue("memberId", memberId).addValue("limit", top2WindowSize);
-        List<Integer> recentRanks =
-                jdbcTemplate.query(recentRanksSql, params, (rs, rowNum) -> getInt(rs, "final_rank"));
-        int top2Rate = calculateTop2Rate(recentRanks);
+        List<RecentBattleWindowRow> recentBattleWindow = jdbcTemplate.query(
+                recentBattleWindowSql,
+                params,
+                (rs, rowNum) -> new RecentBattleWindowRow(getInt(rs, "final_rank"), getLong(rs, "score_delta")));
+        int top2Rate = calculateTop2Rate(recentBattleWindow);
+        int top2SampleSize = recentBattleWindow.size();
+        long recentScoreDeltaTotal = recentBattleWindow.stream()
+                .mapToLong(RecentBattleWindowRow::scoreDelta)
+                .sum();
 
-        return new BattleSummary(totalSummary.battleMatchCount(), top2Rate, totalSummary.scoreDeltaTotal());
+        return new BattleSummary(
+                battleMatchCount == null ? 0L : battleMatchCount, top2Rate, top2SampleSize, recentScoreDeltaTotal);
     }
 
     public List<BattleTrendRow> findRecentBattleTrends(Long memberId, int limit) {
@@ -137,25 +149,30 @@ public class RankingDashboardQueryRepository {
                     select
                         m.id as member_id,
                         m.nickname,
-                        m.tier,
-                        coalesce(m.score, 0) as score,
-                        row_number() over (order by coalesce(m.score, 0) desc, m.id asc) as rank_no
+                        mrp.tier,
+                        coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating,
+                        row_number() over (
+                            order by coalesce(mrp.battle_rating, :defaultBattleRating) desc, m.id asc
+                        ) as rank_no
                     from members m
+                    left join member_rating_profiles mrp on mrp.member_id = m.id
                 ),
                 me as (
                     select rank_no
                     from ranked
                     where member_id = :memberId
                 )
-                select r.rank_no, r.member_id, r.nickname, r.tier, r.score
+                select r.rank_no, r.member_id, r.nickname, r.tier, r.battle_rating
                 from ranked r
                 cross join me
                 where r.rank_no between me.rank_no - :radius and me.rank_no + :radius
                 order by r.rank_no asc
                 """;
 
-        SqlParameterSource params =
-                new MapSqlParameterSource().addValue("memberId", memberId).addValue("radius", radius);
+        SqlParameterSource params = new MapSqlParameterSource()
+                .addValue("memberId", memberId)
+                .addValue("radius", radius)
+                .addValue("defaultBattleRating", DEFAULT_BATTLE_RATING);
         return jdbcTemplate.query(
                 sql,
                 params,
@@ -164,12 +181,21 @@ public class RankingDashboardQueryRepository {
                         rs.getLong("member_id"),
                         rs.getString("nickname"),
                         rs.getString("tier"),
-                        getLong(rs, "score")));
+                        getLong(rs, "battle_rating")));
     }
 
     public List<TierSourceRow> findTierSources() {
-        String sql = "select tier, coalesce(score, 0) as score from members";
-        return jdbcTemplate.query(sql, (rs, rowNum) -> new TierSourceRow(rs.getString("tier"), getLong(rs, "score")));
+        String sql = """
+                select
+                    mrp.tier,
+                    coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating
+                from members m
+                left join member_rating_profiles mrp on mrp.member_id = m.id
+                """;
+        return jdbcTemplate.query(
+                sql,
+                Map.of("defaultBattleRating", DEFAULT_BATTLE_RATING),
+                (rs, rowNum) -> new TierSourceRow(rs.getString("tier"), getLong(rs, "battle_rating")));
     }
 
     public List<RankingDashboardResponse.TagStat> findTagStats(Long memberId) {
@@ -222,14 +248,17 @@ public class RankingDashboardQueryRepository {
         return jdbcTemplate.query(sql, params, rowMapper).stream().findFirst();
     }
 
-    private int calculateTop2Rate(List<Integer> recentRanks) {
-        if (recentRanks == null || recentRanks.isEmpty()) {
+    // 최근 표본에서 final_rank <= 2 인 비율을 퍼센트로 환산한다.
+    private int calculateTop2Rate(List<RecentBattleWindowRow> recentBattleWindow) {
+        if (recentBattleWindow == null || recentBattleWindow.isEmpty()) {
             return 0;
         }
 
-        long top2Count =
-                recentRanks.stream().filter(rank -> rank != null && rank <= 2).count();
-        return (int) Math.round((double) top2Count * 100.0d / recentRanks.size());
+        long top2Count = recentBattleWindow.stream()
+                .map(RecentBattleWindowRow::finalRank)
+                .filter(rank -> rank != null && rank <= 2)
+                .count();
+        return (int) Math.round((double) top2Count * 100.0d / recentBattleWindow.size());
     }
 
     private static long getLong(ResultSet rs, String column) throws SQLException {
@@ -247,13 +276,16 @@ public class RankingDashboardQueryRepository {
         return value == null ? null : value.toLocalDateTime();
     }
 
-    public record MemberRankRow(Long memberId, String nickname, String tier, long score, long rank, long totalCount) {}
+    public record MemberRankRow(
+            Long memberId, String nickname, String tier, long score, long battleRating, long rank, long totalCount) {}
 
-    public record BattleSummary(long battleMatchCount, int top2Rate, long scoreDeltaTotal) {}
+    public record BattleSummary(long battleMatchCount, int top2Rate, int top2SampleSize, long scoreDeltaTotal) {}
 
     public record BattleTrendRow(LocalDateTime occurredAt, long delta) {}
 
-    public record NearbyRankingRow(long rank, Long memberId, String nickname, String tier, long score) {}
+    public record NearbyRankingRow(long rank, Long memberId, String nickname, String tier, long battleRating) {}
 
-    public record TierSourceRow(String tier, long score) {}
+    public record TierSourceRow(String tier, long battleRating) {}
+
+    private record RecentBattleWindowRow(Integer finalRank, long scoreDelta) {}
 }

--- a/src/main/java/com/back/domain/ranking/dashboard/service/RankingDashboardService.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/service/RankingDashboardService.java
@@ -26,12 +26,14 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+// 메인 홈 대시보드 응답을 조립하고 화면용 계산값을 보정한다.
 public class RankingDashboardService {
 
     private static final int TREND_LIMIT = 7;
     private static final int TOP2_WINDOW_SIZE = 20;
     private static final int NEARBY_RANKING_RADIUS = 2;
 
+    // 대시보드에서 쓰는 티어 컷 기준이다.
     private static final List<TierCut> TIER_CUTS = List.of(
             new TierCut("BRONZE_5", 900),
             new TierCut("BRONZE_4", 1060),
@@ -77,7 +79,8 @@ public class RankingDashboardService {
                 .orElseThrow(() -> new ServiceException("MEMBER_404", "Member not found."));
 
         LocalDateTime now = LocalDateTime.now();
-        String currentTier = displayTier(member.tier(), member.score());
+        long battleRating = member.battleRating();
+        String currentTier = displayTier(member.tier(), battleRating);
         String nextTier = resolveNextTier(currentTier);
         BattleSummary battleSummary = queryRepository.findBattleSummary(memberId, TOP2_WINDOW_SIZE);
 
@@ -88,15 +91,17 @@ public class RankingDashboardService {
                 member.rank(),
                 calculatePercentile(member.rank(), member.totalCount()),
                 member.score(),
+                battleRating,
                 nextTier,
                 battleSummary.battleMatchCount(),
                 battleSummary.top2Rate(),
+                battleSummary.top2SampleSize(),
                 battleSummary.scoreDeltaTotal());
 
         return new RankingDashboardResponse(
                 profile,
-                buildScoreTrend(memberId, member.score(), now),
-                buildGateProgress(memberId, member.score(), nextTier, battleSummary.top2Rate()),
+                buildScoreTrend(memberId, battleRating, now),
+                buildGateProgress(memberId, battleRating, nextTier, battleSummary.top2Rate()),
                 buildNearbyRanking(memberId),
                 buildTierDistribution(currentTier),
                 queryRepository.findTagStats(memberId),
@@ -113,6 +118,7 @@ public class RankingDashboardService {
         List<BattleTrendRow> chronologicalRows = new ArrayList<>(recentRows);
         Collections.reverse(chronologicalRows);
 
+        // 현재 배틀 레이팅에서 최근 delta를 역산해 그래프용 포인트를 재구성한다.
         long recentDeltaSum =
                 chronologicalRows.stream().mapToLong(BattleTrendRow::delta).sum();
         long runningScore = currentScore - recentDeltaSum;
@@ -135,6 +141,7 @@ public class RankingDashboardService {
             Long memberId, long currentScore, String nextTier, int top2Rate) {
         long scoreTarget = nextTier == null || "GOD".equals(nextTier) ? currentScore : resolveTierTarget(nextTier);
         List<RankingDashboardResponse.GateProgress> gates = new ArrayList<>();
+        // SCORE 게이트는 화면 라벨에 맞춰 배틀 레이팅 기준으로 내려준다.
         gates.add(new RankingDashboardResponse.GateProgress(
                 "SCORE", "\uBC30\uD2C0 \uB808\uC774\uD305", currentScore, scoreTarget, ""));
 
@@ -175,8 +182,8 @@ public class RankingDashboardService {
                         row.rank(),
                         row.memberId(),
                         row.nickname(),
-                        displayTier(row.tier(), row.score()),
-                        row.score(),
+                        displayTier(row.tier(), row.battleRating()),
+                        row.battleRating(),
                         row.memberId().equals(memberId)))
                 .toList();
     }
@@ -185,7 +192,7 @@ public class RankingDashboardService {
         List<TierSourceRow> rows = queryRepository.findTierSources();
         long totalCount = rows.size();
         Map<String, Long> tierCounts = new LinkedHashMap<>();
-        rows.forEach(row -> tierCounts.merge(displayTier(row.tier(), row.score()), 1L, Long::sum));
+        rows.forEach(row -> tierCounts.merge(displayTier(row.tier(), row.battleRating()), 1L, Long::sum));
 
         return tierCounts.entrySet().stream()
                 .sorted(Comparator.comparingInt(entry -> tierOrder(entry.getKey())))

--- a/src/test/java/com/back/domain/ranking/dashboard/controller/RankingDashboardControllerTest.java
+++ b/src/test/java/com/back/domain/ranking/dashboard/controller/RankingDashboardControllerTest.java
@@ -57,9 +57,14 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
         LocalDateTime now = LocalDateTime.now();
         Long rank1 = insertMember("rank1@example.com", "rank1", 1700, "GOLD_4");
         Long rank2 = insertMember("rank2@example.com", "rank2", 1600, "GOLD_5");
-        Long me = insertMember("me@example.com", "me", 1580, "SILVER_1");
-        Long rank4 = insertMember("rank4@example.com", "rank4", 1400, "SILVER_4");
-        Long rank5 = insertMember("rank5@example.com", "rank5", 1200, "BRONZE_2");
+        Long me = insertMember("me@example.com", "me", 40, "SILVER_1");
+        Long rank4 = insertMember("rank4@example.com", "rank4", 10, "SILVER_4");
+        Long rank5 = insertMember("rank5@example.com", "rank5", 3, "BRONZE_2");
+        insertMemberRatingProfile(rank1, 1700, "GOLD_4");
+        insertMemberRatingProfile(rank2, 1600, "GOLD_5");
+        insertMemberRatingProfile(me, 1580, "SILVER_1");
+        insertMemberRatingProfile(rank4, 1400, "SILVER_4");
+        insertMemberRatingProfile(rank5, 1200, "BRONZE_2");
 
         Long problem1500 = insertProblem("P1500", "DP Basic", 1500);
         Long problem2100 = insertProblem("P2100", "DP Hard", 2100);
@@ -86,10 +91,12 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.profile.tier").value("SILVER_1"))
                 .andExpect(jsonPath("$.profile.rank").value(3))
                 .andExpect(jsonPath("$.profile.percentile").value(60.0))
-                .andExpect(jsonPath("$.profile.score").value(1580))
+                .andExpect(jsonPath("$.profile.score").value(40))
+                .andExpect(jsonPath("$.profile.battleRating").value(1580))
                 .andExpect(jsonPath("$.profile.nextTier").value("GOLD_5"))
                 .andExpect(jsonPath("$.profile.battleMatchCount").value(2))
                 .andExpect(jsonPath("$.profile.top2Rate").value(50))
+                .andExpect(jsonPath("$.profile.top2SampleSize").value(2))
                 .andExpect(jsonPath("$.profile.scoreDeltaTotal").value(15))
                 .andExpect(jsonPath("$.scoreTrend", hasSize(2)))
                 .andExpect(jsonPath("$.scoreTrend[0].label").value("D-6"))
@@ -106,8 +113,11 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.gateProgress[1].target").value(12))
                 .andExpect(jsonPath("$.nearbyRanking", hasSize(5)))
                 .andExpect(jsonPath("$.nearbyRanking[0].memberId").value(rank1))
+                .andExpect(jsonPath("$.nearbyRanking[0].score").value(1700))
                 .andExpect(jsonPath("$.nearbyRanking[1].memberId").value(rank2))
+                .andExpect(jsonPath("$.nearbyRanking[1].score").value(1600))
                 .andExpect(jsonPath("$.nearbyRanking[2].memberId").value(me))
+                .andExpect(jsonPath("$.nearbyRanking[2].score").value(1580))
                 .andExpect(jsonPath("$.nearbyRanking[2].isMe").value(true))
                 .andExpect(jsonPath("$.nearbyRanking[3].memberId").value(rank4))
                 .andExpect(jsonPath("$.nearbyRanking[4].memberId").value(rank5))
@@ -134,13 +144,17 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.profile.tier").value("BRONZE_5"))
                 .andExpect(jsonPath("$.profile.rank").value(1))
                 .andExpect(jsonPath("$.profile.percentile").value(100.0))
+                .andExpect(jsonPath("$.profile.score").value(0))
+                .andExpect(jsonPath("$.profile.battleRating").value(1000))
                 .andExpect(jsonPath("$.profile.battleMatchCount").value(0))
                 .andExpect(jsonPath("$.profile.top2Rate").value(0))
+                .andExpect(jsonPath("$.profile.top2SampleSize").value(0))
                 .andExpect(jsonPath("$.scoreTrend", hasSize(1)))
                 .andExpect(jsonPath("$.scoreTrend[0].label").value("NOW"))
-                .andExpect(jsonPath("$.scoreTrend[0].score").value(0))
+                .andExpect(jsonPath("$.scoreTrend[0].score").value(1000))
                 .andExpect(jsonPath("$.scoreTrend[0].delta").value(0))
                 .andExpect(jsonPath("$.gateProgress[0].key").value("SCORE"))
+                .andExpect(jsonPath("$.gateProgress[0].current").value(1000))
                 .andExpect(jsonPath("$.gateProgress[0].target").value(1060))
                 .andExpect(jsonPath("$.nearbyRanking", hasSize(1)))
                 .andExpect(jsonPath("$.nearbyRanking[0].isMe").value(true))
@@ -162,6 +176,16 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
                 values (nextval('member_id_seq'), ?, ?, 'password', ?, ?, 'USER', now())
                 returning id
                 """, Long.class, email, nickname, score, tier);
+    }
+
+    private void insertMemberRatingProfile(Long memberId, int battleRating, String tier) {
+        jdbcTemplate.update("""
+                insert into member_rating_profiles (
+                    id, member_id, battle_rating, hard_battle_rating, first_solve_score,
+                    tier_score, battle_match_count, first_solved_problem_count, tier, created_at
+                )
+                values (nextval('member_rating_profile_id_seq'), ?, ?, 1000, 0, ?, 0, 0, ?, now())
+                """, memberId, battleRating, battleRating, tier);
     }
 
     private Long insertProblem(String sourceProblemId, String title, int difficultyRating) {


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #191 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #191

---
<html>
<body>
<h1>[feat] 랭킹 대시보드 battleRating 기준 통일 및 응답 필드 보강</h1>

<h3>개요</h3>
<p>이번 PR은 기존 랭킹 대시보드 API에서 <strong>일부 값은 member.score 기준, 일부 값은 배틀 성과 기준</strong>으로 계산되던 부분을 정리하고, <strong>배틀 중심 지표는 모두 battleRating 기준으로 통일</strong>한 작업입니다.</p>
<p>기존 구현에서는 현재 티어, 점수 추이, 주변 랭킹, 티어 분포, gateProgress 같은 배틀 랭킹 성격의 데이터가 <code>members.score</code>를 기반으로 계산되고 있었습니다. 하지만 실제 배틀 경쟁력과 랭킹 문맥에 더 맞는 값은 <code>member_rating_profiles.battle_rating</code>이기 때문에, 이번 PR에서는 대시보드의 핵심 랭킹 지표 기준을 battleRating으로 옮겼습니다.</p>
<p>또한 프론트가 battleRating과 최근 Top2 통계의 표본 크기를 명확히 표시할 수 있도록 <code>battleRating</code>, <code>top2SampleSize</code> 필드를 응답에 추가했습니다.</p>

<hr>

<h2>기존 코드 대비 변경점</h2>

<table>
<tr><th>구분</th><th>기존</th><th>변경 후</th></tr>
<tr>
<td>랭킹 기준</td>
<td><code>members.score</code> 기준</td>
<td><code>member_rating_profiles.battle_rating</code> 기준</td>
</tr>
<tr>
<td>현재 티어 계산</td>
<td>score 기반</td>
<td>battleRating 기반</td>
</tr>
<tr>
<td>scoreTrend 기준값</td>
<td>현재 score에서 delta 역산</td>
<td>현재 battleRating에서 delta 역산</td>
</tr>
<tr>
<td>gateProgress SCORE</td>
<td>score 기준</td>
<td>battleRating 기준</td>
</tr>
<tr>
<td>주변 랭킹 정렬/표시 점수</td>
<td>score 기준</td>
<td>battleRating 기준</td>
</tr>
<tr>
<td>티어 분포 계산 기준</td>
<td>score 기준 tier 유도</td>
<td>battleRating 기준 tier 유도</td>
</tr>
<tr>
<td>프로필 응답</td>
<td><code>score</code>, <code>top2Rate</code>, <code>scoreDeltaTotal</code></td>
<td><code>battleRating</code>, <code>top2SampleSize</code> 추가</td>
</tr>
<tr>
<td>battleRating 미보유 사용자</td>
<td>별도 기준 없음</td>
<td>기본값 <code>1000</code> 사용</td>
</tr>
<tr>
<td>최근 배틀 요약</td>
<td>Top2 비율만 최근 20경기 기준</td>
<td>Top2 비율과 scoreDeltaTotal 모두 최근 20경기 기준으로 정렬</td>
</tr>
</table>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) 랭킹 대시보드의 핵심 기준을 score에서 battleRating으로 통일</h3>
<p>이번 PR의 핵심은 “랭킹 대시보드에서 실제 배틀 실력을 보여주는 값은 무엇인가”에 대한 기준을 정리한 것입니다.</p>
<p>기존에는 서비스 내부에서 아래 값들이 <code>member.score</code> 기준으로 계산되고 있었습니다.</p>

<ul>
<li>현재 티어</li>
<li>다음 티어</li>
<li>점수 추이 그래프</li>
<li>gateProgress SCORE</li>
<li>근처 랭킹</li>
<li>티어 분포</li>
</ul>

<p>이번 PR에서는 이를 <code>member_rating_profiles.battle_rating</code>으로 전환했습니다.</p>

<pre><code class="language-java">long battleRating = member.battleRating();
String currentTier = displayTier(member.tier(), battleRating);
String nextTier = resolveNextTier(currentTier);
</code></pre>

<p>즉, 이제 대시보드에서 “랭킹/티어/배틀 성장”을 의미하는 값들은 모두 battleRating 기준으로 해석됩니다.</p>

<h3>2) member 랭킹 조회 쿼리를 battleRating 기준으로 변경</h3>
<p><code>findMemberRank()</code> 쿼리는 기존에 <code>members.score</code>를 기준으로 순위를 계산하고 있었습니다. 이번 PR에서는 <code>member_rating_profiles</code>를 조인해서 battleRating 기준으로 랭킹을 계산하도록 변경했습니다.</p>

<pre><code class="language-sql">left join member_rating_profiles mrp on mrp.member_id = m.id
...
coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating,
row_number() over (
    order by coalesce(mrp.battle_rating, :defaultBattleRating) desc, m.id asc
) as rank_no
</code></pre>

<p>즉, 현재 랭킹은 이제 아래 기준으로 계산됩니다.</p>
<ul>
<li>battleRating 내림차순</li>
<li>동점이면 member.id 오름차순</li>
</ul>

<p>그리고 사용자별 기본 정보에도 battleRating을 함께 담도록 <code>MemberRankRow</code>가 확장됐습니다.</p>

<h3>3) battleRating이 없는 사용자도 기본값 1000으로 대시보드 계산 가능하도록 처리</h3>
<p>모든 사용자가 항상 <code>member_rating_profiles</code>를 가지고 있는 것은 아니기 때문에, 이번 PR에서는 battleRating이 없는 경우 기본값 <code>1000</code>을 사용하도록 했습니다.</p>

<pre><code class="language-java">private static final long DEFAULT_BATTLE_RATING = 1000L;
</code></pre>

<pre><code class="language-sql">coalesce(mrp.battle_rating, :defaultBattleRating)
</code></pre>

<p>이 규칙은 아래 모든 곳에 동일하게 적용됩니다.</p>
<ul>
<li>내 랭킹 조회</li>
<li>근처 랭킹 조회</li>
<li>티어 분포 계산</li>
<li>빈 사용자 대시보드 기본값</li>
</ul>

<p>즉, 아직 rating profile이 없는 사용자도 대시보드에서 일관된 기본 battleRating 기준으로 계산됩니다.</p>

<h3>4) profile 응답에 battleRating 필드 추가</h3>
<p>기존 프로필 응답에는 <code>score</code>만 있었기 때문에, 프론트가 “계정 점수”와 “배틀 랭킹용 점수”를 명확히 구분하기 어려웠습니다. 이번 PR에서는 이를 분리해서 <code>battleRating</code> 필드를 추가했습니다.</p>

<pre><code class="language-java">public record Profile(
        Long memberId,
        String nickname,
        String tier,
        long rank,
        double percentile,
        long score,
        long battleRating,
        String nextTier,
        long battleMatchCount,
        int top2Rate,
        int top2SampleSize,
        long scoreDeltaTotal) {}
</code></pre>

<p>즉, 이제 profile은 아래처럼 해석할 수 있습니다.</p>
<ul>
<li><code>score</code> : 기존 회원 점수</li>
<li><code>battleRating</code> : 랭킹/티어/배틀 대시보드 기준 점수</li>
</ul>

<p>프론트는 이 둘을 분리해서 표시하거나, battle 중심 화면에서는 battleRating을 우선 노출할 수 있습니다.</p>

<h3>5) 최근 Top2 비율의 표본 크기를 응답에 추가</h3>
<p>기존에는 <code>top2Rate</code> 값만 내려주고 있어서, 그 값이 최근 몇 경기 기준인지 프론트가 직접 알기 어려웠습니다. 이번 PR에서는 <code>top2SampleSize</code>를 추가해 분모를 함께 내려주도록 했습니다.</p>

<pre><code class="language-java">int top2SampleSize = recentBattleWindow.size();
</code></pre>

<p>즉, 이제 프론트는 아래처럼 해석할 수 있습니다.</p>
<ul>
<li><code>top2Rate = 50</code></li>
<li><code>top2SampleSize = 2</code></li>
</ul>

<p>이는 “최근 2경기 중 50%”처럼 보다 정확한 라벨링에 사용할 수 있습니다.</p>

<h3>6) battle summary 집계 기준을 최근 20경기 window로 정리</h3>
<p>기존 구현에서는:</p>
<ul>
<li><code>battleMatchCount</code>는 전체 FINISHED 배틀 수</li>
<li><code>top2Rate</code>는 최근 20경기 기준</li>
<li><code>scoreDeltaTotal</code>는 전체 FINISHED 배틀 점수 합</li>
</ul>

<p>이렇게 한 응답 안에서도 기준이 섞여 있었습니다.</p>
<p>이번 PR에서는 <code>battleMatchCount</code>는 전체 완료 배틀 수를 유지하되, <code>top2Rate</code>와 <code>scoreDeltaTotal</code>은 모두 <strong>최근 20경기 window</strong> 기준으로 맞췄습니다.</p>

<pre><code class="language-sql">select
    bp.final_rank,
    coalesce(bp.score_delta, 0) as score_delta
from battle_participants bp
join battle_rooms br on br.id = bp.room_id
where bp.user_id = :memberId
  and upper(br.status) = 'FINISHED'
  and bp.final_rank is not null
order by coalesce(bp.finish_time, br.timer_end, br.modified_at, br.created_at, bp.created_at) desc,
         bp.id desc
limit :limit
</code></pre>

<p>즉, 이제:</p>
<ul>
<li><code>battleMatchCount</code> : 누적 완료 배틀 수</li>
<li><code>top2Rate</code> : 최근 최대 20경기 중 Top2 비율</li>
<li><code>top2SampleSize</code> : 그 최근 경기 수</li>
<li><code>scoreDeltaTotal</code> : 그 최근 경기들의 score_delta 합</li>
</ul>

<p>로 역할이 더 명확해졌습니다.</p>

<h3>7) scoreTrend를 battleRating 기준 시계열로 변경</h3>
<p>점수 추이 그래프도 기존에는 현재 <code>score</code>에서 최근 delta를 역산해 만들고 있었지만, 이번 PR에서는 현재 <code>battleRating</code> 기준으로 재구성하도록 바꿨습니다.</p>

<pre><code class="language-java">buildScoreTrend(memberId, battleRating, now)
</code></pre>

<p>즉, 최근 완료 배틀의 <code>score_delta</code>를 누적해 그리는 시계열이 이제 “회원 점수 변화”가 아니라 “배틀 레이팅 변화”를 의미하게 됩니다.</p>

<p>이 변경으로 scoreTrend는 다음 의미를 가지게 됩니다.</p>
<ul>
<li>현재 battleRating에서 출발</li>
<li>최근 delta 합을 역산</li>
<li>오래된 순으로 다시 누적</li>
<li><code>D-n</code>, <code>NOW</code> 라벨로 프론트 그래프에 제공</li>
</ul>

<h3>8) gateProgress SCORE도 battleRating 기준으로 변경</h3>
<p>기존 구현에서는 SCORE gate가 <code>members.score</code> 기준이어서, 실제 티어 계산 기준과 어긋날 수 있었습니다. 이번 PR에서는 SCORE gate도 battleRating 기준으로 바꿨습니다.</p>

<pre><code class="language-java">buildGateProgress(memberId, battleRating, nextTier, battleSummary.top2Rate())
</code></pre>

<pre><code class="language-java">new GateProgress("SCORE", "배틀 레이팅", currentScore, scoreTarget, "")
</code></pre>

<p>즉, 이제 gateProgress의 SCORE 항목은 실제 다음 티어 진입과 같은 기준을 바라보게 됩니다.</p>

<h3>9) nearbyRanking도 battleRating 기준 순위/점수로 변경</h3>
<p>근처 랭킹 조회 역시 기존에는 <code>members.score</code> 기준으로 정렬하고 score를 노출하고 있었습니다. 이번 PR에서는 <code>member_rating_profiles.battle_rating</code>을 기준으로 정렬하고, 응답의 <code>score</code> 필드에는 battleRating 값을 넣도록 변경했습니다.</p>

<pre><code class="language-sql">coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating,
row_number() over (
    order by coalesce(mrp.battle_rating, :defaultBattleRating) desc, m.id asc
) as rank_no
</code></pre>

<pre><code class="language-java">new NearbyRanking(
        row.rank(),
        row.memberId(),
        row.nickname(),
        displayTier(row.tier(), row.battleRating()),
        row.battleRating(),
        row.memberId().equals(memberId))
</code></pre>

<p>즉, 메인 홈에서 보여주는 “내 근처 유저들”은 이제 배틀 랭킹 문맥에 더 맞는 값으로 정렬되고 표시됩니다.</p>

<h3>10) tierDistribution도 battleRating 기준으로 계산</h3>
<p>티어 분포 역시 기존에는 회원 score 기반으로 티어를 유도하고 있었습니다. 이번 PR에서는 <code>member_rating_profiles</code>를 읽어 battleRating 기준으로 티어 분포를 계산합니다.</p>

<pre><code class="language-sql">select
    mrp.tier,
    coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating
from members m
left join member_rating_profiles mrp on mrp.member_id = m.id
</code></pre>

<p>서비스에서는 각 row를 아래처럼 해석합니다.</p>

<pre><code class="language-java">rows.forEach(row -> tierCounts.merge(displayTier(row.tier(), row.battleRating()), 1L, Long::sum));
</code></pre>

<p>즉, 전체 티어 분포도 이제 battleRating 기준 티어 체계와 같은 언어를 사용합니다.</p>

<h3>11) 빈 사용자 대시보드 기본값도 battleRating 기준으로 보정</h3>
<p>이력이 없는 사용자 케이스에서도 battleRating 기준 응답이 자연스럽게 나오도록 테스트와 구현이 함께 보정되었습니다.</p>

<p>기존에는 score가 0이면 scoreTrend도 0, gateProgress SCORE current도 0으로 내려왔지만, 이번 PR에서는 rating profile이 없는 사용자의 기본 battleRating을 <code>1000</code>으로 해석합니다.</p>

<p>즉, 히스토리가 없는 사용자 응답은 아래처럼 바뀝니다.</p>
<ul>
<li><code>profile.score = 0</code> 유지</li>
<li><code>profile.battleRating = 1000</code> 추가</li>
<li><code>scoreTrend[0].score = 1000</code></li>
<li><code>gateProgress[0].current = 1000</code></li>
</ul>

<p>이렇게 하면 battle 중심 대시보드의 기본 상태가 더 자연스럽게 표현됩니다.</p>

<h3>12) 테스트 데이터도 member_rating_profiles 기준으로 확장</h3>
<p><code>RankingDashboardControllerTest</code>는 이번 변경을 반영해, 회원 score와 battleRating을 의도적으로 다르게 넣는 방식으로 보강됐습니다.</p>

<p>예를 들어 성공 케이스에서:</p>
<ul>
<li><code>members.score</code>는 낮은 값</li>
<li><code>member_rating_profiles.battle_rating</code>은 실제 랭킹용 값</li>
</ul>

<p>으로 넣고, 응답 검증도 아래처럼 나뉘어 확인합니다.</p>

<pre><code class="language-java">.andExpect(jsonPath("$.profile.score").value(40))
.andExpect(jsonPath("$.profile.battleRating").value(1580))
.andExpect(jsonPath("$.nearbyRanking[2].score").value(1580))
.andExpect(jsonPath("$.scoreTrend[1].score").value(1580))
</code></pre>

<p>즉, 이번 테스트는 “score는 그대로 남지만 대시보드 랭킹 지표는 battleRating 기준으로 바뀌었다”는 점을 명확하게 검증합니다.</p>

<h3>13) top2 / scoreDelta 응답 해석을 더 명확하게 만듦</h3>
<p>이번 응답 보강으로 profile의 battle 성과 영역은 아래처럼 읽을 수 있게 됐습니다.</p>

<ul>
<li><code>battleMatchCount</code> : 전체 완료 배틀 수</li>
<li><code>top2Rate</code> : 최근 최대 20경기 중 Top2 비율</li>
<li><code>top2SampleSize</code> : 최근 경기 표본 수</li>
<li><code>scoreDeltaTotal</code> : 그 최근 경기들에서의 누적 score delta</li>
</ul>

<p>즉, “최근 경기 기준 성과”와 “누적 완료 경기 수”를 프론트가 더 오해 없이 표시할 수 있도록 응답 의미를 보강했습니다.</p>

<h3>14) 컨트롤러 진입점은 그대로 유지</h3>
<p>API 엔드포인트 자체는 기존 브랜치에서 추가한 그대로 유지됩니다.</p>

<pre><code class="language-text">GET /api/v1/rankings/me/dashboard
</code></pre>

<p>이번 PR의 변화는 엔드포인트 추가가 아니라, <strong>그 내부 집계 기준과 응답 해석을 battleRating 중심으로 정리한 것</strong>에 가깝습니다.</p>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">GET /api/v1/rankings/me/dashboard
      ↓
RankingDashboardController
  - 현재 로그인 사용자 확인
      ↓
RankingDashboardService.getMyDashboard(memberId)
      ↓
1. members + member_rating_profiles 조인으로
   현재 사용자 battleRating / tier / rank 조회
      ↓
2. battleRating 기준으로
   currentTier / nextTier 계산
      ↓
3. 최근 완료 배틀 최대 20경기 기준으로
   top2Rate / top2SampleSize / scoreDeltaTotal 계산
      ↓
4. battleRating 기준으로
   scoreTrend / gateProgress / nearbyRanking / tierDistribution 계산
      ↓
5. tagStats / reviewSummary 조합
      ↓
RankingDashboardResponse 반환
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>랭킹 대시보드의 핵심 지표가 score와 battleRating 사이에서 섞이지 않고 하나의 기준으로 정리됩니다.</li>
<li>프론트가 battle 중심 화면에서 더 자연스러운 랭킹/티어/추이 데이터를 받을 수 있습니다.</li>
<li><code>battleRating</code>, <code>top2SampleSize</code> 추가로 응답 의미가 더 명확해집니다.</li>
<li>rating profile이 없는 사용자도 기본 battleRating 1000 기준으로 일관된 대시보드 응답을 받을 수 있습니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li><code>profile.score</code>와 <code>profile.battleRating</code>이 의도대로 분리되어 내려오는지 확인</li>
<li>랭킹, 주변 랭킹, 티어 분포, scoreTrend, gateProgress가 모두 battleRating 기준으로 계산되는지 확인</li>
<li><code>top2Rate</code>, <code>top2SampleSize</code>, <code>scoreDeltaTotal</code>가 최근 최대 20경기 기준으로 해석되는지 확인</li>
<li><code>member_rating_profiles</code>가 없는 사용자에게 기본 battleRating 1000이 적용되는지 확인</li>
<li>프론트가 기존 <code>score</code> 필드를 계속 사용하던 부분이 있다면, battle 관련 UI는 <code>battleRating</code>으로 전환이 필요한지 확인</li>
</ol>
</body>
</html>

