### PR TITLE
refactor: SR/AP 점수 체계 및 대시보드 정합성 개선

### DIFF
--- a/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
+++ b/src/main/java/com/back/domain/battle/result/service/BattleResultService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,10 +44,6 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class BattleResultService {
-
-    // 점수 정책 완화: 1등 +20, 2등 +8, 3등 +2, 4등 -5
-    private static final long[] SCORE_TABLE = {20L, 8L, 2L};
-    private static final long LAST_PLACE_PENALTY = -5L;
 
     // 오답 패널티: WA 1회당 20초
     private static final long WA_PENALTY_SECONDS = 20L;
@@ -95,39 +92,36 @@ public class BattleResultService {
 
         List<RatingProfileService.BattlePlacement> placements = new ArrayList<>(sorted.size());
         List<BattleParticipant> acParticipants = new ArrayList<>();
+        Map<Long, Integer> rankByMemberId = new HashMap<>(sorted.size());
 
-        // 4. 등수 & 점수 부여
+        // 4. 등수 부여 + Elo 정산 입력 구성
         int rank = 1;
-        int totalParticipants = sorted.size();
         for (BattleParticipant participant : sorted) {
             boolean isAC = participant.getStatus() == BattleParticipantStatus.SOLVED;
             boolean isDisconnected = participant.getStatus() == BattleParticipantStatus.ABANDONED
                     || participant.getStatus() == BattleParticipantStatus.QUIT;
-            long scoreDelta = 0L;
-            if (isAC && rank <= SCORE_TABLE.length) {
-                scoreDelta = SCORE_TABLE[rank - 1];
-            }
-            if (isDisconnected) {
-                scoreDelta = LAST_PLACE_PENALTY;
-            } else if (totalParticipants >= 4 && rank == totalParticipants) {
-                scoreDelta = LAST_PLACE_PENALTY;
-            }
+            rankByMemberId.put(participant.getMember().getId(), rank);
 
-            participant.applyResult(rank, scoreDelta);
-
-            // 5. Member.score 갱신
-            participant.getMember().applyScore(scoreDelta);
             if (isAC) {
                 acParticipants.add(participant);
             }
-            // Elo 정산은 participant 전체 순위가 필요하므로 별도 리스트로 누적한다.
-            placements.add(new RatingProfileService.BattlePlacement(participant.getMember(), rank));
+            placements.add(new RatingProfileService.BattlePlacement(participant.getMember(), rank, isDisconnected));
 
             rank++;
         }
 
-        // 배틀 SR 정산(Elo 기반 + 양학 감쇠 + 언더독 보너스).
-        ratingProfileService.applyBattlePlacements(placements, room.getProblem().getDifficultyRating());
+        // 배틀 SR 정산(Elo 기반 + 양학 감쇠 + 언더독 보너스 + 포기 패널티).
+        Map<Long, Integer> deltaByMemberId = ratingProfileService.applyBattlePlacements(
+                placements, room.getProblem().getDifficultyRating());
+        if (deltaByMemberId == null) {
+            deltaByMemberId = Map.of();
+        }
+        for (BattleParticipant participant : sorted) {
+            int finalRank = rankByMemberId.getOrDefault(participant.getMember().getId(), 0);
+            int scoreDelta =
+                    deltaByMemberId.getOrDefault(participant.getMember().getId(), 0);
+            participant.applyResult(finalRank, scoreDelta);
+        }
 
         for (BattleParticipant participant : acParticipants) {
             // 배틀에서 처음으로 푼 문제라면 난이도 기반 first-AC 보너스를 1회 반영한다.

--- a/src/main/java/com/back/domain/member/member/dto/MyInfoResponse.java
+++ b/src/main/java/com/back/domain/member/member/dto/MyInfoResponse.java
@@ -4,12 +4,12 @@ import com.back.domain.member.member.entity.Member;
 
 public record MyInfoResponse(Long memberId, String nickname, String email, Long score, String tier, String role) {
 
-    public static MyInfoResponse from(Member member, String rankingTier) {
+    public static MyInfoResponse from(Member member, String rankingTier, long rankingScore) {
         return new MyInfoResponse(
                 member.getId(),
                 member.getNickname(),
                 member.getEmail(),
-                member.getScore(),
+                rankingScore,
                 rankingTier,
                 member.getRole().name());
     }

--- a/src/main/java/com/back/domain/member/member/dto/RatingProgressResponse.java
+++ b/src/main/java/com/back/domain/member/member/dto/RatingProgressResponse.java
@@ -8,7 +8,6 @@ public record RatingProgressResponse(CurrentProgress current, NextTierProgress n
             String displayTier,
             String tier,
             int battleRating,
-            int hardBattleRating,
             int activityPoint,
             int battleMatchCount,
             int firstSolvedProblemCount,

--- a/src/main/java/com/back/domain/member/member/service/MemberRatingProgressService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberRatingProgressService.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberRatingProgressService {
 
-    private static final int INITIAL_SKILL_RATING = 1000;
+    private static final int INITIAL_SKILL_RATING = 0;
     private static final int INITIAL_ACTIVITY_POINT = 0;
     private static final int TOP2_WINDOW_SIZE = 20;
     private static final String COMPARISON_AT_LEAST = "AT_LEAST";
@@ -53,7 +53,6 @@ public class MemberRatingProgressService {
         int battleMatchCount = nullToZero(profile.getBattleMatchCount());
         int firstSolvedProblemCount = nullToZero(profile.getFirstSolvedProblemCount());
         int battleRating = nullToDefault(profile.getBattleRating(), INITIAL_SKILL_RATING);
-        int hardBattleRating = nullToDefault(profile.getHardBattleRating(), INITIAL_SKILL_RATING);
         int activityPoint = nullToDefault(profile.getFirstSolveScore(), INITIAL_ACTIVITY_POINT);
         RatingTier currentTier = profile.getTier() == null ? RatingTier.BRONZE_5 : profile.getTier();
         String displayTier = TierPolicy.resolveDisplayTier(currentTier, battleMatchCount, firstSolvedProblemCount);
@@ -76,7 +75,6 @@ public class MemberRatingProgressService {
                 displayTier,
                 currentTier.name(),
                 battleRating,
-                hardBattleRating,
                 activityPoint,
                 battleMatchCount,
                 firstSolvedProblemCount,
@@ -91,7 +89,6 @@ public class MemberRatingProgressService {
                 displayTier,
                 currentTier,
                 battleRating,
-                hardBattleRating,
                 activityPoint,
                 battleMatchCount,
                 firstSolvedProblemCount,
@@ -109,7 +106,6 @@ public class MemberRatingProgressService {
             String displayTier,
             RatingTier currentTier,
             int battleRating,
-            int hardBattleRating,
             int activityPoint,
             int battleMatchCount,
             int firstSolvedProblemCount,
@@ -149,7 +145,7 @@ public class MemberRatingProgressService {
             boolean seatSatisfied = seatRank != null && seatRank <= 5;
             RatingProgressResponse.RequirementProgress seatRequirement = new RatingProgressResponse.RequirementProgress(
                     "godSeatRank",
-                    "MASTER_1 상위 5석(Hard SR 순위)",
+                    "MASTER_1 상위 5석(SR 순위)",
                     COMPARISON_AT_MOST,
                     currentRank,
                     5.0d,
@@ -159,7 +155,7 @@ public class MemberRatingProgressService {
             return new RatingProgressResponse.NextTierProgress(
                     nextTier.name(),
                     seatSatisfied,
-                    "GOD은 MASTER_1 유저 중 Hard SR 상위 5명에게만 부여됩니다.",
+                    "GOD은 MASTER_1 유저 중 SR 상위 5명에게만 부여됩니다.",
                     seatRank,
                     List.of(seatRequirement));
         }
@@ -170,12 +166,6 @@ public class MemberRatingProgressService {
         if (requiredSkillRating != null) {
             requirements.add(
                     buildAtLeastRequirement("battleRating", "SR (battleRating)", battleRating, requiredSkillRating));
-        }
-
-        Integer requiredHardSkillRating = resolveHardSkillThreshold(nextTier);
-        if (requiredHardSkillRating != null) {
-            requirements.add(
-                    buildAtLeastRequirement("hardBattleRating", "Hard SR", hardBattleRating, requiredHardSkillRating));
         }
 
         GateRequirement gateRequirement = resolveGateRequirement(nextTier);
@@ -229,51 +219,36 @@ public class MemberRatingProgressService {
 
     private Integer resolveSkillThreshold(RatingTier tier) {
         return switch (tier) {
-            case BRONZE_5 -> 900;
-            case BRONZE_4 -> 1060;
-            case BRONZE_3 -> 1120;
-            case BRONZE_2 -> 1180;
-            case BRONZE_1 -> 1240;
-            case SILVER_5 -> 1300;
-            case SILVER_4 -> 1360;
-            case SILVER_3 -> 1420;
-            case SILVER_2 -> 1480;
-            case SILVER_1 -> 1540;
-            case GOLD_5 -> 1600;
-            case GOLD_4 -> 1660;
-            case GOLD_3 -> 1720;
-            case GOLD_2 -> 1780;
-            case GOLD_1 -> 1840;
-            case PLATINUM_5 -> 1900;
-            case PLATINUM_4 -> 1960;
-            case PLATINUM_3 -> 2020;
-            case PLATINUM_2 -> 2080;
-            case PLATINUM_1 -> 2140;
-            case DIAMOND_5 -> 2200;
-            case DIAMOND_4 -> 2260;
-            case DIAMOND_3 -> 2320;
-            case DIAMOND_2 -> 2380;
-            case DIAMOND_1 -> 2440;
-            case MASTER_4 -> 2500;
-            case MASTER_3 -> 2575;
-            case MASTER_2 -> 2650;
-            case MASTER_1 -> 2725;
+            case BRONZE_5 -> 0;
+            case BRONZE_4 -> 60;
+            case BRONZE_3 -> 120;
+            case BRONZE_2 -> 180;
+            case BRONZE_1 -> 240;
+            case SILVER_5 -> 300;
+            case SILVER_4 -> 360;
+            case SILVER_3 -> 420;
+            case SILVER_2 -> 480;
+            case SILVER_1 -> 540;
+            case GOLD_5 -> 600;
+            case GOLD_4 -> 660;
+            case GOLD_3 -> 720;
+            case GOLD_2 -> 780;
+            case GOLD_1 -> 840;
+            case PLATINUM_5 -> 900;
+            case PLATINUM_4 -> 960;
+            case PLATINUM_3 -> 1020;
+            case PLATINUM_2 -> 1080;
+            case PLATINUM_1 -> 1140;
+            case DIAMOND_5 -> 1200;
+            case DIAMOND_4 -> 1260;
+            case DIAMOND_3 -> 1320;
+            case DIAMOND_2 -> 1380;
+            case DIAMOND_1 -> 1440;
+            case MASTER_4 -> 1500;
+            case MASTER_3 -> 1575;
+            case MASTER_2 -> 1650;
+            case MASTER_1 -> 1725;
             case GOD -> null;
-        };
-    }
-
-    private Integer resolveHardSkillThreshold(RatingTier tier) {
-        return switch (tier) {
-            case DIAMOND_5 -> 2200;
-            case DIAMOND_4 -> 2260;
-            case DIAMOND_3 -> 2320;
-            case DIAMOND_2 -> 2380;
-            case DIAMOND_1 -> 2440;
-            case MASTER_4 -> 2500;
-            case MASTER_3 -> 2575;
-            case MASTER_2 -> 2650;
-            case MASTER_1 -> 2725;
-            default -> null;
         };
     }
 
@@ -301,7 +276,7 @@ public class MemberRatingProgressService {
 
     private Integer resolveMasterSeatRank(Long memberId) {
         List<MemberRatingProfile> candidates =
-                memberRatingProfileRepository.findAllByTierInOrderByHardBattleRatingDescBattleRatingDescMemberIdAsc(
+                memberRatingProfileRepository.findAllByTierInOrderByBattleRatingDescFirstSolveScoreDescMemberIdAsc(
                         List.of(RatingTier.GOD, RatingTier.MASTER_1));
         if (candidates == null || candidates.isEmpty()) {
             return null;

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -13,6 +13,7 @@ import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.rating.policy.TierPolicy;
+import com.back.domain.rating.profile.entity.MemberRatingProfile;
 import com.back.domain.rating.profile.repository.MemberRatingProfileRepository;
 import com.back.domain.rating.profile.service.RatingProfileService;
 import com.back.global.exception.ServiceException;
@@ -76,15 +77,21 @@ public class MemberService {
                 .findById(memberId)
                 .orElseThrow(() -> new ServiceException("MEMBER_404", "존재하지 않는 회원입니다"));
 
-        String rankingTier = memberRatingProfileRepository
-                .findByMemberId(memberId)
-                .map(ratingProfile -> TierPolicy.resolveDisplayTier(
+        MemberRatingProfile ratingProfile =
+                memberRatingProfileRepository.findByMemberId(memberId).orElse(null);
+
+        String rankingTier = ratingProfile != null
+                ? TierPolicy.resolveDisplayTier(
                         ratingProfile.getTier(),
                         ratingProfile.getBattleMatchCount(),
-                        ratingProfile.getFirstSolvedProblemCount()))
-                .orElseGet(() -> TierPolicy.resolveDisplayTier(null, null, null));
+                        ratingProfile.getFirstSolvedProblemCount())
+                : TierPolicy.resolveDisplayTier(null, null, null);
 
-        return RsData.of("200", "내 정보 조회 성공", MyInfoResponse.from(member, rankingTier));
+        long rankingScore = ratingProfile == null || ratingProfile.getTierScore() == null
+                ? 0L
+                : ratingProfile.getTierScore().longValue();
+
+        return RsData.of("200", "내 정보 조회 성공", MyInfoResponse.from(member, rankingTier, rankingScore));
     }
 
     // 로그인 — 인증 성공 시 accessToken + refreshToken 반환 (쿠키 설정은 컨트롤러가 담당)

--- a/src/main/java/com/back/domain/ranking/dashboard/repository/RankingDashboardQueryRepository.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/repository/RankingDashboardQueryRepository.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 // 메인 홈 대시보드에 필요한 랭킹/배틀 집계 전용 조회를 모아둔다.
 public class RankingDashboardQueryRepository {
-    private static final long DEFAULT_BATTLE_RATING = 1000L;
+    private static final long DEFAULT_BATTLE_RATING = 0L;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -33,14 +33,18 @@ public class RankingDashboardQueryRepository {
                         m.id as member_id,
                         m.nickname,
                         mrp.tier,
-                        coalesce(m.score, 0) as score,
+                        coalesce(mrp.battle_rating, :defaultBattleRating) as score,
                         coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating,
-                        row_number() over (order by coalesce(mrp.battle_rating, :defaultBattleRating) desc, m.id asc) as rank_no,
+                        coalesce(mrp.battle_match_count, 0) as battle_match_count,
+                        coalesce(mrp.first_solved_problem_count, 0) as first_solved_problem_count,
+                        row_number() over (
+                            order by coalesce(mrp.battle_rating, :defaultBattleRating) desc, m.id asc
+                        ) as rank_no,
                         count(*) over () as total_count
                     from members m
                     left join member_rating_profiles mrp on mrp.member_id = m.id
                 )
-                select member_id, nickname, tier, score, battle_rating, rank_no, total_count
+                select member_id, nickname, tier, score, battle_rating, battle_match_count, first_solved_problem_count, rank_no, total_count
                 from ranked
                 where member_id = :memberId
                 """;
@@ -54,6 +58,8 @@ public class RankingDashboardQueryRepository {
                         rs.getString("tier"),
                         getLong(rs, "score"),
                         getLong(rs, "battle_rating"),
+                        getInt(rs, "battle_match_count"),
+                        getInt(rs, "first_solved_problem_count"),
                         getLong(rs, "rank_no"),
                         getLong(rs, "total_count")));
     }
@@ -151,6 +157,8 @@ public class RankingDashboardQueryRepository {
                         m.nickname,
                         mrp.tier,
                         coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating,
+                        coalesce(mrp.battle_match_count, 0) as battle_match_count,
+                        coalesce(mrp.first_solved_problem_count, 0) as first_solved_problem_count,
                         row_number() over (
                             order by coalesce(mrp.battle_rating, :defaultBattleRating) desc, m.id asc
                         ) as rank_no
@@ -162,7 +170,7 @@ public class RankingDashboardQueryRepository {
                     from ranked
                     where member_id = :memberId
                 )
-                select r.rank_no, r.member_id, r.nickname, r.tier, r.battle_rating
+                select r.rank_no, r.member_id, r.nickname, r.tier, r.battle_rating, r.battle_match_count, r.first_solved_problem_count
                 from ranked r
                 cross join me
                 where r.rank_no between me.rank_no - :radius and me.rank_no + :radius
@@ -181,21 +189,29 @@ public class RankingDashboardQueryRepository {
                         rs.getLong("member_id"),
                         rs.getString("nickname"),
                         rs.getString("tier"),
-                        getLong(rs, "battle_rating")));
+                        getLong(rs, "battle_rating"),
+                        getInt(rs, "battle_match_count"),
+                        getInt(rs, "first_solved_problem_count")));
     }
 
     public List<TierSourceRow> findTierSources() {
         String sql = """
                 select
                     mrp.tier,
-                    coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating
+                    coalesce(mrp.battle_rating, :defaultBattleRating) as battle_rating,
+                    coalesce(mrp.battle_match_count, 0) as battle_match_count,
+                    coalesce(mrp.first_solved_problem_count, 0) as first_solved_problem_count
                 from members m
                 left join member_rating_profiles mrp on mrp.member_id = m.id
                 """;
         return jdbcTemplate.query(
                 sql,
                 Map.of("defaultBattleRating", DEFAULT_BATTLE_RATING),
-                (rs, rowNum) -> new TierSourceRow(rs.getString("tier"), getLong(rs, "battle_rating")));
+                (rs, rowNum) -> new TierSourceRow(
+                        rs.getString("tier"),
+                        getLong(rs, "battle_rating"),
+                        getInt(rs, "battle_match_count"),
+                        getInt(rs, "first_solved_problem_count")));
     }
 
     public List<RankingDashboardResponse.TagStat> findTagStats(Long memberId) {
@@ -277,15 +293,30 @@ public class RankingDashboardQueryRepository {
     }
 
     public record MemberRankRow(
-            Long memberId, String nickname, String tier, long score, long battleRating, long rank, long totalCount) {}
+            Long memberId,
+            String nickname,
+            String tier,
+            long score,
+            long battleRating,
+            int battleMatchCount,
+            int firstSolvedProblemCount,
+            long rank,
+            long totalCount) {}
 
     public record BattleSummary(long battleMatchCount, int top2Rate, int top2SampleSize, long scoreDeltaTotal) {}
 
     public record BattleTrendRow(LocalDateTime occurredAt, long delta) {}
 
-    public record NearbyRankingRow(long rank, Long memberId, String nickname, String tier, long battleRating) {}
+    public record NearbyRankingRow(
+            long rank,
+            Long memberId,
+            String nickname,
+            String tier,
+            long battleRating,
+            int battleMatchCount,
+            int firstSolvedProblemCount) {}
 
-    public record TierSourceRow(String tier, long battleRating) {}
+    public record TierSourceRow(String tier, long battleRating, int battleMatchCount, int firstSolvedProblemCount) {}
 
     private record RecentBattleWindowRow(Integer finalRank, long scoreDelta) {}
 }

--- a/src/main/java/com/back/domain/ranking/dashboard/service/RankingDashboardService.java
+++ b/src/main/java/com/back/domain/ranking/dashboard/service/RankingDashboardService.java
@@ -20,6 +20,8 @@ import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryReposit
 import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryRepository.BattleTrendRow;
 import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryRepository.MemberRankRow;
 import com.back.domain.ranking.dashboard.repository.RankingDashboardQueryRepository.TierSourceRow;
+import com.back.domain.rating.policy.TierPolicy;
+import com.back.domain.rating.profile.entity.RatingTier;
 import com.back.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
@@ -29,41 +31,41 @@ import lombok.RequiredArgsConstructor;
 // 메인 홈 대시보드 응답을 조립하고 화면용 계산값을 보정한다.
 public class RankingDashboardService {
 
-    private static final int TREND_LIMIT = 7;
+    private static final int TREND_LIMIT = 20;
     private static final int TOP2_WINDOW_SIZE = 20;
     private static final int NEARBY_RANKING_RADIUS = 2;
 
     // 대시보드에서 쓰는 티어 컷 기준이다.
     private static final List<TierCut> TIER_CUTS = List.of(
-            new TierCut("BRONZE_5", 900),
-            new TierCut("BRONZE_4", 1060),
-            new TierCut("BRONZE_3", 1120),
-            new TierCut("BRONZE_2", 1180),
-            new TierCut("BRONZE_1", 1240),
-            new TierCut("SILVER_5", 1300),
-            new TierCut("SILVER_4", 1360),
-            new TierCut("SILVER_3", 1420),
-            new TierCut("SILVER_2", 1480),
-            new TierCut("SILVER_1", 1540),
-            new TierCut("GOLD_5", 1600),
-            new TierCut("GOLD_4", 1660),
-            new TierCut("GOLD_3", 1720),
-            new TierCut("GOLD_2", 1780),
-            new TierCut("GOLD_1", 1840),
-            new TierCut("PLATINUM_5", 1900),
-            new TierCut("PLATINUM_4", 1960),
-            new TierCut("PLATINUM_3", 2020),
-            new TierCut("PLATINUM_2", 2080),
-            new TierCut("PLATINUM_1", 2140),
-            new TierCut("DIAMOND_5", 2200),
-            new TierCut("DIAMOND_4", 2260),
-            new TierCut("DIAMOND_3", 2320),
-            new TierCut("DIAMOND_2", 2380),
-            new TierCut("DIAMOND_1", 2440),
-            new TierCut("MASTER_4", 2500),
-            new TierCut("MASTER_3", 2575),
-            new TierCut("MASTER_2", 2650),
-            new TierCut("MASTER_1", 2725),
+            new TierCut("BRONZE_5", 0),
+            new TierCut("BRONZE_4", 60),
+            new TierCut("BRONZE_3", 120),
+            new TierCut("BRONZE_2", 180),
+            new TierCut("BRONZE_1", 240),
+            new TierCut("SILVER_5", 300),
+            new TierCut("SILVER_4", 360),
+            new TierCut("SILVER_3", 420),
+            new TierCut("SILVER_2", 480),
+            new TierCut("SILVER_1", 540),
+            new TierCut("GOLD_5", 600),
+            new TierCut("GOLD_4", 660),
+            new TierCut("GOLD_3", 720),
+            new TierCut("GOLD_2", 780),
+            new TierCut("GOLD_1", 840),
+            new TierCut("PLATINUM_5", 900),
+            new TierCut("PLATINUM_4", 960),
+            new TierCut("PLATINUM_3", 1020),
+            new TierCut("PLATINUM_2", 1080),
+            new TierCut("PLATINUM_1", 1140),
+            new TierCut("DIAMOND_5", 1200),
+            new TierCut("DIAMOND_4", 1260),
+            new TierCut("DIAMOND_3", 1320),
+            new TierCut("DIAMOND_2", 1380),
+            new TierCut("DIAMOND_1", 1440),
+            new TierCut("MASTER_4", 1500),
+            new TierCut("MASTER_3", 1575),
+            new TierCut("MASTER_2", 1650),
+            new TierCut("MASTER_1", 1725),
             new TierCut("GOD", Long.MAX_VALUE));
 
     private final RankingDashboardQueryRepository queryRepository;
@@ -80,7 +82,8 @@ public class RankingDashboardService {
 
         LocalDateTime now = LocalDateTime.now();
         long battleRating = member.battleRating();
-        String currentTier = displayTier(member.tier(), battleRating);
+        String currentTier =
+                displayTier(member.tier(), member.battleMatchCount(), member.firstSolvedProblemCount(), battleRating);
         String nextTier = resolveNextTier(currentTier);
         BattleSummary battleSummary = queryRepository.findBattleSummary(memberId, TOP2_WINDOW_SIZE);
 
@@ -182,7 +185,8 @@ public class RankingDashboardService {
                         row.rank(),
                         row.memberId(),
                         row.nickname(),
-                        displayTier(row.tier(), row.battleRating()),
+                        displayTier(
+                                row.tier(), row.battleMatchCount(), row.firstSolvedProblemCount(), row.battleRating()),
                         row.battleRating(),
                         row.memberId().equals(memberId)))
                 .toList();
@@ -192,7 +196,10 @@ public class RankingDashboardService {
         List<TierSourceRow> rows = queryRepository.findTierSources();
         long totalCount = rows.size();
         Map<String, Long> tierCounts = new LinkedHashMap<>();
-        rows.forEach(row -> tierCounts.merge(displayTier(row.tier(), row.battleRating()), 1L, Long::sum));
+        rows.forEach(row -> tierCounts.merge(
+                displayTier(row.tier(), row.battleMatchCount(), row.firstSolvedProblemCount(), row.battleRating()),
+                1L,
+                Long::sum));
 
         return tierCounts.entrySet().stream()
                 .sorted(Comparator.comparingInt(entry -> tierOrder(entry.getKey())))
@@ -204,12 +211,21 @@ public class RankingDashboardService {
                 .toList();
     }
 
-    private String displayTier(String rawTier, long score) {
+    private String displayTier(String rawTier, int battleMatchCount, int firstSolvedProblemCount, long score) {
+        RatingTier parsedTier = null;
         if (rawTier != null && !rawTier.isBlank()) {
-            String normalizedTier = rawTier.trim();
-            if ("UNRANKED".equals(normalizedTier) || tierOrder(normalizedTier) >= 0) {
-                return normalizedTier;
+            try {
+                parsedTier = RatingTier.valueOf(rawTier.trim());
+            } catch (IllegalArgumentException ignored) {
+                parsedTier = null;
             }
+        }
+        String resolved = TierPolicy.resolveDisplayTier(parsedTier, battleMatchCount, firstSolvedProblemCount);
+        if (!"UNRANKED".equals(resolved)) {
+            return resolved;
+        }
+        if (battleMatchCount == 0 && firstSolvedProblemCount == 0) {
+            return "UNRANKED";
         }
         return deriveTierFromScore(score);
     }

--- a/src/main/java/com/back/domain/rating/policy/TierPolicy.java
+++ b/src/main/java/com/back/domain/rating/policy/TierPolicy.java
@@ -12,14 +12,13 @@ public final class TierPolicy {
     // 티어는 SR 기반 후보와 AP/난이도 게이트 상한을 동시에 만족해야 한다.
     public static RatingTier resolveTier(
             Integer skillRating,
-            Integer hardSkillRating,
             Integer activityPoint,
             long solved1400Plus,
             long solved1700Plus,
             long solved2000Plus,
             long solved2300Plus,
             double recentTop2Ratio) {
-        RatingTier srTier = resolveSkillTier(skillRating == null ? 1000 : skillRating);
+        RatingTier srTier = resolveSkillTier(skillRating == null ? 0 : skillRating);
         RatingTier gateTier = resolveGateTier(
                 activityPoint == null ? 0 : activityPoint,
                 solved1400Plus,
@@ -27,14 +26,9 @@ public final class TierPolicy {
                 solved2000Plus,
                 solved2300Plus,
                 recentTop2Ratio);
-        RatingTier hardTier = resolveHardTier(hardSkillRating == null ? 1000 : hardSkillRating);
 
         // 1) SR 컷라인 후보와 2) 활동/난이도 게이트 상한 중 더 낮은 쪽을 적용한다.
         RatingTier resolved = lowerTier(srTier, gateTier);
-        if (isAtLeast(resolved, RatingTier.DIAMOND_5)) {
-            // 다이아 이상은 Hard SR 컷라인을 추가로 통과해야 한다.
-            resolved = lowerTier(resolved, hardTier);
-        }
 
         if (resolved == RatingTier.GOD) {
             // GOD은 전역 TOP 좌석제로만 부여한다.
@@ -44,55 +38,40 @@ public final class TierPolicy {
     }
 
     private static RatingTier resolveSkillTier(int skillRating) {
-        if (skillRating >= 2725) return RatingTier.MASTER_1;
-        if (skillRating >= 2650) return RatingTier.MASTER_2;
-        if (skillRating >= 2575) return RatingTier.MASTER_3;
-        if (skillRating >= 2500) return RatingTier.MASTER_4;
+        if (skillRating >= 1725) return RatingTier.MASTER_1;
+        if (skillRating >= 1650) return RatingTier.MASTER_2;
+        if (skillRating >= 1575) return RatingTier.MASTER_3;
+        if (skillRating >= 1500) return RatingTier.MASTER_4;
 
-        if (skillRating >= 2440) return RatingTier.DIAMOND_1;
-        if (skillRating >= 2380) return RatingTier.DIAMOND_2;
-        if (skillRating >= 2320) return RatingTier.DIAMOND_3;
-        if (skillRating >= 2260) return RatingTier.DIAMOND_4;
-        if (skillRating >= 2200) return RatingTier.DIAMOND_5;
+        if (skillRating >= 1440) return RatingTier.DIAMOND_1;
+        if (skillRating >= 1380) return RatingTier.DIAMOND_2;
+        if (skillRating >= 1320) return RatingTier.DIAMOND_3;
+        if (skillRating >= 1260) return RatingTier.DIAMOND_4;
+        if (skillRating >= 1200) return RatingTier.DIAMOND_5;
 
-        if (skillRating >= 2140) return RatingTier.PLATINUM_1;
-        if (skillRating >= 2080) return RatingTier.PLATINUM_2;
-        if (skillRating >= 2020) return RatingTier.PLATINUM_3;
-        if (skillRating >= 1960) return RatingTier.PLATINUM_4;
-        if (skillRating >= 1900) return RatingTier.PLATINUM_5;
+        if (skillRating >= 1140) return RatingTier.PLATINUM_1;
+        if (skillRating >= 1080) return RatingTier.PLATINUM_2;
+        if (skillRating >= 1020) return RatingTier.PLATINUM_3;
+        if (skillRating >= 960) return RatingTier.PLATINUM_4;
+        if (skillRating >= 900) return RatingTier.PLATINUM_5;
 
-        if (skillRating >= 1840) return RatingTier.GOLD_1;
-        if (skillRating >= 1780) return RatingTier.GOLD_2;
-        if (skillRating >= 1720) return RatingTier.GOLD_3;
-        if (skillRating >= 1660) return RatingTier.GOLD_4;
-        if (skillRating >= 1600) return RatingTier.GOLD_5;
+        if (skillRating >= 840) return RatingTier.GOLD_1;
+        if (skillRating >= 780) return RatingTier.GOLD_2;
+        if (skillRating >= 720) return RatingTier.GOLD_3;
+        if (skillRating >= 660) return RatingTier.GOLD_4;
+        if (skillRating >= 600) return RatingTier.GOLD_5;
 
-        if (skillRating >= 1540) return RatingTier.SILVER_1;
-        if (skillRating >= 1480) return RatingTier.SILVER_2;
-        if (skillRating >= 1420) return RatingTier.SILVER_3;
-        if (skillRating >= 1360) return RatingTier.SILVER_4;
-        if (skillRating >= 1300) return RatingTier.SILVER_5;
+        if (skillRating >= 540) return RatingTier.SILVER_1;
+        if (skillRating >= 480) return RatingTier.SILVER_2;
+        if (skillRating >= 420) return RatingTier.SILVER_3;
+        if (skillRating >= 360) return RatingTier.SILVER_4;
+        if (skillRating >= 300) return RatingTier.SILVER_5;
 
-        if (skillRating >= 1240) return RatingTier.BRONZE_1;
-        if (skillRating >= 1180) return RatingTier.BRONZE_2;
-        if (skillRating >= 1120) return RatingTier.BRONZE_3;
-        if (skillRating >= 1060) return RatingTier.BRONZE_4;
+        if (skillRating >= 240) return RatingTier.BRONZE_1;
+        if (skillRating >= 180) return RatingTier.BRONZE_2;
+        if (skillRating >= 120) return RatingTier.BRONZE_3;
+        if (skillRating >= 60) return RatingTier.BRONZE_4;
         return RatingTier.BRONZE_5;
-    }
-
-    private static RatingTier resolveHardTier(int hardSkillRating) {
-        if (hardSkillRating >= 2725) return RatingTier.MASTER_1;
-        if (hardSkillRating >= 2650) return RatingTier.MASTER_2;
-        if (hardSkillRating >= 2575) return RatingTier.MASTER_3;
-        if (hardSkillRating >= 2500) return RatingTier.MASTER_4;
-
-        if (hardSkillRating >= 2440) return RatingTier.DIAMOND_1;
-        if (hardSkillRating >= 2380) return RatingTier.DIAMOND_2;
-        if (hardSkillRating >= 2320) return RatingTier.DIAMOND_3;
-        if (hardSkillRating >= 2260) return RatingTier.DIAMOND_4;
-        if (hardSkillRating >= 2200) return RatingTier.DIAMOND_5;
-
-        return RatingTier.PLATINUM_1;
     }
 
     private static RatingTier resolveGateTier(
@@ -126,10 +105,6 @@ public final class TierPolicy {
             return RatingTier.SILVER_1;
         }
         return RatingTier.BRONZE_1;
-    }
-
-    private static boolean isAtLeast(RatingTier current, RatingTier standard) {
-        return current.ordinal() >= standard.ordinal();
     }
 
     private static RatingTier lowerTier(RatingTier first, RatingTier second) {

--- a/src/main/java/com/back/domain/rating/profile/entity/MemberRatingProfile.java
+++ b/src/main/java/com/back/domain/rating/profile/entity/MemberRatingProfile.java
@@ -43,10 +43,6 @@ public class MemberRatingProfile extends BaseEntity {
     @Column(name = "battle_rating")
     private Integer battleRating;
 
-    // 하드 배틀(난이도 2000+) 전용 실력 지표(Hard SR)
-    @Column(name = "hard_battle_rating")
-    private Integer hardBattleRating;
-
     // 활동 점수(AP): 문제별 first-AC 난이도 누적 지표(솔로/배틀 공통)
     @Column(name = "first_solve_score")
     private Integer firstSolveScore;
@@ -70,10 +66,9 @@ public class MemberRatingProfile extends BaseEntity {
     public static MemberRatingProfile createDefault(Member member) {
         MemberRatingProfile ranking = new MemberRatingProfile();
         ranking.member = member;
-        ranking.battleRating = 1000;
-        ranking.hardBattleRating = 1000;
+        ranking.battleRating = 0;
         ranking.firstSolveScore = 0;
-        ranking.tierScore = 1000;
+        ranking.tierScore = 0;
         ranking.battleMatchCount = 0;
         ranking.firstSolvedProblemCount = 0;
         ranking.tier = RatingTier.BRONZE_5;
@@ -82,12 +77,7 @@ public class MemberRatingProfile extends BaseEntity {
 
     // null 안전 누적으로 SR 증감을 반영한다.
     public void applyBattleRatingDelta(int delta) {
-        this.battleRating = (this.battleRating == null ? 1000 : this.battleRating) + delta;
-    }
-
-    // null 안전 누적으로 Hard SR 증감을 반영한다.
-    public void applyHardBattleRatingDelta(int delta) {
-        this.hardBattleRating = (this.hardBattleRating == null ? 1000 : this.hardBattleRating) + delta;
+        this.battleRating = (this.battleRating == null ? 0 : this.battleRating) + delta;
     }
 
     // null 안전 누적으로 문제별 first-AC 난이도 점수를 반영한다.

--- a/src/main/java/com/back/domain/rating/profile/repository/MemberRatingProfileRepository.java
+++ b/src/main/java/com/back/domain/rating/profile/repository/MemberRatingProfileRepository.java
@@ -24,6 +24,6 @@ public interface MemberRatingProfileRepository extends JpaRepository<MemberRatin
     // 문제별 first-AC 난이도 누적 리더보드
     Page<MemberRatingProfile> findAllByOrderByFirstSolveScoreDescMemberIdAsc(Pageable pageable);
 
-    List<MemberRatingProfile> findAllByTierInOrderByHardBattleRatingDescBattleRatingDescMemberIdAsc(
+    List<MemberRatingProfile> findAllByTierInOrderByBattleRatingDescFirstSolveScoreDescMemberIdAsc(
             Collection<RatingTier> tiers);
 }

--- a/src/main/java/com/back/domain/rating/profile/service/RatingProfileService.java
+++ b/src/main/java/com/back/domain/rating/profile/service/RatingProfileService.java
@@ -28,16 +28,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RatingProfileService {
 
-    private static final int INITIAL_SKILL_RATING = 1000;
-    private static final int MIN_SKILL_RATING = 900;
-    private static final int PLACEMENT_BOOST_MATCH_COUNT = 20;
+    private static final int INITIAL_SKILL_RATING = 0;
+    private static final int MIN_SKILL_RATING = 0;
     private static final double ELO_BASE = 400.0d;
-    private static final int EARLY_K = 64;
+    private static final int PLACEMENT_STAGE_1_MATCH_COUNT = 2;
+    private static final int PLACEMENT_STAGE_2_MATCH_COUNT = 10;
+    private static final int PLACEMENT_STAGE_3_MATCH_COUNT = 30;
+    private static final int STAGE_1_K = 64;
+    private static final int STAGE_2_K = 48;
+    private static final int STAGE_3_K = 32;
     private static final int NORMAL_K = 24;
     private static final int MAX_DELTA_PER_MATCH = 35;
     private static final double EARLY_LOSS_REDUCTION_MULTIPLIER = 0.5d;
     private static final int LOSS_STREAK_ACTIVATION = 3;
     private static final int BRONZE_SILVER_LOSS_STREAK_DELTA_FLOOR = -12;
+    private static final int FORFEIT_PENALTY = -10;
+    private static final int THIRD_PLACE_MIN_REWARD = 1;
 
     // Codeforces rating(800~3500+) 기준으로 first solve 보너스를 10~20 사이로 축소한다.
     private static final int FIRST_SOLVE_BASE_RATING = 800;
@@ -45,7 +51,6 @@ public class RatingProfileService {
     private static final int FIRST_SOLVE_MIN_SCORE = 10;
     private static final int FIRST_SOLVE_MAX_SCORE = 20;
 
-    private static final int HARD_MATCH_DIFFICULTY = 2000;
     private static final int TOP2_WINDOW_SIZE = 20;
     private static final int GOD_SEAT_LIMIT = 5;
 
@@ -53,7 +58,11 @@ public class RatingProfileService {
     private final MemberProblemFirstSolveRepository memberProblemFirstSolveRepository;
     private final BattleParticipantRepository battleParticipantRepository;
 
-    public record BattlePlacement(Member member, int rank) {}
+    public record BattlePlacement(Member member, int rank, boolean forfeited) {
+        public BattlePlacement(Member member, int rank) {
+            this(member, rank, false);
+        }
+    }
 
     @Transactional
     public void ensureProfile(Member member) {
@@ -61,13 +70,19 @@ public class RatingProfileService {
     }
 
     @Transactional
-    public void applyBattlePlacements(List<BattlePlacement> placements, Integer problemDifficultyRating) {
+    public Map<Long, Integer> applyBattlePlacements(List<BattlePlacement> placements, Integer problemDifficultyRating) {
+        Map<Long, Integer> ratingDeltaByMemberId = new HashMap<>();
         if (placements == null || placements.isEmpty()) {
-            return;
+            return ratingDeltaByMemberId;
         }
         if (!isRankedDifficulty(problemDifficultyRating)) {
             // 원본 rating이 없거나 비정상인 문제는 랭크 정산 대상에서 제외한다.
-            return;
+            for (BattlePlacement placement : placements) {
+                if (placement.member() != null && placement.member().getId() != null) {
+                    ratingDeltaByMemberId.put(placement.member().getId(), 0);
+                }
+            }
+            return ratingDeltaByMemberId;
         }
 
         int participantCount = placements.size();
@@ -101,13 +116,12 @@ public class RatingProfileService {
             double expectedScore = calculateExpectedScore(memberId, myRating, skillSnapshot);
             double actualScore = calculateActualScore(placement.rank(), participantCount);
 
-            // 배치 구간(초반 20판)은 K를 크게 두어 강한 유저가 빠르게 제자리 티어로 수렴하게 한다.
             int matchCount = matchCountSnapshot.getOrDefault(memberId, 0);
-            int kFactor = matchCount < PLACEMENT_BOOST_MATCH_COUNT ? EARLY_K : NORMAL_K;
+            int kFactor = resolveKFactor(matchCount);
             double rawDelta = kFactor * (actualScore - expectedScore);
 
-            if (rawDelta < 0 && matchCount < PLACEMENT_BOOST_MATCH_COUNT) {
-                // 초반 배치 구간에서는 패배 하락폭을 절반으로 완화해 진입 장벽을 낮춘다.
+            if (rawDelta < 0 && matchCount < PLACEMENT_STAGE_2_MATCH_COUNT) {
+                // 초반 구간에서는 패배 하락폭을 절반으로 완화해 초보 진입 장벽을 낮춘다.
                 rawDelta *= EARLY_LOSS_REDUCTION_MULTIPLIER;
             } else if (rawDelta > 0) {
                 // 상승분에만 난이도/상대차 감쇠를 걸어 양학 인플레를 줄인다.
@@ -120,21 +134,23 @@ public class RatingProfileService {
             // 1판 변동 상한으로 급격한 오버슈팅/언더슈팅을 막는다.
             int delta = clamp((int) Math.round(rawDelta), -MAX_DELTA_PER_MATCH, MAX_DELTA_PER_MATCH);
             delta = applyBronzeSilverLossStreakProtection(memberId, profile, placement.rank(), delta);
+            if (!placement.forfeited() && placement.rank() == 3) {
+                // 3등은 최소 +1을 보장해 참여 동기를 유지한다.
+                delta = Math.max(delta, THIRD_PLACE_MIN_REWARD);
+            }
+            if (placement.forfeited()) {
+                delta += FORFEIT_PENALTY;
+            }
             int finalBattleDelta = applyRatingFloor(myRating, delta);
             profile.applyBattleRatingDelta(finalBattleDelta);
             profile.increaseBattleMatchCount();
 
-            // Hard SR은 하드 문제 배틀(2000+)에서만 별도 누적한다.
-            if (isHardMatch(problemDifficultyRating)) {
-                int currentHardRating = toSkillRating(profile.getHardBattleRating());
-                int finalHardDelta = applyRatingFloor(currentHardRating, delta);
-                profile.applyHardBattleRatingDelta(finalHardDelta);
-            }
-
             refreshTier(profile);
+            ratingDeltaByMemberId.put(memberId, finalBattleDelta);
         }
 
         synchronizeGodTop5();
+        return ratingDeltaByMemberId;
     }
 
     @Transactional
@@ -190,7 +206,6 @@ public class RatingProfileService {
     private void refreshTier(MemberRatingProfile profile) {
         Long memberId = profile.getMember().getId();
         int battleRating = toSkillRating(profile.getBattleRating());
-        int hardBattleRating = toSkillRating(profile.getHardBattleRating());
         int activityPoint = profile.getFirstSolveScore() == null ? 0 : profile.getFirstSolveScore();
         long solved1400Plus =
                 memberProblemFirstSolveRepository.countByMemberIdAndProblemDifficultyRatingGreaterThanEqual(
@@ -211,7 +226,6 @@ public class RatingProfileService {
         profile.updateTierScore(battleRating);
         profile.updateTier(TierPolicy.resolveTier(
                 battleRating,
-                hardBattleRating,
                 activityPoint,
                 solved1400Plus,
                 solved1700Plus,
@@ -220,10 +234,10 @@ public class RatingProfileService {
                 recentTop2Ratio));
     }
 
-    // GOD은 MASTER_1 후보군 중 Hard SR 상위 5명에게만 부여한다.
+    // GOD은 MASTER_1 후보군 중 SR 상위 5명에게만 부여한다.
     private void synchronizeGodTop5() {
         List<MemberRatingProfile> candidates =
-                memberRatingProfileRepository.findAllByTierInOrderByHardBattleRatingDescBattleRatingDescMemberIdAsc(
+                memberRatingProfileRepository.findAllByTierInOrderByBattleRatingDescFirstSolveScoreDescMemberIdAsc(
                         List.of(RatingTier.GOD, RatingTier.MASTER_1));
         if (candidates == null || candidates.isEmpty()) {
             return;
@@ -255,6 +269,13 @@ public class RatingProfileService {
 
     private int toSkillRating(Integer rawRating) {
         return rawRating == null ? INITIAL_SKILL_RATING : rawRating;
+    }
+
+    private int resolveKFactor(int matchCount) {
+        if (matchCount < PLACEMENT_STAGE_1_MATCH_COUNT) return STAGE_1_K;
+        if (matchCount < PLACEMENT_STAGE_2_MATCH_COUNT) return STAGE_2_K;
+        if (matchCount < PLACEMENT_STAGE_3_MATCH_COUNT) return STAGE_3_K;
+        return NORMAL_K;
     }
 
     private double calculateExpectedScore(Long memberId, int myRating, Map<Long, Integer> skillSnapshot) {
@@ -330,10 +351,6 @@ public class RatingProfileService {
         }
 
         return 0;
-    }
-
-    private boolean isHardMatch(Integer difficultyRating) {
-        return difficultyRating != null && difficultyRating >= HARD_MATCH_DIFFICULTY;
     }
 
     private boolean isRankedDifficulty(Integer difficultyRating) {

--- a/src/main/java/com/back/global/init/DatabaseIndexInitializer.java
+++ b/src/main/java/com/back/global/init/DatabaseIndexInitializer.java
@@ -31,10 +31,6 @@ public class DatabaseIndexInitializer {
                 ADD COLUMN IF NOT EXISTS first_solved_problem_count INTEGER
                 """);
         jdbcTemplate.execute("""
-                ALTER TABLE member_rating_profiles
-                ADD COLUMN IF NOT EXISTS hard_battle_rating INTEGER
-                """);
-        jdbcTemplate.execute("""
                 DO $$
                 BEGIN
                     IF EXISTS (
@@ -50,32 +46,19 @@ public class DatabaseIndexInitializer {
                     END IF;
                 END $$;
                 """);
-        // 새 레이팅 체계 기본값: SR/Hard SR 기본점을 1000으로 맞춘다.
+        // 새 레이팅 체계 기본값: SR/AP는 0점에서 시작한다.
         jdbcTemplate.execute("""
                 UPDATE member_rating_profiles
                 SET battle_rating = CASE
-                    WHEN battle_rating IS NULL OR battle_rating = 0 THEN 1000
+                    WHEN battle_rating IS NULL THEN 0
                     ELSE battle_rating
                 END
                 """);
         jdbcTemplate.execute("""
                 UPDATE member_rating_profiles
-                SET hard_battle_rating = COALESCE(
-                    hard_battle_rating,
-                    CASE
-                        WHEN battle_rating IS NULL OR battle_rating = 0 THEN 1000
-                        ELSE battle_rating
-                    END
-                )
-                """);
-        jdbcTemplate.execute("""
-                UPDATE member_rating_profiles
                 SET tier_score = COALESCE(
                     tier_score,
-                    CASE
-                        WHEN battle_rating IS NULL OR battle_rating = 0 THEN 1000
-                        ELSE battle_rating
-                    END
+                    COALESCE(battle_rating, 0)
                 )
                 """);
         jdbcTemplate.execute("""
@@ -112,8 +95,7 @@ public class DatabaseIndexInitializer {
                 ON member_rating_profiles (battle_rating DESC, member_id ASC)
                 """);
         jdbcTemplate.execute("""
-                CREATE INDEX IF NOT EXISTS idx_member_rating_profiles_hard_battle_rating
-                ON member_rating_profiles (hard_battle_rating DESC, member_id ASC)
+                DROP INDEX IF EXISTS idx_member_rating_profiles_hard_battle_rating
                 """);
         jdbcTemplate.execute("""
                 CREATE INDEX IF NOT EXISTS idx_member_rating_profiles_first_solve_score
@@ -128,7 +110,7 @@ public class DatabaseIndexInitializer {
                 ON member_problem_first_solves (first_solved_at DESC)
                 """);
         log.info("DB index 확인 완료 - uq_one_playing_per_member, idx_member_rating_profiles_tier_score,"
-                + " idx_member_rating_profiles_battle_rating, idx_member_rating_profiles_hard_battle_rating,"
+                + " idx_member_rating_profiles_battle_rating,"
                 + " idx_member_rating_profiles_first_solve_score, idx_mpfs_member_id, idx_mpfs_first_solved_at");
     }
 }

--- a/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -187,11 +188,12 @@ class BattleResultServiceTest {
         when(participant.getId()).thenReturn(11L);
         when(participant.getStatus()).thenReturn(BattleParticipantStatus.ABANDONED);
         when(participant.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(101L);
+        when(ratingProfileService.applyBattlePlacements(any(), eq(1200))).thenReturn(Map.of(101L, -10));
 
         withAfterCommit(() -> battleResultService.settle(1L));
 
-        verify(participant).applyResult(1, -5L);
-        verify(member).applyScore(-5L);
+        verify(participant).applyResult(1, -10L);
         verify(participant, never()).timeout();
     }
 
@@ -211,11 +213,12 @@ class BattleResultServiceTest {
         when(participant.getId()).thenReturn(22L);
         when(participant.getStatus()).thenReturn(BattleParticipantStatus.QUIT);
         when(participant.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(202L);
+        when(ratingProfileService.applyBattlePlacements(any(), eq(1200))).thenReturn(Map.of(202L, -10));
 
         withAfterCommit(() -> battleResultService.settle(2L));
 
-        verify(participant).applyResult(1, -5L);
-        verify(member).applyScore(-5L);
+        verify(participant).applyResult(1, -10L);
     }
 
     private void withAfterCommit(Runnable action) {

--- a/src/test/java/com/back/domain/ranking/dashboard/controller/RankingDashboardControllerTest.java
+++ b/src/test/java/com/back/domain/ranking/dashboard/controller/RankingDashboardControllerTest.java
@@ -91,7 +91,7 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.profile.tier").value("SILVER_1"))
                 .andExpect(jsonPath("$.profile.rank").value(3))
                 .andExpect(jsonPath("$.profile.percentile").value(60.0))
-                .andExpect(jsonPath("$.profile.score").value(40))
+                .andExpect(jsonPath("$.profile.score").value(1580))
                 .andExpect(jsonPath("$.profile.battleRating").value(1580))
                 .andExpect(jsonPath("$.profile.nextTier").value("GOLD_5"))
                 .andExpect(jsonPath("$.profile.battleMatchCount").value(2))
@@ -107,7 +107,7 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.scoreTrend[1].delta").value(-5))
                 .andExpect(jsonPath("$.gateProgress[0].key").value("SCORE"))
                 .andExpect(jsonPath("$.gateProgress[0].current").value(1580))
-                .andExpect(jsonPath("$.gateProgress[0].target").value(1600))
+                .andExpect(jsonPath("$.gateProgress[0].target").value(600))
                 .andExpect(jsonPath("$.gateProgress[1].key").value("SOLVED_1400"))
                 .andExpect(jsonPath("$.gateProgress[1].current").value(2))
                 .andExpect(jsonPath("$.gateProgress[1].target").value(12))
@@ -141,24 +141,24 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").doesNotExist())
                 .andExpect(jsonPath("$.profile.memberId").value(me))
-                .andExpect(jsonPath("$.profile.tier").value("BRONZE_5"))
+                .andExpect(jsonPath("$.profile.tier").value("UNRANKED"))
                 .andExpect(jsonPath("$.profile.rank").value(1))
                 .andExpect(jsonPath("$.profile.percentile").value(100.0))
                 .andExpect(jsonPath("$.profile.score").value(0))
-                .andExpect(jsonPath("$.profile.battleRating").value(1000))
+                .andExpect(jsonPath("$.profile.battleRating").value(0))
                 .andExpect(jsonPath("$.profile.battleMatchCount").value(0))
                 .andExpect(jsonPath("$.profile.top2Rate").value(0))
                 .andExpect(jsonPath("$.profile.top2SampleSize").value(0))
                 .andExpect(jsonPath("$.scoreTrend", hasSize(1)))
                 .andExpect(jsonPath("$.scoreTrend[0].label").value("NOW"))
-                .andExpect(jsonPath("$.scoreTrend[0].score").value(1000))
+                .andExpect(jsonPath("$.scoreTrend[0].score").value(0))
                 .andExpect(jsonPath("$.scoreTrend[0].delta").value(0))
                 .andExpect(jsonPath("$.gateProgress[0].key").value("SCORE"))
-                .andExpect(jsonPath("$.gateProgress[0].current").value(1000))
-                .andExpect(jsonPath("$.gateProgress[0].target").value(1060))
+                .andExpect(jsonPath("$.gateProgress[0].current").value(0))
+                .andExpect(jsonPath("$.gateProgress[0].target").value(0))
                 .andExpect(jsonPath("$.nearbyRanking", hasSize(1)))
                 .andExpect(jsonPath("$.nearbyRanking[0].isMe").value(true))
-                .andExpect(jsonPath("$.tierDistribution[0].tier").value("BRONZE_5"))
+                .andExpect(jsonPath("$.tierDistribution[0].tier").value("UNRANKED"))
                 .andExpect(jsonPath("$.tierDistribution[0].isMyTier").value(true))
                 .andExpect(jsonPath("$.tagStats", hasSize(0)))
                 .andExpect(jsonPath("$.reviewSummary.dueTodayCount").value(0))
@@ -181,10 +181,10 @@ class RankingDashboardControllerTest extends IntegrationTestBase {
     private void insertMemberRatingProfile(Long memberId, int battleRating, String tier) {
         jdbcTemplate.update("""
                 insert into member_rating_profiles (
-                    id, member_id, battle_rating, hard_battle_rating, first_solve_score,
+                    id, member_id, battle_rating, first_solve_score,
                     tier_score, battle_match_count, first_solved_problem_count, tier, created_at
                 )
-                values (nextval('member_rating_profile_id_seq'), ?, ?, 1000, 0, ?, 0, 0, ?, now())
+                values (nextval('member_rating_profile_id_seq'), ?, ?, 0, ?, 1, 1, ?, now())
                 """, memberId, battleRating, battleRating, tier);
     }
 

--- a/src/test/java/com/back/domain/rating/policy/TierPolicyTest.java
+++ b/src/test/java/com/back/domain/rating/policy/TierPolicyTest.java
@@ -12,23 +12,23 @@ class TierPolicyTest {
     @Test
     @DisplayName("SR은 높아도 AP 게이트를 못 넘으면 티어가 제한된다")
     void resolveTier_cappedByGate() {
-        RatingTier tier = TierPolicy.resolveTier(2500, 2500, 0, 0, 0, 0, 0, 0.0d);
+        RatingTier tier = TierPolicy.resolveTier(1500, 0, 0, 0, 0, 0, 0.0d);
 
         assertThat(tier).isEqualTo(RatingTier.BRONZE_1);
     }
 
     @Test
-    @DisplayName("다이아 이상은 Hard SR을 만족하지 못하면 플래티넘으로 제한된다")
-    void resolveTier_cappedByHardRating() {
-        RatingTier tier = TierPolicy.resolveTier(2400, 2000, 2000, 20, 20, 30, 10, 0.8d);
+    @DisplayName("다이아 게이트를 만족하면 SR 컷과 함께 다이아 티어를 계산한다")
+    void resolveTier_diamondBySkillAndGate() {
+        RatingTier tier = TierPolicy.resolveTier(1500, 1300, 30, 20, 30, 8, 0.6d);
 
-        assertThat(tier).isEqualTo(RatingTier.PLATINUM_1);
+        assertThat(tier).isEqualTo(RatingTier.DIAMOND_1);
     }
 
     @Test
     @DisplayName("SR/AP/난이도/최근폼을 모두 만족하면 MASTER_1을 계산한다")
     void resolveTier_masterByAllConditions() {
-        RatingTier tier = TierPolicy.resolveTier(2750, 2750, 2500, 50, 30, 70, 20, 0.7d);
+        RatingTier tier = TierPolicy.resolveTier(1800, 2500, 50, 30, 70, 20, 0.7d);
 
         assertThat(tier).isEqualTo(RatingTier.MASTER_1);
     }
@@ -36,7 +36,7 @@ class TierPolicyTest {
     @Test
     @DisplayName("입력값이 null이어도 안전하게 BRONZE_5를 반환한다")
     void resolveTier_whenNull_returnsBronze5() {
-        assertThat(TierPolicy.resolveTier(null, null, null, 0, 0, 0, 0, 0.0d)).isEqualTo(RatingTier.BRONZE_5);
+        assertThat(TierPolicy.resolveTier(null, null, 0, 0, 0, 0, 0.0d)).isEqualTo(RatingTier.BRONZE_5);
     }
 
     @Test

--- a/src/test/java/com/back/domain/rating/profile/service/RatingProfileServiceTest.java
+++ b/src/test/java/com/back/domain/rating/profile/service/RatingProfileServiceTest.java
@@ -58,6 +58,7 @@ class RatingProfileServiceTest {
 
         MemberRatingProfile winnerProfile = MemberRatingProfile.createDefault(winner);
         MemberRatingProfile loserProfile = MemberRatingProfile.createDefault(loser);
+        loserProfile.applyBattleRatingDelta(200);
 
         when(memberRatingProfileRepository.findByMemberId(1L)).thenReturn(Optional.of(winnerProfile));
         when(memberRatingProfileRepository.findByMemberId(2L)).thenReturn(Optional.of(loserProfile));
@@ -72,19 +73,20 @@ class RatingProfileServiceTest {
 
         assertThat(winnerProfile.getBattleMatchCount()).isEqualTo(1);
         assertThat(loserProfile.getBattleMatchCount()).isEqualTo(1);
-        assertThat(winnerProfile.getBattleRating()).isGreaterThan(1000);
-        assertThat(loserProfile.getBattleRating()).isLessThan(1000);
-        assertThat(winnerProfile.getHardBattleRating()).isGreaterThan(1000);
+        assertThat(winnerProfile.getBattleRating()).isGreaterThan(0);
+        assertThat(loserProfile.getBattleRating()).isLessThan(200);
     }
 
     @Test
-    @DisplayName("배치 구간(초반 20판) 패배는 하락폭을 절반으로 완화한다")
+    @DisplayName("배치 초반 구간 패배는 하락폭을 절반으로 완화한다")
     void applyBattlePlacements_reducesLossDuringPlacementMatches() {
         Member winner = Member.of(11L, "placement-winner@example.com", "placement-winner");
         Member loser = Member.of(12L, "placement-loser@example.com", "placement-loser");
 
         MemberRatingProfile winnerProfile = MemberRatingProfile.createDefault(winner);
         MemberRatingProfile loserProfile = MemberRatingProfile.createDefault(loser);
+        winnerProfile.applyBattleRatingDelta(300);
+        loserProfile.applyBattleRatingDelta(300);
 
         when(memberRatingProfileRepository.findByMemberId(11L)).thenReturn(Optional.of(winnerProfile));
         when(memberRatingProfileRepository.findByMemberId(12L)).thenReturn(Optional.of(loserProfile));
@@ -98,7 +100,69 @@ class RatingProfileServiceTest {
                 2000);
 
         // 기본 Elo 하락폭(-32)에 비해 배치 구간 완화(50%)가 적용되어 -16으로 반영된다.
-        assertThat(loserProfile.getBattleRating()).isEqualTo(984);
+        assertThat(loserProfile.getBattleRating()).isEqualTo(284);
+    }
+
+    @Test
+    @DisplayName("3등은 최소 +1 SR을 보장한다")
+    void applyBattlePlacements_thirdPlaceGetsAtLeastOnePoint() {
+        Member first = Member.of(101L, "first@example.com", "first");
+        Member second = Member.of(102L, "second@example.com", "second");
+        Member third = Member.of(103L, "third@example.com", "third");
+        Member fourth = Member.of(104L, "fourth@example.com", "fourth");
+
+        MemberRatingProfile firstProfile = MemberRatingProfile.createDefault(first);
+        MemberRatingProfile secondProfile = MemberRatingProfile.createDefault(second);
+        MemberRatingProfile thirdProfile = MemberRatingProfile.createDefault(third);
+        MemberRatingProfile fourthProfile = MemberRatingProfile.createDefault(fourth);
+        firstProfile.applyBattleRatingDelta(300);
+        secondProfile.applyBattleRatingDelta(300);
+        thirdProfile.applyBattleRatingDelta(300);
+        fourthProfile.applyBattleRatingDelta(300);
+
+        when(memberRatingProfileRepository.findByMemberId(101L)).thenReturn(Optional.of(firstProfile));
+        when(memberRatingProfileRepository.findByMemberId(102L)).thenReturn(Optional.of(secondProfile));
+        when(memberRatingProfileRepository.findByMemberId(103L)).thenReturn(Optional.of(thirdProfile));
+        when(memberRatingProfileRepository.findByMemberId(104L)).thenReturn(Optional.of(fourthProfile));
+        when(battleParticipantRepository.findRecentFinalRanksByMemberId(anyLong(), any(Pageable.class)))
+                .thenReturn(List.of(1, 2, 3, 4));
+
+        var deltas = ratingProfileService.applyBattlePlacements(
+                List.of(
+                        new RatingProfileService.BattlePlacement(first, 1, false),
+                        new RatingProfileService.BattlePlacement(second, 2, false),
+                        new RatingProfileService.BattlePlacement(third, 3, false),
+                        new RatingProfileService.BattlePlacement(fourth, 4, false)),
+                2000);
+
+        assertThat(deltas.get(103L)).isEqualTo(1);
+        assertThat(thirdProfile.getBattleRating()).isEqualTo(301);
+    }
+
+    @Test
+    @DisplayName("포기(QUIT/ABANDONED)는 Elo 결과에 추가 -10 패널티를 적용한다")
+    void applyBattlePlacements_forfeitAppliesAdditionalPenalty() {
+        Member winner = Member.of(111L, "winner-forfeit@example.com", "winner-forfeit");
+        Member quitter = Member.of(112L, "quitter@example.com", "quitter");
+
+        MemberRatingProfile winnerProfile = MemberRatingProfile.createDefault(winner);
+        MemberRatingProfile quitterProfile = MemberRatingProfile.createDefault(quitter);
+        winnerProfile.applyBattleRatingDelta(300);
+        quitterProfile.applyBattleRatingDelta(300);
+
+        when(memberRatingProfileRepository.findByMemberId(111L)).thenReturn(Optional.of(winnerProfile));
+        when(memberRatingProfileRepository.findByMemberId(112L)).thenReturn(Optional.of(quitterProfile));
+        when(battleParticipantRepository.findRecentFinalRanksByMemberId(anyLong(), any(Pageable.class)))
+                .thenReturn(List.of(1, 2));
+
+        var deltas = ratingProfileService.applyBattlePlacements(
+                List.of(
+                        new RatingProfileService.BattlePlacement(winner, 1, false),
+                        new RatingProfileService.BattlePlacement(quitter, 2, true)),
+                2000);
+
+        assertThat(deltas.get(112L)).isEqualTo(-26);
+        assertThat(quitterProfile.getBattleRating()).isEqualTo(274);
     }
 
     @Test
@@ -121,6 +185,14 @@ class RatingProfileServiceTest {
         MemberRatingProfile gold2Profile = MemberRatingProfile.createDefault(gold2);
         MemberRatingProfile gold3Profile = MemberRatingProfile.createDefault(gold3);
         MemberRatingProfile goldLoserProfile = MemberRatingProfile.createDefault(goldLoser);
+        silver1Profile.applyBattleRatingDelta(300);
+        silver2Profile.applyBattleRatingDelta(300);
+        silver3Profile.applyBattleRatingDelta(300);
+        silverLoserProfile.applyBattleRatingDelta(300);
+        gold1Profile.applyBattleRatingDelta(300);
+        gold2Profile.applyBattleRatingDelta(300);
+        gold3Profile.applyBattleRatingDelta(300);
+        goldLoserProfile.applyBattleRatingDelta(300);
         goldLoserProfile.updateTier(RatingTier.GOLD_5);
 
         when(memberRatingProfileRepository.findByMemberId(21L)).thenReturn(Optional.of(silver1Profile));
@@ -150,21 +222,20 @@ class RatingProfileServiceTest {
                 2000);
 
         // 브론즈/실버는 3연패 이상에서 하락폭이 -12 바닥으로 보호된다.
-        assertThat(silverLoserProfile.getBattleRating()).isEqualTo(988);
+        assertThat(silverLoserProfile.getBattleRating()).isEqualTo(288);
         // 골드 이상은 같은 조건에서도 보호 로직이 적용되지 않는다.
-        assertThat(goldLoserProfile.getBattleRating()).isEqualTo(984);
+        assertThat(goldLoserProfile.getBattleRating()).isEqualTo(284);
     }
 
     @Test
-    @DisplayName("SR은 최소 900 바닥을 유지해 추가 하락을 막는다")
+    @DisplayName("SR은 최소 0 바닥을 유지해 추가 하락을 막는다")
     void applyBattlePlacements_appliesSkillRatingFloor() {
         Member winner = Member.of(41L, "floor-winner@example.com", "floor-winner");
         Member floorMember = Member.of(42L, "floor-member@example.com", "floor-member");
 
         MemberRatingProfile winnerProfile = MemberRatingProfile.createDefault(winner);
         MemberRatingProfile floorProfile = MemberRatingProfile.createDefault(floorMember);
-        floorProfile.applyBattleRatingDelta(-100);
-        floorProfile.applyHardBattleRatingDelta(-100);
+        floorProfile.applyBattleRatingDelta(5);
         floorProfile.updateTier(RatingTier.GOLD_5);
         for (int i = 0; i < 30; i++) {
             floorProfile.increaseBattleMatchCount();
@@ -181,8 +252,7 @@ class RatingProfileServiceTest {
                         new RatingProfileService.BattlePlacement(floorMember, 2)),
                 2200);
 
-        assertThat(floorProfile.getBattleRating()).isEqualTo(900);
-        assertThat(floorProfile.getHardBattleRating()).isEqualTo(900);
+        assertThat(floorProfile.getBattleRating()).isEqualTo(0);
     }
 
     @Test
@@ -208,7 +278,7 @@ class RatingProfileServiceTest {
         assertThat(applied).isTrue();
         assertThat(profile.getFirstSolveScore()).isEqualTo(15);
         assertThat(profile.getFirstSolvedProblemCount()).isEqualTo(1);
-        assertThat(profile.getTierScore()).isEqualTo(1000);
+        assertThat(profile.getTierScore()).isEqualTo(0);
         assertThat(profile.getTier().name()).isEqualTo("BRONZE_5");
     }
 
@@ -235,7 +305,7 @@ class RatingProfileServiceTest {
         assertThat(applied).isTrue();
         assertThat(profile.getFirstSolveScore()).isEqualTo(14);
         assertThat(profile.getFirstSolvedProblemCount()).isEqualTo(1);
-        assertThat(profile.getTierScore()).isEqualTo(1000);
+        assertThat(profile.getTierScore()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
## 작업 개요
점수 체계를 SR/AP 2축으로 정리하고, 배틀 정산/티어 진행도/랭킹 대시보드가 동일한 기준을 사용하도록 백엔드를 정합화했습니다.

## 주요 변경
### 1) SR/AP 점수 체계 및 배틀 정산 연동
- 배틀 결과 정산 로직을 SR/AP 정책과 일치하도록 정비
- 티어 정책(TierPolicy) 기준 반영
- 레이팅 프로필 기본값/초기화 흐름 정리
- 관련 단위 테스트 보강

### 2) 대시보드/진행도 SR 기준 정합성 개선
- `RatingProgressResponse`에서 `hardBattleRating` 제거
- `MemberRatingProgressService`를 SR 0점 시작 기준으로 조정
- GOD 좌석 계산 기준을 Hard SR이 아닌 SR 기반으로 정리
- 랭킹 대시보드 조회/서비스에서 battle_rating 중심으로 일관화
- 대시보드 트렌드 조회 개수 확장(7 -> 20)
- 관련 컨트롤러 테스트 업데이트

## 커밋
- `6c0f5df` refactor: SR/AP 점수 체계 개편 및 배틀 정산 연동
- `f6107f8` refactor: 대시보드 및 티어 진행도 SR 기준 정합성 개선

## 검증
- `./gradlew test --tests com.back.domain.rating.profile.service.RatingProfileServiceTest --tests com.back.domain.battle.result.service.BattleResultServiceTest --tests com.back.domain.rating.policy.TierPolicyTest`
- `./gradlew test --tests com.back.domain.ranking.dashboard.controller.RankingDashboardControllerTest`

## 참고
프론트 표시값과 백엔드 응답 정합성은 후속 프론트 PR에서 함께 맞추는 것을 권장합니다.
