### PR TITLE
[feat] getTodayReviews 반환 필드 확장 (난이도, 레이팅, 시간/메모리 제한, 전체 수)

### DIFF
--- a/src/main/java/com/back/domain/review/reviewschedule/dto/TodayReviewResponse.java
+++ b/src/main/java/com/back/domain/review/reviewschedule/dto/TodayReviewResponse.java
@@ -2,6 +2,7 @@ package com.back.domain.review.reviewschedule.dto;
 
 import java.util.List;
 
+import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
 
 public record TodayReviewResponse(int totalCount, List<ReviewItem> reviews) {
@@ -10,10 +11,25 @@ public record TodayReviewResponse(int totalCount, List<ReviewItem> reviews) {
         this(reviews.size(), reviews);
     }
 
-    public record ReviewItem(Long problemId, String problemTitle, int reviewCount) {
+    public record ReviewItem(
+            Long problemId,
+            String problemTitle,
+            DifficultyLevel difficulty,
+            Integer difficultyRating,
+            Long timeLimitMs,
+            Long memoryLimitMb,
+            int reviewCount) {
+
         public static ReviewItem from(ReviewSchedule schedule) {
+            var problem = schedule.getProblem();
             return new ReviewItem(
-                    schedule.getProblem().getId(), schedule.getProblem().getTitle(), schedule.getReviewCount());
+                    problem.getId(),
+                    problem.getTitle(),
+                    problem.getDifficulty(),
+                    problem.getDifficultyRating(),
+                    problem.getTimeLimitMs(),
+                    problem.getMemoryLimitMb(),
+                    schedule.getReviewCount());
         }
     }
 }

--- a/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/controller/ReviewScheduleControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.review.reviewschedule.dto.ReviewScheduleResponse;
 import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
 import com.back.domain.review.reviewschedule.service.ReviewScheduleService;
@@ -40,7 +41,8 @@ class ReviewScheduleControllerTest {
     @DisplayName("로그인 상태에서 요청하면 서비스 결과와 함께 200을 반환한다")
     void getTodayReviews_authenticated_returns200WithItems() {
         Member actor = Member.of(1L, "test@test.com", "tester");
-        TodayReviewResponse.ReviewItem item = new TodayReviewResponse.ReviewItem(10L, "문제A", 1);
+        TodayReviewResponse.ReviewItem item =
+                new TodayReviewResponse.ReviewItem(10L, "문제A", DifficultyLevel.EASY, 800, 1000L, 256L, 1);
         TodayReviewResponse serviceResponse = new TodayReviewResponse(List.of(item));
 
         when(rq.getActor()).thenReturn(actor);
@@ -53,6 +55,7 @@ class ReviewScheduleControllerTest {
         assertThat(result.data().reviews()).hasSize(1);
         assertThat(result.data().reviews().get(0).problemId()).isEqualTo(10L);
         assertThat(result.data().reviews().get(0).problemTitle()).isEqualTo("문제A");
+        assertThat(result.data().reviews().get(0).difficulty()).isEqualTo(DifficultyLevel.EASY);
         assertThat(result.data().reviews().get(0).reviewCount()).isEqualTo(1);
     }
 

--- a/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
+++ b/src/test/java/com/back/domain/review/reviewschedule/service/ReviewScheduleServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.review.reviewschedule.dto.ReviewScheduleResponse;
 import com.back.domain.review.reviewschedule.dto.TodayReviewResponse;
 import com.back.domain.review.reviewschedule.entity.ReviewSchedule;
@@ -108,29 +109,31 @@ class ReviewScheduleServiceTest {
     @DisplayName("오늘 복습할 스케줄이 있으면 ReviewItem 목록을 반환한다")
     void getTodayReviews_returnsItems() {
         Problem p1 = mock(Problem.class);
-        Problem p2 = mock(Problem.class);
         when(p1.getId()).thenReturn(10L);
         when(p1.getTitle()).thenReturn("문제A");
-        when(p2.getId()).thenReturn(20L);
-        when(p2.getTitle()).thenReturn("문제B");
+        when(p1.getDifficulty()).thenReturn(DifficultyLevel.EASY);
+        when(p1.getDifficultyRating()).thenReturn(800);
+        when(p1.getTimeLimitMs()).thenReturn(1000L);
+        when(p1.getMemoryLimitMb()).thenReturn(256L);
 
         Member m1 = mock(Member.class);
-        Member m2 = mock(Member.class);
         ReviewSchedule s1 = ReviewSchedule.of(m1, p1, solvedAt, solvedAt.plusDays(3));
-        ReviewSchedule s2 = ReviewSchedule.of(m2, p2, solvedAt, solvedAt.plusDays(3));
-        s2.updateOnAc(solvedAt, solvedAt.plusDays(7), true);
 
-        when(reviewScheduleRepository.findTodayReviews(any(), any())).thenReturn(List.of(s1, s2));
+        when(reviewScheduleRepository.findTodayReviews(any(), any())).thenReturn(List.of(s1));
 
         TodayReviewResponse response = reviewScheduleService.getTodayReviews(99L);
 
-        assertThat(response.totalCount()).isEqualTo(2);
-        assertThat(response.reviews()).hasSize(2);
-        assertThat(response.reviews().get(0).problemId()).isEqualTo(10L);
-        assertThat(response.reviews().get(0).problemTitle()).isEqualTo("문제A");
-        assertThat(response.reviews().get(0).reviewCount()).isEqualTo(1);
-        assertThat(response.reviews().get(1).problemId()).isEqualTo(20L);
-        assertThat(response.reviews().get(1).reviewCount()).isEqualTo(2);
+        assertThat(response.totalCount()).isEqualTo(1);
+        assertThat(response.reviews()).hasSize(1);
+
+        TodayReviewResponse.ReviewItem item = response.reviews().get(0);
+        assertThat(item.problemId()).isEqualTo(10L);
+        assertThat(item.problemTitle()).isEqualTo("문제A");
+        assertThat(item.difficulty()).isEqualTo(DifficultyLevel.EASY);
+        assertThat(item.difficultyRating()).isEqualTo(800);
+        assertThat(item.timeLimitMs()).isEqualTo(1000L);
+        assertThat(item.memoryLimitMb()).isEqualTo(256L);
+        assertThat(item.reviewCount()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #193
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #193

---

## 📝 작업 내용
<!-- 무엇을 왜 변경했는지 2~4줄로 작성 -->
getTodayReviews 반환 필드 확장 (난이도, 레이팅, 시간/메모리 제한, 전체 수)

---

## ✅ 주요 변경 사항
1) 예) 새로운 기능 추가
2) 
3) 

---

## 🧪 테스트 결과
<!-- 실행한 테스트 명령어/결과 작성 -->
```bash
# 예) ./gradlew test --tests "com.back.domain.email.scheduler.DdayEmailSchedulerTest"
```

- [ ] 로컬 테스트 통과
- [ ] 관련 시나리오 수동 확인

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
