### PR TITLE
[feat] 마이페이지 풀이 잔디 히트맵 조회 API 추가

### DIFF
--- a/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
+++ b/src/main/java/com/back/domain/battle/battleparticipant/repository/BattleParticipantRepository.java
@@ -1,5 +1,6 @@
 package com.back.domain.battle.battleparticipant.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -142,4 +143,17 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
             """)
     // 최근 Top2 비율 산정용: 최신 순으로 finalRank만 가볍게 조회한다.
     List<Integer> findRecentFinalRanksByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    // 잔디 히트맵용: 같은 문제를 여러 방에서 풀어도 최초 solve 시각 1건만 집계한다.
+    @Query("""
+            select min(bp.finishTime)
+            from BattleParticipant bp
+            join bp.battleRoom br
+            where bp.member.id = :memberId
+              and bp.status = :status
+              and br.problem is not null
+            group by br.problem.id
+            """)
+    List<LocalDateTime> findFirstSolvedAtByMemberIdAndStatus(
+            @Param("memberId") Long memberId, @Param("status") BattleParticipantStatus status);
 }

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -1,6 +1,11 @@
 package com.back.domain.member.member.controller;
 
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.back.domain.battle.result.dto.MyBattleResultsResponse;
 import com.back.domain.battle.result.service.BattleResultService;
@@ -9,9 +14,11 @@ import com.back.domain.member.member.dto.LoginRequest;
 import com.back.domain.member.member.dto.LoginTokens;
 import com.back.domain.member.member.dto.MyInfoResponse;
 import com.back.domain.member.member.dto.RatingProgressResponse;
+import com.back.domain.member.member.dto.SolveHeatmapResponse;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberRatingProgressService;
 import com.back.domain.member.member.service.MemberService;
+import com.back.domain.member.member.service.MemberSolveHeatmapService;
 import com.back.global.exception.ServiceException;
 import com.back.global.jwt.RefreshTokenService;
 import com.back.global.rq.Rq;
@@ -26,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
     private final MemberService memberService;
     private final MemberRatingProgressService memberRatingProgressService;
+    private final MemberSolveHeatmapService memberSolveHeatmapService;
     private final BattleResultService battleResultService;
     private final RefreshTokenService refreshTokenService;
     private final Rq rq;
@@ -104,5 +112,16 @@ public class MemberController {
         }
 
         return memberRatingProgressService.getMyRatingProgress(actor.getId());
+    }
+
+    // 내 풀이 잔디 조회
+    @GetMapping("/me/solve-heatmap")
+    public RsData<SolveHeatmapResponse> getMySolveHeatmap(@RequestParam(required = false) Integer year) {
+        Member actor = rq.getActor();
+        if (actor == null || actor.getId() == null) {
+            throw new ServiceException("MEMBER_401", "로그인이 필요합니다");
+        }
+
+        return memberSolveHeatmapService.getMySolveHeatmap(actor.getId(), year);
     }
 }

--- a/src/main/java/com/back/domain/member/member/dto/SolveHeatmapResponse.java
+++ b/src/main/java/com/back/domain/member/member/dto/SolveHeatmapResponse.java
@@ -1,0 +1,29 @@
+package com.back.domain.member.member.dto;
+
+import java.util.List;
+
+// 마이페이지 잔디 히트맵을 그리기 위한 최종 응답 DTO
+public record SolveHeatmapResponse(
+        int year,
+        List<Integer> availableYears,
+        int totalSolvedCount,
+        int maxDailySolvedCount,
+        List<MonthLabel> monthLabels,
+        List<Week> weeks) {
+
+    // 각 월 라벨이 몇 번째 주 컬럼부터 시작하는지 알려준다.
+    public record MonthLabel(int month, String label, int weekIndex) {}
+
+    // 프론트는 weeks -> days 구조를 그대로 순회해서 잔디 그리드를 그리면 된다.
+    public record Week(String weekStartDate, List<Day> days) {}
+
+    // 셀 하나에 필요한 카운트/색상/툴팁 정보를 모두 담는다.
+    public record Day(
+            String date,
+            int soloSolvedCount,
+            int battleSolvedCount,
+            int totalSolvedCount,
+            int level,
+            boolean inSelectedYear,
+            boolean isToday) {}
+}

--- a/src/main/java/com/back/domain/member/member/service/MemberSolveHeatmapService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberSolveHeatmapService.java
@@ -1,0 +1,238 @@
+package com.back.domain.member.member.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.springframework.stereotype.Service;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.member.member.dto.SolveHeatmapResponse;
+import com.back.domain.problem.solo.submission.repository.SoloSubmissionRepository;
+import com.back.domain.problem.submission.entity.SubmissionResult;
+import com.back.global.exception.ServiceException;
+import com.back.global.rsData.RsData;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberSolveHeatmapService {
+
+    // 잔디 그리드는 GitHub 스타일에 맞춰 일요일 시작, 토요일 종료로 계산한다.
+    private static final DayOfWeek WEEK_START = DayOfWeek.SUNDAY;
+    private static final DayOfWeek WEEK_END = DayOfWeek.SATURDAY;
+
+    private final SoloSubmissionRepository soloSubmissionRepository;
+    private final BattleParticipantRepository battleParticipantRepository;
+
+    // 사용자의 특정 연도 잔디 데이터를 계산해서 프론트가 바로 그릴 수 있는 형태로 반환한다.
+    public RsData<SolveHeatmapResponse> getMySolveHeatmap(Long memberId, Integer year) {
+        if (memberId == null || memberId <= 0) {
+            throw new ServiceException("MEMBER_400", "유효한 회원 ID가 필요합니다.");
+        }
+
+        int selectedYear = resolveYear(year);
+        // 날짜별로 solo/battle 카운트를 누적할 맵이다.
+        Map<LocalDate, DailySolveCount> countsByDate = new TreeMap<>();
+        // 잔디에서 이동 가능한 연도 목록도 같이 만든다.
+        NavigableSet<Integer> availableYears = new TreeSet<>(Comparator.reverseOrder());
+
+        // solo는 문제별 최초 AC 1건만 가져와서 날짜별 카운트에 반영한다.
+        mergeSolveDates(
+                countsByDate,
+                availableYears,
+                soloSubmissionRepository.findFirstAcTimesByMemberIdAndResult(memberId, SubmissionResult.AC),
+                SolveMode.SOLO);
+        // battle도 문제별 최초 solve 1건만 가져와서 별도 카운트한다.
+        mergeSolveDates(
+                countsByDate,
+                availableYears,
+                battleParticipantRepository.findFirstSolvedAtByMemberIdAndStatus(
+                        memberId, BattleParticipantStatus.SOLVED),
+                SolveMode.BATTLE);
+
+        // 선택 연도에 데이터가 없어도 빈 잔디를 보여주기 위해 목록에는 넣어둔다.
+        availableYears.add(selectedYear);
+
+        // 선택 연도 안의 totalSolvedCount만 합산해서 상단 요약값을 만든다.
+        int totalSolvedCount = countsByDate.entrySet().stream()
+                .filter(entry -> entry.getKey().getYear() == selectedYear)
+                .mapToInt(entry -> entry.getValue().totalSolvedCount())
+                .sum();
+
+        // 선택 연도에서 가장 많이 푼 하루의 개수. 상대 레벨 계산에 사용한다.
+        int maxDailySolvedCount = countsByDate.entrySet().stream()
+                .filter(entry -> entry.getKey().getYear() == selectedYear)
+                .mapToInt(entry -> entry.getValue().totalSolvedCount())
+                .max()
+                .orElse(0);
+
+        LocalDate today = LocalDate.now();
+        LocalDate firstDayOfYear = LocalDate.of(selectedYear, 1, 1);
+        LocalDate lastDayOfYear = LocalDate.of(selectedYear, 12, 31);
+        // 1월 1일이 주중에 있어도 앞쪽 패딩 칸을 포함해 시작 주를 맞춘다.
+        LocalDate gridStart = firstDayOfYear.with(TemporalAdjusters.previousOrSame(WEEK_START));
+        // 12월 31일도 마지막 주 끝까지 패딩 칸을 포함한다.
+        LocalDate gridEnd = lastDayOfYear.with(TemporalAdjusters.nextOrSame(WEEK_END));
+
+        SolveHeatmapResponse response = new SolveHeatmapResponse(
+                selectedYear,
+                List.copyOf(availableYears),
+                totalSolvedCount,
+                maxDailySolvedCount,
+                buildMonthLabels(selectedYear, gridStart),
+                buildWeeks(gridStart, gridEnd, selectedYear, today, countsByDate, maxDailySolvedCount));
+
+        return RsData.of("200", "풀이 잔디 조회 성공", response);
+    }
+
+    // year 파라미터가 없으면 현재 연도를 기본값으로 사용한다.
+    private int resolveYear(Integer year) {
+        int resolvedYear = year != null ? year : LocalDate.now().getYear();
+        if (resolvedYear < 1 || resolvedYear > 9999) {
+            throw new ServiceException("MEMBER_400", "유효한 year 값이 필요합니다.");
+        }
+        return resolvedYear;
+    }
+
+    // 최초 풀이 시각 목록을 받아 날짜별 잔디 카운트로 합친다.
+    private void mergeSolveDates(
+            Map<LocalDate, DailySolveCount> countsByDate,
+            NavigableSet<Integer> availableYears,
+            List<LocalDateTime> dateTimes,
+            SolveMode solveMode) {
+        if (dateTimes == null) {
+            return;
+        }
+
+        for (LocalDateTime dateTime : dateTimes) {
+            if (dateTime == null) {
+                continue;
+            }
+
+            // 시각은 버리고, 어느 날짜에 풀었는지만 남긴다.
+            LocalDate date = dateTime.toLocalDate();
+            availableYears.add(date.getYear());
+            countsByDate.computeIfAbsent(date, ignored -> new DailySolveCount()).increment(solveMode);
+        }
+    }
+
+    // 날짜별 카운트를 프론트가 바로 그릴 수 있는 주 단위 배열 구조로 변환한다.
+    private List<SolveHeatmapResponse.Week> buildWeeks(
+            LocalDate gridStart,
+            LocalDate gridEnd,
+            int selectedYear,
+            LocalDate today,
+            Map<LocalDate, DailySolveCount> countsByDate,
+            int maxDailySolvedCount) {
+        List<SolveHeatmapResponse.Week> weeks = new ArrayList<>();
+
+        for (LocalDate weekStart = gridStart; !weekStart.isAfter(gridEnd); weekStart = weekStart.plusWeeks(1)) {
+            List<SolveHeatmapResponse.Day> days = new ArrayList<>(7);
+
+            for (int offset = 0; offset < 7; offset++) {
+                LocalDate date = weekStart.plusDays(offset);
+                // 선택한 연도 바깥의 패딩 칸은 항상 빈 셀처럼 보이게 0으로 처리한다.
+                boolean inSelectedYear = date.getYear() == selectedYear;
+                DailySolveCount dailySolveCount =
+                        inSelectedYear ? countsByDate.getOrDefault(date, DailySolveCount.EMPTY) : DailySolveCount.EMPTY;
+                int totalSolvedCount = dailySolveCount.totalSolvedCount();
+
+                days.add(new SolveHeatmapResponse.Day(
+                        date.toString(),
+                        dailySolveCount.soloSolvedCount(),
+                        dailySolveCount.battleSolvedCount(),
+                        totalSolvedCount,
+                        resolveLevel(totalSolvedCount, maxDailySolvedCount),
+                        inSelectedYear,
+                        date.equals(today)));
+            }
+
+            weeks.add(new SolveHeatmapResponse.Week(weekStart.toString(), days));
+        }
+
+        return weeks;
+    }
+
+    // 각 월 라벨이 몇 번째 주에 걸치는지 계산해 프론트에 전달한다.
+    private List<SolveHeatmapResponse.MonthLabel> buildMonthLabels(int selectedYear, LocalDate gridStart) {
+        List<SolveHeatmapResponse.MonthLabel> monthLabels = new ArrayList<>(12);
+
+        for (Month month : Month.values()) {
+            LocalDate monthStart = LocalDate.of(selectedYear, month, 1);
+            LocalDate monthWeekStart = monthStart.with(TemporalAdjusters.previousOrSame(WEEK_START));
+            int weekIndex = (int) ChronoUnit.WEEKS.between(gridStart, monthWeekStart);
+
+            monthLabels.add(new SolveHeatmapResponse.MonthLabel(
+                    month.getValue(),
+                    month.name().substring(0, 1) + month.name().substring(1, 3).toLowerCase(),
+                    weekIndex));
+        }
+
+        return monthLabels;
+    }
+
+    // totalSolvedCount를 잔디 색상 단계(level 0~4)로 변환한다.
+    private int resolveLevel(int totalSolvedCount, int maxDailySolvedCount) {
+        // 풀이가 없으면 가장 연한 단계다.
+        if (totalSolvedCount <= 0) {
+            return 0;
+        }
+
+        // 연간 최대 풀이 수가 4 이하이면 count를 그대로 level처럼 사용한다.
+        if (maxDailySolvedCount <= 4) {
+            return Math.min(totalSolvedCount, 4);
+        }
+
+        // 최대 풀이 수가 더 크면, 최대값을 4단계로 나눠 상대 레벨을 만든다.
+        return Math.max(1, Math.min(4, (int) Math.ceil((double) totalSolvedCount * 4 / maxDailySolvedCount)));
+    }
+
+    // 내부 계산에서 solo/battle을 구분하기 위한 enum
+    private enum SolveMode {
+        SOLO,
+        BATTLE
+    }
+
+    // 날짜 하나에 대해 solo/battle/total 카운트를 누적하기 위한 내부 객체
+    private static final class DailySolveCount {
+        private static final DailySolveCount EMPTY = new DailySolveCount();
+
+        private int soloSolvedCount;
+        private int battleSolvedCount;
+
+        // 같은 날짜에 어떤 모드 풀이가 있었는지에 따라 해당 카운트를 1 증가시킨다.
+        private void increment(SolveMode solveMode) {
+            if (solveMode == SolveMode.SOLO) {
+                soloSolvedCount++;
+                return;
+            }
+
+            battleSolvedCount++;
+        }
+
+        private int soloSolvedCount() {
+            return soloSolvedCount;
+        }
+
+        private int battleSolvedCount() {
+            return battleSolvedCount;
+        }
+
+        private int totalSolvedCount() {
+            return soloSolvedCount + battleSolvedCount;
+        }
+    }
+}

--- a/src/main/java/com/back/domain/problem/solo/submission/repository/SoloSubmissionRepository.java
+++ b/src/main/java/com/back/domain/problem/solo/submission/repository/SoloSubmissionRepository.java
@@ -1,5 +1,7 @@
 package com.back.domain.problem.solo.submission.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,10 +9,22 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.back.domain.problem.solo.submission.entity.SoloSubmission;
+import com.back.domain.problem.submission.entity.SubmissionResult;
 
 public interface SoloSubmissionRepository extends JpaRepository<SoloSubmission, Long> {
 
     // 채점 후 연관된 member/problem을 즉시 사용해야 해서 fetch join 조회를 별도로 둔다.
     @Query("select s from SoloSubmission s join fetch s.member join fetch s.problem where s.id = :id")
     Optional<SoloSubmission> findWithMemberAndProblemById(@Param("id") Long id);
+
+    // 잔디 히트맵용: 같은 문제를 여러 번 AC해도 최초 AC 시각 1건만 집계한다.
+    @Query("""
+            select min(s.createdAt)
+            from SoloSubmission s
+            where s.member.id = :memberId
+              and s.result = :result
+            group by s.problem.id
+            """)
+    List<LocalDateTime> findFirstAcTimesByMemberIdAndResult(
+            @Param("memberId") Long memberId, @Param("result") SubmissionResult result);
 }

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerBattleResultsTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerBattleResultsTest.java
@@ -20,6 +20,7 @@ import com.back.domain.battle.result.service.BattleResultService;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberRatingProgressService;
 import com.back.domain.member.member.service.MemberService;
+import com.back.domain.member.member.service.MemberSolveHeatmapService;
 import com.back.global.globalExceptionHandler.GlobalExceptionHandler;
 import com.back.global.jwt.RefreshTokenService;
 import com.back.global.rq.Rq;
@@ -28,6 +29,7 @@ class MemberControllerBattleResultsTest {
 
     private final MemberService memberService = mock(MemberService.class);
     private final MemberRatingProgressService memberRatingProgressService = mock(MemberRatingProgressService.class);
+    private final MemberSolveHeatmapService memberSolveHeatmapService = mock(MemberSolveHeatmapService.class);
     private final BattleResultService battleResultService = mock(BattleResultService.class);
     private final RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
     private final Rq rq = mock(Rq.class);
@@ -37,7 +39,12 @@ class MemberControllerBattleResultsTest {
     @BeforeEach
     void setUp() {
         MemberController controller = new MemberController(
-                memberService, memberRatingProgressService, battleResultService, refreshTokenService, rq);
+                memberService,
+                memberRatingProgressService,
+                memberSolveHeatmapService,
+                battleResultService,
+                refreshTokenService,
+                rq);
 
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerSolveHeatmapTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerSolveHeatmapTest.java
@@ -1,0 +1,91 @@
+package com.back.domain.member.member.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.back.domain.battle.result.service.BattleResultService;
+import com.back.domain.member.member.dto.SolveHeatmapResponse;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberRatingProgressService;
+import com.back.domain.member.member.service.MemberService;
+import com.back.domain.member.member.service.MemberSolveHeatmapService;
+import com.back.global.globalExceptionHandler.GlobalExceptionHandler;
+import com.back.global.jwt.RefreshTokenService;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+
+class MemberControllerSolveHeatmapTest {
+
+    private final MemberService memberService = mock(MemberService.class);
+    private final MemberRatingProgressService memberRatingProgressService = mock(MemberRatingProgressService.class);
+    private final MemberSolveHeatmapService memberSolveHeatmapService = mock(MemberSolveHeatmapService.class);
+    private final BattleResultService battleResultService = mock(BattleResultService.class);
+    private final RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
+    private final Rq rq = mock(Rq.class);
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        MemberController controller = new MemberController(
+                memberService,
+                memberRatingProgressService,
+                memberSolveHeatmapService,
+                battleResultService,
+                refreshTokenService,
+                rq);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Solve heatmap includes the requested year response for logged-in users.")
+    void getMySolveHeatmap_success() throws Exception {
+        Member actor = Member.of(7L, "heatmap@example.com", "heatmap-user");
+
+        SolveHeatmapResponse response = new SolveHeatmapResponse(
+                2026,
+                List.of(2026, 2025),
+                2,
+                2,
+                List.of(new SolveHeatmapResponse.MonthLabel(4, "Apr", 13)),
+                List.of(new SolveHeatmapResponse.Week(
+                        "2026-04-05", List.of(new SolveHeatmapResponse.Day("2026-04-09", 1, 1, 2, 2, true, false)))));
+
+        when(rq.getActor()).thenReturn(actor);
+        when(memberSolveHeatmapService.getMySolveHeatmap(7L, 2026))
+                .thenReturn(RsData.of("200", "Solve heatmap fetched successfully.", response));
+
+        mockMvc.perform(get("/api/v1/members/me/solve-heatmap").param("year", "2026"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.data.year").value(2026))
+                .andExpect(jsonPath("$.data.availableYears[0]").value(2026))
+                .andExpect(jsonPath("$.data.weeks[0].days[0].soloSolvedCount").value(1))
+                .andExpect(jsonPath("$.data.weeks[0].days[0].battleSolvedCount").value(1))
+                .andExpect(jsonPath("$.data.weeks[0].days[0].totalSolvedCount").value(2));
+    }
+
+    @Test
+    @DisplayName("Anonymous users receive 401 for solve heatmap.")
+    void getMySolveHeatmap_fail_whenNotLoggedIn() throws Exception {
+        when(rq.getActor()).thenReturn(null);
+
+        mockMvc.perform(get("/api/v1/members/me/solve-heatmap"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("MEMBER_401"));
+    }
+}

--- a/src/test/java/com/back/domain/member/member/service/MemberSolveHeatmapRepositoryIntegrationTest.java
+++ b/src/test/java/com/back/domain/member/member/service/MemberSolveHeatmapRepositoryIntegrationTest.java
@@ -1,0 +1,128 @@
+package com.back.domain.member.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.battle.battleparticipant.entity.BattleParticipant;
+import com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus;
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.battle.battleroom.entity.BattleRoom;
+import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.problem.enums.DifficultyLevel;
+import com.back.domain.problem.problem.enums.InputMode;
+import com.back.domain.problem.problem.enums.JudgeType;
+import com.back.domain.problem.problem.repository.ProblemRepository;
+import com.back.domain.problem.solo.submission.entity.SoloSubmission;
+import com.back.domain.problem.solo.submission.repository.SoloSubmissionRepository;
+import com.back.domain.problem.submission.entity.SubmissionResult;
+import com.back.global.IntegrationTestBase;
+
+@Transactional
+class MemberSolveHeatmapRepositoryIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private SoloSubmissionRepository soloSubmissionRepository;
+
+    @Autowired
+    private BattleParticipantRepository battleParticipantRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private BattleRoomRepository battleRoomRepository;
+
+    @Test
+    @DisplayName("Solo heatmap source keeps only one first AC per problem even after replaying the same problem.")
+    void soloQuery_returnsOneFirstAcPerProblem() {
+        Member member = memberRepository.saveAndFlush(Member.createUser("solo-user", "solo@example.com", "pw"));
+        Problem problem = saveProblem("solo-problem");
+
+        SoloSubmission first = SoloSubmission.create(member, problem, "code-1", "java");
+        first.applyJudgeResult(SubmissionResult.AC, 1, 1);
+        soloSubmissionRepository.saveAndFlush(first);
+
+        SoloSubmission second = SoloSubmission.create(member, problem, "code-2", "java");
+        second.applyJudgeResult(SubmissionResult.AC, 1, 1);
+        soloSubmissionRepository.saveAndFlush(second);
+
+        List<LocalDateTime> firstAcTimes =
+                soloSubmissionRepository.findFirstAcTimesByMemberIdAndResult(member.getId(), SubmissionResult.AC);
+
+        assertThat(firstAcTimes).hasSize(1);
+        assertThat(firstAcTimes.get(0)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Battle heatmap source keeps only one first solve per problem even across multiple rooms.")
+    void battleQuery_returnsOneFirstSolvePerProblem() {
+        Member member = memberRepository.saveAndFlush(Member.createUser("battle-user", "battle@example.com", "pw"));
+        Problem problem = saveProblem("battle-problem");
+
+        BattleRoom room1 = battleRoomRepository.saveAndFlush(BattleRoom.create(problem, 4));
+        room1.startBattle(Duration.ofMinutes(10));
+        battleRoomRepository.saveAndFlush(room1);
+
+        BattleParticipant participant1 = BattleParticipant.create(room1, member);
+        participant1.join();
+        participant1.complete(LocalDateTime.now().minusDays(1));
+        battleParticipantRepository.saveAndFlush(participant1);
+
+        BattleRoom room2 = battleRoomRepository.saveAndFlush(BattleRoom.create(problem, 4));
+        room2.startBattle(Duration.ofMinutes(10));
+        battleRoomRepository.saveAndFlush(room2);
+
+        BattleParticipant participant2 = BattleParticipant.create(room2, member);
+        participant2.join();
+        participant2.complete(LocalDateTime.now());
+        battleParticipantRepository.saveAndFlush(participant2);
+
+        List<LocalDateTime> firstSolvedTimes = battleParticipantRepository.findFirstSolvedAtByMemberIdAndStatus(
+                member.getId(), BattleParticipantStatus.SOLVED);
+
+        assertThat(firstSolvedTimes).hasSize(1);
+        assertThat(firstSolvedTimes.get(0)).isNotNull();
+    }
+
+    private Problem saveProblem(String sourceProblemId) {
+        Problem problem = instantiateProblem();
+        ReflectionTestUtils.setField(problem, "sourceProblemId", sourceProblemId);
+        ReflectionTestUtils.setField(problem, "title", "Problem " + sourceProblemId);
+        ReflectionTestUtils.setField(problem, "difficulty", DifficultyLevel.EASY);
+        ReflectionTestUtils.setField(problem, "content", "content");
+        ReflectionTestUtils.setField(problem, "difficultyRating", 1200);
+        ReflectionTestUtils.setField(problem, "timeLimitMs", 1000L);
+        ReflectionTestUtils.setField(problem, "memoryLimitMb", 256L);
+        ReflectionTestUtils.setField(problem, "inputFormat", "input");
+        ReflectionTestUtils.setField(problem, "outputFormat", "output");
+        ReflectionTestUtils.setField(problem, "inputMode", InputMode.STDIO);
+        ReflectionTestUtils.setField(problem, "judgeType", JudgeType.EXACT);
+        ReflectionTestUtils.setField(problem, "checkerCode", null);
+        return problemRepository.saveAndFlush(problem);
+    }
+
+    private Problem instantiateProblem() {
+        try {
+            var constructor = Problem.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to instantiate problem for test setup.", e);
+        }
+    }
+}

--- a/src/test/java/com/back/domain/member/member/service/MemberSolveHeatmapServiceTest.java
+++ b/src/test/java/com/back/domain/member/member/service/MemberSolveHeatmapServiceTest.java
@@ -1,0 +1,139 @@
+package com.back.domain.member.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.domain.battle.battleparticipant.repository.BattleParticipantRepository;
+import com.back.domain.member.member.dto.SolveHeatmapResponse;
+import com.back.domain.problem.solo.submission.repository.SoloSubmissionRepository;
+import com.back.domain.problem.submission.entity.SubmissionResult;
+import com.back.global.rsData.RsData;
+
+class MemberSolveHeatmapServiceTest {
+
+    private final SoloSubmissionRepository soloSubmissionRepository = mock(SoloSubmissionRepository.class);
+    private final BattleParticipantRepository battleParticipantRepository = mock(BattleParticipantRepository.class);
+
+    private final MemberSolveHeatmapService memberSolveHeatmapService =
+            new MemberSolveHeatmapService(soloSubmissionRepository, battleParticipantRepository);
+
+    @Test
+    @DisplayName("Missing year defaults to the current year and returns an empty zero grid when no data exists.")
+    void getMySolveHeatmap_defaultsToCurrentYearWithEmptyGrid() {
+        when(soloSubmissionRepository.findFirstAcTimesByMemberIdAndResult(1L, SubmissionResult.AC))
+                .thenReturn(List.of());
+        when(battleParticipantRepository.findFirstSolvedAtByMemberIdAndStatus(
+                        1L, com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.SOLVED))
+                .thenReturn(List.of());
+
+        RsData<SolveHeatmapResponse> result = memberSolveHeatmapService.getMySolveHeatmap(1L, null);
+
+        assertThat(result.resultCode()).isEqualTo("200");
+        assertThat(result.data().year()).isEqualTo(LocalDate.now().getYear());
+        assertThat(result.data().availableYears())
+                .containsExactly(LocalDate.now().getYear());
+        assertThat(result.data().totalSolvedCount()).isZero();
+        assertThat(result.data().maxDailySolvedCount()).isZero();
+        assertThat(result.data().weeks()).isNotEmpty();
+        assertThat(result.data().weeks())
+                .allSatisfy(week -> assertThat(week.days()).hasSize(7));
+        assertThat(result.data().weeks().stream()
+                        .flatMap(week -> week.days().stream())
+                        .filter(SolveHeatmapResponse.Day::inSelectedYear)
+                        .count())
+                .isEqualTo(Year.of(LocalDate.now().getYear()).length());
+        assertThat(result.data().weeks().stream()
+                        .flatMap(week -> week.days().stream())
+                        .allMatch(day -> day.level() == 0))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("Solo and battle solves on the same day are counted separately and summed in the tooltip total.")
+    void getMySolveHeatmap_separatesSoloAndBattleCounts() {
+        when(soloSubmissionRepository.findFirstAcTimesByMemberIdAndResult(2L, SubmissionResult.AC))
+                .thenReturn(List.of(LocalDateTime.of(2026, 4, 9, 10, 0)));
+        when(battleParticipantRepository.findFirstSolvedAtByMemberIdAndStatus(
+                        2L, com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.SOLVED))
+                .thenReturn(List.of(LocalDateTime.of(2026, 4, 9, 20, 0)));
+
+        SolveHeatmapResponse response =
+                memberSolveHeatmapService.getMySolveHeatmap(2L, 2026).data();
+        SolveHeatmapResponse.Day day = findDay(response, "2026-04-09");
+
+        assertThat(response.totalSolvedCount()).isEqualTo(2);
+        assertThat(response.maxDailySolvedCount()).isEqualTo(2);
+        assertThat(day.soloSolvedCount()).isEqualTo(1);
+        assertThat(day.battleSolvedCount()).isEqualTo(1);
+        assertThat(day.totalSolvedCount()).isEqualTo(2);
+        assertThat(day.level()).isEqualTo(2);
+        assertThat(day.inSelectedYear()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Relative levels scale against the maximum daily solve count when it is above four.")
+    void getMySolveHeatmap_usesRelativeLevelsWhenMaxExceedsFour() {
+        when(soloSubmissionRepository.findFirstAcTimesByMemberIdAndResult(3L, SubmissionResult.AC))
+                .thenReturn(List.of(
+                        LocalDateTime.of(2026, 4, 9, 9, 0),
+                        LocalDateTime.of(2026, 4, 9, 10, 0),
+                        LocalDateTime.of(2026, 4, 9, 11, 0),
+                        LocalDateTime.of(2026, 4, 9, 12, 0),
+                        LocalDateTime.of(2026, 4, 9, 13, 0),
+                        LocalDateTime.of(2026, 4, 9, 14, 0),
+                        LocalDateTime.of(2026, 4, 9, 15, 0),
+                        LocalDateTime.of(2026, 4, 9, 16, 0),
+                        LocalDateTime.of(2026, 4, 10, 10, 0),
+                        LocalDateTime.of(2026, 4, 10, 11, 0),
+                        LocalDateTime.of(2026, 4, 10, 12, 0),
+                        LocalDateTime.of(2026, 4, 10, 13, 0)));
+        when(battleParticipantRepository.findFirstSolvedAtByMemberIdAndStatus(
+                        3L, com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.SOLVED))
+                .thenReturn(List.of());
+
+        SolveHeatmapResponse response =
+                memberSolveHeatmapService.getMySolveHeatmap(3L, 2026).data();
+
+        assertThat(response.maxDailySolvedCount()).isEqualTo(8);
+        assertThat(findDay(response, "2026-04-09").level()).isEqualTo(4);
+        assertThat(findDay(response, "2026-04-10").level()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("When the maximum daily solve count is four or less, the count maps directly to the level.")
+    void getMySolveHeatmap_usesDirectLevelsWhenMaxIsFourOrLess() {
+        when(soloSubmissionRepository.findFirstAcTimesByMemberIdAndResult(4L, SubmissionResult.AC))
+                .thenReturn(List.of(
+                        LocalDateTime.of(2026, 4, 9, 9, 0),
+                        LocalDateTime.of(2026, 4, 9, 10, 0),
+                        LocalDateTime.of(2026, 4, 9, 11, 0),
+                        LocalDateTime.of(2026, 4, 10, 10, 0)));
+        when(battleParticipantRepository.findFirstSolvedAtByMemberIdAndStatus(
+                        4L, com.back.domain.battle.battleparticipant.entity.BattleParticipantStatus.SOLVED))
+                .thenReturn(List.of());
+
+        SolveHeatmapResponse response =
+                memberSolveHeatmapService.getMySolveHeatmap(4L, 2026).data();
+
+        assertThat(response.maxDailySolvedCount()).isEqualTo(3);
+        assertThat(findDay(response, "2026-04-09").level()).isEqualTo(3);
+        assertThat(findDay(response, "2026-04-10").level()).isEqualTo(1);
+    }
+
+    private SolveHeatmapResponse.Day findDay(SolveHeatmapResponse response, String date) {
+        return response.weeks().stream()
+                .flatMap(week -> week.days().stream())
+                .filter(day -> day.date().equals(date))
+                .findFirst()
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #197 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #197 

---

<html>
<body>
<h1>[feat] 마이페이지 풀이 잔디 히트맵 조회 API 구현</h1>

<h3>개요</h3>
<p>이번 PR은 마이페이지에서 사용할 <strong>풀이 잔디 히트맵 조회 API</strong>를 추가한 작업입니다.</p>
<p>기존에는 사용자가 언제 문제를 풀었는지 연도 단위로 시각화할 수 있는 전용 API가 없었습니다. 이번 PR에서는 <code>GET /api/v1/members/me/solve-heatmap</code> 엔드포인트를 추가하고, <strong>solo 풀이와 battle 풀이를 날짜별로 합산한 GitHub 스타일의 잔디 그리드 데이터</strong>를 반환하도록 구현했습니다.</p>
<p>또한 같은 문제를 여러 번 맞힌 경우에도 히트맵에서는 “풀이한 날”을 과하게 부풀리지 않도록, <strong>문제별 첫 AC / 첫 solve 시각만 집계</strong>하는 저장소 쿼리를 함께 추가했습니다.</p>

<hr>

<h2>기존 코드 대비 변경점</h2>

<table>
<tr><th>구분</th><th>기존</th><th>변경 후</th></tr>
<tr>
<td>마이페이지 풀이 잔디 API</td>
<td>전용 API 없음</td>
<td><code>GET /api/v1/members/me/solve-heatmap</code> 추가</td>
</tr>
<tr>
<td>풀이 집계 기준</td>
<td>일자별 통합 집계 없음</td>
<td>solo 첫 AC + battle 첫 solve를 날짜별로 합산</td>
</tr>
<tr>
<td>중복 풀이 처리</td>
<td>히트맵용 중복 제거 규칙 없음</td>
<td>같은 문제를 여러 번 풀어도 문제별 첫 solve 1건만 반영</td>
</tr>
<tr>
<td>응답 구조</td>
<td>없음</td>
<td><code>year</code>, <code>availableYears</code>, <code>monthLabels</code>, <code>weeks</code> 포함</td>
</tr>
<tr>
<td>일자 정보</td>
<td>없음</td>
<td><code>soloSolvedCount</code>, <code>battleSolvedCount</code>, <code>totalSolvedCount</code>, <code>level</code> 제공</td>
</tr>
<tr>
<td>연도 패딩 grid</td>
<td>없음</td>
<td>선택 연도를 주 단위 grid로 맞추기 위해 앞뒤 padding day 포함</td>
</tr>
<tr>
<td>컨트롤러 테스트</td>
<td>기존 MemberController 생성자 기준</td>
<td>새 서비스 의존성 반영 및 solve-heatmap 전용 테스트 추가</td>
</tr>
</table>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) 마이페이지 풀이 잔디 조회 API 추가</h3>
<p><code>MemberController</code>에 아래 엔드포인트를 추가했습니다.</p>

<pre><code class="language-text">GET /api/v1/members/me/solve-heatmap?year=2026
</code></pre>

<p>이 API는 현재 로그인한 사용자 기준으로만 조회됩니다.</p>

<pre><code class="language-java">@GetMapping("/me/solve-heatmap")
public RsData<SolveHeatmapResponse> getMySolveHeatmap(@RequestParam(required = false) Integer year) {
    Member actor = rq.getActor();
    if (actor == null || actor.getId() == null) {
        throw new ServiceException("MEMBER_401", "로그인이 필요합니다.");
    }

    return memberSolveHeatmapService.getMySolveHeatmap(actor.getId(), year);
}
</code></pre>

<p>즉, 클라이언트가 memberId를 직접 넘기는 구조가 아니라, 인증된 사용자 자신의 히트맵만 조회할 수 있습니다.</p>

<h3>2) year 파라미터는 선택값이며, 없으면 현재 연도를 기본 사용</h3>
<p>서비스는 <code>year</code> 파라미터가 없으면 현재 연도를 기본값으로 사용합니다.</p>

<pre><code class="language-java">int resolvedYear = year != null ? year : LocalDate.now().getYear();
</code></pre>

<p>또한 잘못된 year 값에 대해서는 예외를 던지도록 했습니다.</p>

<pre><code class="language-java">if (resolvedYear < 1 || resolvedYear > 9999) {
    throw new ServiceException("MEMBER_400", "유효한 year 값이 필요합니다.");
}
</code></pre>

<p>즉, 이 API는</p>
<ul>
<li><code>/me/solve-heatmap</code> 호출 시 현재 연도 조회</li>
<li><code>/me/solve-heatmap?year=2025</code> 호출 시 특정 연도 조회</li>
</ul>
<p>를 모두 지원합니다.</p>

<h3>3) 응답 DTO는 프론트가 바로 잔디를 그릴 수 있는 구조로 설계</h3>
<p><code>SolveHeatmapResponse</code>는 프론트가 별도 재가공 없이 바로 연도 선택 UI와 잔디 그리드를 그릴 수 있도록 구성했습니다.</p>

<p>최상위 응답 필드는 아래와 같습니다.</p>
<ul>
<li><code>year</code> : 현재 조회 중인 연도</li>
<li><code>availableYears</code> : 이동 가능한 연도 목록</li>
<li><code>totalSolvedCount</code> : 선택 연도 총 풀이 수</li>
<li><code>maxDailySolvedCount</code> : 선택 연도 하루 최대 풀이 수</li>
<li><code>monthLabels</code> : 월 라벨 위치 정보</li>
<li><code>weeks</code> : 실제 잔디 그리드</li>
</ul>

<p>특히 day 단위 데이터는 아래처럼 세분화했습니다.</p>

<pre><code class="language-java">public record Day(
        String date,
        int soloSolvedCount,
        int battleSolvedCount,
        int totalSolvedCount,
        int level,
        boolean inSelectedYear,
        boolean isToday) {}
</code></pre>

<p>즉, 툴팁이나 색상 계산에 필요한 정보가 모두 day 하나에 들어 있습니다.</p>

<h3>4) solo 풀이와 battle 풀이를 분리해서 카운트한 뒤 total로 합산</h3>
<p>이번 히트맵은 단순 총합만 내려주는 것이 아니라, 같은 날짜에 solo 풀이와 battle 풀이가 각각 몇 건 있었는지를 분리해서 담습니다.</p>

<p>서비스 내부에서는 날짜별 카운트를 아래 형태로 누적합니다.</p>
<ul>
<li><code>soloSolvedCount</code></li>
<li><code>battleSolvedCount</code></li>
<li><code>totalSolvedCount = solo + battle</code></li>
</ul>

<p>즉, 프론트는 색상은 total 기준으로 그리고, 툴팁에서는 “solo 1 / battle 1 / total 2” 같은 식으로 상세 표시를 할 수 있습니다.</p>

<h3>5) solo는 문제별 첫 AC만 집계</h3>
<p>같은 문제를 여러 번 맞췄더라도 잔디 히트맵에서는 같은 문제를 여러 번 센 것처럼 보이면 안 되기 때문에, solo 제출은 문제별 첫 AC 시각 1건만 가져오도록 저장소 메서드를 추가했습니다.</p>

<pre><code class="language-java">@Query("""
        select min(s.createdAt)
        from SoloSubmission s
        where s.member.id = :memberId
          and s.result = :result
        group by s.problem.id
        """)
List&lt;LocalDateTime&gt; findFirstAcTimesByMemberIdAndResult(...)
</code></pre>

<p>즉, 같은 사용자가 같은 문제를 여러 번 AC해도 히트맵 집계에는 첫 AC 날짜만 반영됩니다.</p>

<h3>6) battle도 문제별 첫 solve만 집계</h3>
<p>battle 쪽도 같은 문제를 여러 방에서 반복해서 푼 경우가 있을 수 있기 때문에, 문제별 첫 solve 시각만 집계하도록 저장소 쿼리를 추가했습니다.</p>

<pre><code class="language-java">@Query("""
        select min(bp.finishTime)
        from BattleParticipant bp
        join bp.battleRoom br
        where bp.member.id = :memberId
          and bp.status = :status
          and br.problem is not null
        group by br.problem.id
        """)
List&lt;LocalDateTime&gt; findFirstSolvedAtByMemberIdAndStatus(...)
</code></pre>

<p>즉, battle 히트맵도 “문제를 처음 해결한 날”만 1건으로 계산됩니다.</p>

<h3>7) 문제 단위 중복 제거 후 날짜 단위로 merge</h3>
<p>서비스는 solo/battle 저장소에서 각각 가져온 “문제별 첫 solve 시각 리스트”를 날짜 단위로 합칩니다.</p>

<pre><code class="language-java">mergeSolveDates(
        countsByDate,
        availableYears,
        soloSubmissionRepository.findFirstAcTimesByMemberIdAndResult(...),
        SolveMode.SOLO);

mergeSolveDates(
        countsByDate,
        availableYears,
        battleParticipantRepository.findFirstSolvedAtByMemberIdAndStatus(...),
        SolveMode.BATTLE);
</code></pre>

<p>여기서 핵심은 아래 2단계입니다.</p>
<ul>
<li>저장소 단계: 문제별 첫 solve만 추출</li>
<li>서비스 단계: 그 결과를 날짜별로 다시 합산</li>
</ul>

<p>즉, “같은 문제 중복”은 제거하면서도 “같은 날짜의 여러 문제 풀이”는 정상적으로 합산됩니다.</p>

<h3>8) availableYears는 실제 풀이 데이터 + 선택 연도를 함께 보장</h3>
<p>히트맵에서 연도 이동 UI를 만들 수 있도록, 서비스는 풀이가 있었던 연도들을 모아 <code>availableYears</code>로 반환합니다.</p>

<p>이 값은 내림차순 정렬됩니다.</p>

<pre><code class="language-java">NavigableSet&lt;Integer&gt; availableYears = new TreeSet&lt;&gt;(Comparator.reverseOrder());
</code></pre>

<p>또한 선택 연도에 데이터가 하나도 없더라도 빈 히트맵을 그릴 수 있어야 하므로, 선택 연도는 항상 목록에 포함시킵니다.</p>

<pre><code class="language-java">availableYears.add(selectedYear);
</code></pre>

<p>즉, 데이터가 없는 연도를 조회해도 프론트는 연도 선택 UI와 빈 grid를 정상적으로 표시할 수 있습니다.</p>

<h3>9) totalSolvedCount와 maxDailySolvedCount를 함께 계산</h3>
<p>응답 상단 요약에 사용할 수 있도록 선택 연도 기준으로 아래 값도 같이 계산합니다.</p>

<ul>
<li><code>totalSolvedCount</code> : 그 해 전체 풀이 수</li>
<li><code>maxDailySolvedCount</code> : 그 해 하루 최대 풀이 수</li>
</ul>

<p>이 값은 히트맵 색상 레벨 계산에도 사용됩니다.</p>
<p>즉, 프론트는</p>
<ul>
<li>상단 숫자 요약</li>
<li>색상 intensity 계산 참고값</li>
</ul>
<p>을 같은 응답 안에서 함께 받을 수 있습니다.</p>

<h3>10) GitHub 스타일과 맞추기 위해 주 단위 grid를 완성해서 반환</h3>
<p>이번 구현의 중요한 포인트는 단순 날짜 목록이 아니라, 프론트가 바로 잔디를 그릴 수 있도록 <strong>주 단위 그리드 자체</strong>를 서버에서 만들어 준다는 점입니다.</p>

<p>기준은 아래와 같습니다.</p>
<ul>
<li>주 시작: 일요일</li>
<li>주 종료: 토요일</li>
</ul>

<pre><code class="language-java">private static final DayOfWeek WEEK_START = DayOfWeek.SUNDAY;
private static final DayOfWeek WEEK_END = DayOfWeek.SATURDAY;
</code></pre>

<p>선택 연도 1월 1일이 주 중간에 있어도, 앞쪽 padding day를 포함한 첫 주를 맞춥니다.</p>

<pre><code class="language-java">LocalDate gridStart = firstDayOfYear.with(TemporalAdjusters.previousOrSame(WEEK_START));
LocalDate gridEnd = lastDayOfYear.with(TemporalAdjusters.nextOrSame(WEEK_END));
</code></pre>

<p>즉, 응답의 <code>weeks</code>는 항상 완전한 주 단위 구조를 가지며, 연도 앞뒤 padding 셀도 함께 포함합니다.</p>

<h3>11) padding day는 inSelectedYear=false로 구분</h3>
<p>앞뒤 padding day는 실제 선택 연도에 속하지 않는 셀이라서, 프론트가 옅은 빈 칸처럼 표시할 수 있도록 <code>inSelectedYear</code> 플래그를 함께 제공합니다.</p>

<pre><code class="language-java">boolean inSelectedYear = date.getYear() == selectedYear;
</code></pre>

<p>이 날짜들은 count가 모두 0으로 내려갑니다.</p>
<p>즉, 프론트는:</p>
<ul>
<li><code>inSelectedYear=true</code> : 실제 잔디 셀</li>
<li><code>inSelectedYear=false</code> : 패딩 셀</li>
</ul>
<p>로 구분해서 렌더링할 수 있습니다.</p>

<h3>12) monthLabels로 월 라벨 위치까지 함께 계산</h3>
<p>월 이름을 어디에 붙여야 하는지도 프론트가 다시 계산하지 않도록, 서버가 <code>monthLabels</code>를 함께 제공합니다.</p>

<pre><code class="language-java">new SolveHeatmapResponse.MonthLabel(
        month.getValue(),
        month.name().substring(0, 1) + month.name().substring(1, 3).toLowerCase(),
        weekIndex)
</code></pre>

<p>즉, 월 라벨은 아래 정보를 가집니다.</p>
<ul>
<li><code>month</code> : 월 숫자</li>
<li><code>label</code> : Jan, Feb, Mar 같은 표시 문자열</li>
<li><code>weekIndex</code> : 몇 번째 주 컬럼부터 시작하는지</li>
</ul>

<p>프론트는 이 값을 그대로 써서 상단 월 라벨을 배치할 수 있습니다.</p>

<h3>13) level은 0~4 단계로 계산</h3>
<p>각 날짜 셀의 색상 농도는 <code>level</code> 값으로 내려줍니다. 규칙은 아래와 같습니다.</p>

<ul>
<li><code>0</code> : 풀이 없음</li>
<li><code>1~4</code> : 풀이 수에 따른 농도 단계</li>
</ul>

<p>세부 규칙은 두 가지 경우로 나뉩니다.</p>

<p><strong>1. 해당 연도의 최대 일일 풀이 수가 4 이하일 때</strong></p>
<p>count를 그대로 level처럼 사용합니다.</p>

<pre><code class="language-java">if (maxDailySolvedCount &lt;= 4) {
    return Math.min(totalSolvedCount, 4);
}
</code></pre>

<p>즉, 1문제면 level 1, 3문제면 level 3입니다.</p>

<p><strong>2. 최대 일일 풀이 수가 5 이상일 때</strong></p>
<p>최댓값을 4단계로 나눠 상대 레벨을 계산합니다.</p>

<pre><code class="language-java">return Math.max(1, Math.min(4,
        (int) Math.ceil((double) totalSolvedCount * 4 / maxDailySolvedCount)));
</code></pre>

<p>즉, 풀이가 많은 해에도 색상 단계가 0~4 안에서 상대적으로 균형 있게 분포되도록 했습니다.</p>

<h3>14) today 표시를 위한 isToday 플래그 제공</h3>
<p>현재 날짜 셀을 프론트에서 강조 표시할 수 있도록 <code>isToday</code>를 day 응답에 포함했습니다.</p>

<pre><code class="language-java">date.equals(today)
</code></pre>

<p>즉, 프론트는 별도 클라이언트 계산 없이 현재 날짜 셀을 바로 강조할 수 있습니다.</p>

<h3>15) 컨트롤러 응답은 기존 MemberController 규약에 맞춰 RsData로 반환</h3>
<p>이 API는 raw JSON이 아니라 기존 <code>MemberController</code> 응답 규약을 따라 <code>RsData&lt;SolveHeatmapResponse&gt;</code>로 반환됩니다.</p>

<p>즉, 응답 구조는 아래 형태입니다.</p>

<pre><code class="language-text">{
  "resultCode": "200",
  "msg": "풀이 잔디 조회 성공",
  "data": {
    "year": ...,
    "availableYears": [...],
    "weeks": [...]
  }
}
</code></pre>

<p>기존 회원 관련 API와 같은 응답 래퍼를 유지한 것입니다.</p>

<h3>16) MemberController 기존 테스트도 생성자 변경에 맞춰 정리</h3>
<p><code>MemberController</code>에 <code>MemberSolveHeatmapService</code> 의존성이 추가되면서, 기존 <code>MemberControllerBattleResultsTest</code>도 생성자 인자를 맞추도록 같이 수정했습니다.</p>

<p>즉, 이번 PR은 새 기능 추가와 함께 기존 컨트롤러 테스트가 깨지지 않도록 테스트 wiring도 같이 보완한 작업입니다.</p>

<hr>

<h2>테스트 추가</h2>

<h3>1) Controller 테스트</h3>
<p><code>MemberControllerSolveHeatmapTest</code>를 추가했습니다.</p>

<ul>
<li>로그인 사용자가 year 파라미터를 넘겼을 때 정상적으로 <code>200</code>과 heatmap 응답을 받는지 확인</li>
<li>비로그인 사용자는 <code>MEMBER_401</code>을 받는지 확인</li>
</ul>

<h3>2) Service 테스트</h3>
<p><code>MemberSolveHeatmapServiceTest</code>를 추가해 히트맵 계산 규칙을 검증했습니다.</p>

<ul>
<li>year 미지정 시 현재 연도를 기본값으로 사용하는지 확인</li>
<li>데이터가 없을 때도 빈 grid를 완성해서 반환하는지 확인</li>
<li>같은 날짜의 solo/battle 풀이가 분리되어 카운트되는지 확인</li>
<li>최대 일일 풀이 수가 4 이하일 때 direct level 규칙을 쓰는지 확인</li>
<li>최대 일일 풀이 수가 5 이상일 때 relative level 규칙을 쓰는지 확인</li>
</ul>

<h3>3) Repository 통합 테스트</h3>
<p><code>MemberSolveHeatmapRepositoryIntegrationTest</code>를 추가해 “문제별 첫 solve만 1건으로 집계”되는 핵심 규칙을 검증했습니다.</p>

<ul>
<li>solo에서 같은 문제를 여러 번 AC해도 첫 AC 1건만 조회되는지 확인</li>
<li>battle에서 같은 문제를 여러 방에서 풀어도 첫 solve 1건만 조회되는지 확인</li>
</ul>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">GET /api/v1/members/me/solve-heatmap?year=2026
      ↓
MemberController
  - 현재 로그인 사용자 확인
  - 비로그인 시 MEMBER_401
      ↓
MemberSolveHeatmapService.getMySolveHeatmap(memberId, year)
      ↓
1. year 파라미터 보정
2. solo 문제별 첫 AC 시각 조회
3. battle 문제별 첫 solve 시각 조회
4. 날짜별 solo / battle 카운트 merge
5. availableYears 계산
6. totalSolvedCount / maxDailySolvedCount 계산
7. gridStart / gridEnd 계산
8. monthLabels 생성
9. weeks -> days 구조 생성
10. level / inSelectedYear / isToday 계산
      ↓
RsData<SolveHeatmapResponse> 반환
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>마이페이지에서 연도별 풀이 히트맵을 그릴 수 있는 전용 API가 생깁니다.</li>
<li>solo와 battle 풀이를 함께 보여주면서도, 같은 문제를 반복 풀이한 경우에는 과집계하지 않습니다.</li>
<li>프론트가 month label, week grid, day level을 다시 계산하지 않고 바로 렌더링할 수 있습니다.</li>
<li>데이터가 없는 연도도 빈 잔디 grid로 안정적으로 표현할 수 있습니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li><code>/api/v1/members/me/solve-heatmap</code> 호출 시 현재 로그인 사용자 기준으로만 조회되는지 확인</li>
<li>같은 문제를 solo나 battle에서 여러 번 풀어도 첫 solve 1건만 히트맵에 반영되는지 확인</li>
<li>같은 날짜의 solo/battle 풀이가 <code>soloSolvedCount</code>, <code>battleSolvedCount</code>로 분리되고 <code>totalSolvedCount</code>로 합산되는지 확인</li>
<li>선택 연도 앞뒤 padding 셀에 대해 <code>inSelectedYear=false</code>가 올바르게 내려오는지 확인</li>
<li>하루 최대 풀이 수에 따라 <code>level</code>이 direct/relative 규칙으로 기대대로 계산되는지 확인</li>
</ol>
</body>
</html>
