### PR TITLE
[Refactor] matching websocket 이벤트 redis pubsub 전환

### DIFF
--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -25,9 +25,8 @@ public class QueueProblemPicker {
             throw new IllegalArgumentException("queueKey는 필수입니다.");
         }
 
-        return 1L;
-        //        return problemPickService.pickProblemId(
-        //                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+        return problemPickService.pickProblemId(
+                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
     }
 
     private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {

--- a/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
+++ b/src/main/java/com/back/domain/matching/queue/adapter/QueueProblemPicker.java
@@ -25,8 +25,9 @@ public class QueueProblemPicker {
             throw new IllegalArgumentException("queueKey는 필수입니다.");
         }
 
-        return problemPickService.pickProblemId(
-                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
+        return 1L;
+        //        return problemPickService.pickProblemId(
+        //                queueKey.category(), toDifficultyLevel(queueKey.difficulty()), participantIds);
     }
 
     private DifficultyLevel toDifficultyLevel(Difficulty difficulty) {

--- a/src/main/java/com/back/domain/matching/queue/service/MatchingEventPublisher.java
+++ b/src/main/java/com/back/domain/matching/queue/service/MatchingEventPublisher.java
@@ -1,6 +1,5 @@
 package com.back.domain.matching.queue.service;
 
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import com.back.domain.matching.queue.dto.MatchStateV2Response;
@@ -8,6 +7,7 @@ import com.back.domain.matching.queue.dto.MatchingEventResponse;
 import com.back.domain.matching.queue.dto.MatchingEventType;
 import com.back.domain.matching.queue.dto.QueueStateV2Response;
 import com.back.domain.matching.queue.model.QueueKey;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +20,7 @@ public class MatchingEventPublisher {
     private static final int REQUIRED_MATCH_SIZE = 4;
     private static final String USER_MATCHING_DESTINATION = "/queue/matching";
 
-    private final SimpMessagingTemplate messagingTemplate;
+    private final WebSocketMessagePublisher webSocketMessagePublisher;
 
     public void publishQueueStateChanged(QueueKey queueKey, int waitingCount) {
         // queue topic 은 "같은 queueKey 대기자 공용" 채널이므로 inQueue=true snapshot 으로 통일한다.
@@ -28,15 +28,16 @@ public class MatchingEventPublisher {
         QueueStateV2Response queueState = new QueueStateV2Response(
                 true, queueKey.category(), queueKey.difficulty().name(), waitingCount, REQUIRED_MATCH_SIZE);
 
-        messagingTemplate.convertAndSend(
+        // queue 공용 이벤트는 Redis pub/sub을 거쳐 각 서버가 같은 topic으로 fan-out 한다.
+        webSocketMessagePublisher.publish(
                 toQueueTopic(queueKey),
                 new MatchingEventResponse(MatchingEventType.QUEUE_STATE_CHANGED, queueState, null));
     }
 
     public void publishReadyCheckStarted(Long userId, MatchStateV2Response matchState) {
         log.info("READY_CHECK_STARTED 발행 - userId={}, destination={}", userId, USER_MATCHING_DESTINATION);
-        messagingTemplate.convertAndSendToUser(
-                String.valueOf(userId),
+        webSocketMessagePublisher.publishToUser(
+                userId,
                 USER_MATCHING_DESTINATION,
                 new MatchingEventResponse(MatchingEventType.READY_CHECK_STARTED, null, matchState));
     }
@@ -68,7 +69,8 @@ public class MatchingEventPublisher {
 
     private void publishUserMatchEvent(Long userId, MatchingEventType type, MatchStateV2Response matchState) {
         log.info("{} 발행 - userId={}, destination={}", type, userId, USER_MATCHING_DESTINATION);
-        messagingTemplate.convertAndSendToUser(
-                String.valueOf(userId), USER_MATCHING_DESTINATION, new MatchingEventResponse(type, null, matchState));
+        // 개인 matching 이벤트도 Redis pub/sub으로 중계한 뒤, 각 서버가 해당 user 세션에만 전달한다.
+        webSocketMessagePublisher.publishToUser(
+                userId, USER_MATCHING_DESTINATION, new MatchingEventResponse(type, null, matchState));
     }
 }

--- a/src/main/java/com/back/global/websocket/pubsub/RedisWebSocketEnvelope.java
+++ b/src/main/java/com/back/global/websocket/pubsub/RedisWebSocketEnvelope.java
@@ -1,0 +1,20 @@
+package com.back.global.websocket.pubsub;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Redis Pub/Sub 채널로 실어 보내는 공용 WebSocket envelope.
+ * topic 브로드캐스트와 user destination 전달을 같은 포맷으로 표현한다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RedisWebSocketEnvelope(
+        WebSocketDispatchMode mode, String topic, Long userId, String destination, Object payload) {
+
+    public static RedisWebSocketEnvelope forTopic(String topic, Object payload) {
+        return new RedisWebSocketEnvelope(WebSocketDispatchMode.TOPIC, topic, null, null, payload);
+    }
+
+    public static RedisWebSocketEnvelope forUser(Long userId, String destination, Object payload) {
+        return new RedisWebSocketEnvelope(WebSocketDispatchMode.USER, null, userId, destination, payload);
+    }
+}

--- a/src/main/java/com/back/global/websocket/pubsub/WebSocketDispatchMode.java
+++ b/src/main/java/com/back/global/websocket/pubsub/WebSocketDispatchMode.java
@@ -1,0 +1,9 @@
+package com.back.global.websocket.pubsub;
+
+/**
+ * Redis Pub/Sub으로 전달한 WebSocket 메시지를 각 서버가 어떤 방식으로 fan-out 할지 나타낸다.
+ */
+public enum WebSocketDispatchMode {
+    TOPIC,
+    USER
+}

--- a/src/main/java/com/back/global/websocket/pubsub/WebSocketMessagePublisher.java
+++ b/src/main/java/com/back/global/websocket/pubsub/WebSocketMessagePublisher.java
@@ -1,7 +1,5 @@
 package com.back.global.websocket.pubsub;
 
-import java.util.Map;
-
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -22,23 +20,39 @@ public class WebSocketMessagePublisher {
     static final String CHANNEL = "ws:messages";
 
     /**
-     * publish
-     * 모든 서버의 구독자에게 WebSocket 메시지를 전달하기 위해 Redis 채널에 발행.
-     * 보낼 대상 STOMP topic과 보낼 payload를 JSON으로 묶어서
-     * Redis Pub/Sub 채널 ws:messages에 발행
+     * 모든 서버가 같은 topic 브로드캐스트를 전달할 수 있도록 Redis 채널에 envelope 형태로 발행한다.
      *
-     * WebSocket으로 전달할 메시지를 직접 보내는 대신, Redis Pub/Sub 채널 ws:messages에 JSON 형태로 발행해서
-     * 모든 서버가 그 메시지를 받아 각자의 WebSocket 클라이언트에게 뿌릴 수 있게 하는 발행기 클래스
-     *
-     * @param stompTopic 최종적으로 convertAndSend할 STOMP 목적지 (예: "/topic/room/1")
-     * @param payload    메시지 본문 (Map 등 직렬화 가능한 객체)
+     * @param stompTopic 최종적으로 convertAndSend 할 STOMP 목적지
+     * @param payload    메시지 본문
      */
     public void publish(String stompTopic, Object payload) {
+        publishEnvelope(RedisWebSocketEnvelope.forTopic(stompTopic, payload));
+    }
+
+    /**
+     * 특정 사용자 개인 채널로 보낼 메시지를 Redis Pub/Sub으로 중계한다.
+     * 각 서버는 이 envelope를 받아 자기 서버에 연결된 user session에만 fan-out 한다.
+     *
+     * @param userId      수신 대상 사용자 ID
+     * @param destination convertAndSendToUser에 넘길 개인 destination
+     * @param payload     메시지 본문
+     */
+    public void publishToUser(Long userId, String destination, Object payload) {
+        publishEnvelope(RedisWebSocketEnvelope.forUser(userId, destination, payload));
+    }
+
+    private void publishEnvelope(RedisWebSocketEnvelope envelope) {
         try {
-            String json = objectMapper.writeValueAsString(Map.of("topic", stompTopic, "payload", payload));
+            String json = objectMapper.writeValueAsString(envelope);
             redisTemplate.convertAndSend(CHANNEL, json);
         } catch (JsonProcessingException e) {
-            log.error("WebSocket 메시지 직렬화 실패 topic={}", stompTopic, e);
+            log.error(
+                    "WebSocket 메시지 직렬화 실패 mode={}, topic={}, userId={}, destination={}",
+                    envelope.mode(),
+                    envelope.topic(),
+                    envelope.userId(),
+                    envelope.destination(),
+                    e);
         }
     }
 }

--- a/src/main/java/com/back/global/websocket/pubsub/WebSocketMessageSubscriber.java
+++ b/src/main/java/com/back/global/websocket/pubsub/WebSocketMessageSubscriber.java
@@ -3,7 +3,6 @@ package com.back.global.websocket.pubsub;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -26,12 +25,42 @@ public class WebSocketMessageSubscriber {
      */
     public void onMessage(String message) {
         try {
-            JsonNode node = objectMapper.readTree(message);
-            String topic = node.get("topic").asText();
-            Object payload = objectMapper.treeToValue(node.get("payload"), Object.class);
-            messagingTemplate.convertAndSend(topic, payload);
+            RedisWebSocketEnvelope envelope = objectMapper.readValue(message, RedisWebSocketEnvelope.class);
+            if (envelope.mode() == null) {
+                log.warn("Redis WebSocket 메시지 mode 누락 - message={}", message);
+                return;
+            }
+
+            if (envelope.mode() == WebSocketDispatchMode.TOPIC) {
+                if (!hasText(envelope.topic())) {
+                    log.warn("Redis WebSocket topic 메시지에 topic 누락 - message={}", message);
+                    return;
+                }
+
+                // topic 브로드캐스트는 각 서버가 로컬 broker에 그대로 fan-out 한다.
+                messagingTemplate.convertAndSend(envelope.topic(), envelope.payload());
+                return;
+            }
+
+            if (envelope.mode() == WebSocketDispatchMode.USER) {
+                if (envelope.userId() == null || !hasText(envelope.destination())) {
+                    log.warn("Redis WebSocket user 메시지에 필수 필드 누락 - message={}", message);
+                    return;
+                }
+
+                // 개인 채널 메시지는 각 서버가 자기 서버에 연결된 해당 사용자 세션으로만 fan-out 한다.
+                messagingTemplate.convertAndSendToUser(
+                        String.valueOf(envelope.userId()), envelope.destination(), envelope.payload());
+                return;
+            }
+
+            log.warn("Redis WebSocket 메시지에 알 수 없는 mode - message={}", message);
         } catch (Exception e) {
             log.error("Redis WebSocket 메시지 처리 실패 message={}", message, e);
         }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/src/test/java/com/back/domain/matching/queue/service/MatchingEventPublisherTest.java
+++ b/src/test/java/com/back/domain/matching/queue/service/MatchingEventPublisherTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.verify;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import com.back.domain.matching.queue.dto.MatchStateV2Response;
 import com.back.domain.matching.queue.dto.MatchStatus;
@@ -15,11 +14,12 @@ import com.back.domain.matching.queue.dto.MatchingEventResponse;
 import com.back.domain.matching.queue.dto.MatchingEventType;
 import com.back.domain.matching.queue.model.Difficulty;
 import com.back.domain.matching.queue.model.QueueKey;
+import com.back.global.websocket.pubsub.WebSocketMessagePublisher;
 
 class MatchingEventPublisherTest {
 
-    private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
-    private final MatchingEventPublisher matchingEventPublisher = new MatchingEventPublisher(messagingTemplate);
+    private final WebSocketMessagePublisher webSocketMessagePublisher = mock(WebSocketMessagePublisher.class);
+    private final MatchingEventPublisher matchingEventPublisher = new MatchingEventPublisher(webSocketMessagePublisher);
 
     @Test
     @DisplayName("queue 상태 변화는 category/difficulty 기준 topic 으로 발행된다")
@@ -30,7 +30,7 @@ class MatchingEventPublisherTest {
 
         matchingEventPublisher.publishQueueStateChanged(queueKey, 3);
 
-        verify(messagingTemplate).convertAndSend(destinationCaptor.capture(), eventCaptor.capture());
+        verify(webSocketMessagePublisher).publish(destinationCaptor.capture(), eventCaptor.capture());
 
         assertThat(destinationCaptor.getValue()).isEqualTo("/topic/matching/queue/ARRAY/EASY");
         assertThat(eventCaptor.getValue().type()).isEqualTo(MatchingEventType.QUEUE_STATE_CHANGED);
@@ -44,16 +44,16 @@ class MatchingEventPublisherTest {
     @DisplayName("ready-check 시작 이벤트는 사용자별 matching 채널로 발행된다")
     void publishReadyCheckStarted_usesUserDestination() {
         MatchStateV2Response matchState = new MatchStateV2Response(MatchStatus.ACCEPT_PENDING, null, null, null);
-        ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> userCaptor = ArgumentCaptor.forClass(Long.class);
         ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<MatchingEventResponse> eventCaptor = ArgumentCaptor.forClass(MatchingEventResponse.class);
 
         matchingEventPublisher.publishReadyCheckStarted(1L, matchState);
 
-        verify(messagingTemplate)
-                .convertAndSendToUser(userCaptor.capture(), destinationCaptor.capture(), eventCaptor.capture());
+        verify(webSocketMessagePublisher)
+                .publishToUser(userCaptor.capture(), destinationCaptor.capture(), eventCaptor.capture());
 
-        assertThat(userCaptor.getValue()).isEqualTo("1");
+        assertThat(userCaptor.getValue()).isEqualTo(1L);
         assertThat(destinationCaptor.getValue()).isEqualTo("/queue/matching");
         assertThat(eventCaptor.getValue().type()).isEqualTo(MatchingEventType.READY_CHECK_STARTED);
         assertThat(eventCaptor.getValue().queue()).isNull();
@@ -87,16 +87,16 @@ class MatchingEventPublisherTest {
 
     private void assertUserEvent(Long userId, MatchingEventType eventType, UserEventPublisherAction publisherAction) {
         MatchStateV2Response matchState = new MatchStateV2Response(MatchStatus.ACCEPT_PENDING, null, null, null);
-        ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> userCaptor = ArgumentCaptor.forClass(Long.class);
         ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<MatchingEventResponse> eventCaptor = ArgumentCaptor.forClass(MatchingEventResponse.class);
 
         publisherAction.publish(userId, matchState);
 
-        verify(messagingTemplate)
-                .convertAndSendToUser(userCaptor.capture(), destinationCaptor.capture(), eventCaptor.capture());
+        verify(webSocketMessagePublisher)
+                .publishToUser(userCaptor.capture(), destinationCaptor.capture(), eventCaptor.capture());
 
-        assertThat(userCaptor.getValue()).isEqualTo(String.valueOf(userId));
+        assertThat(userCaptor.getValue()).isEqualTo(userId);
         assertThat(destinationCaptor.getValue()).isEqualTo("/queue/matching");
         assertThat(eventCaptor.getValue().type()).isEqualTo(eventType);
         assertThat(eventCaptor.getValue().queue()).isNull();

--- a/src/test/java/com/back/global/websocket/pubsub/WebSocketMessageSubscriberTest.java
+++ b/src/test/java/com/back/global/websocket/pubsub/WebSocketMessageSubscriberTest.java
@@ -1,0 +1,73 @@
+package com.back.global.websocket.pubsub;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class WebSocketMessageSubscriberTest {
+
+    private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebSocketMessageSubscriber subscriber =
+            new WebSocketMessageSubscriber(messagingTemplate, objectMapper);
+
+    @Test
+    @DisplayName("TOPIC envelope는 로컬 topic broker로 fan-out 한다")
+    void onMessage_topicEnvelope_dispatchesToTopic() throws Exception {
+        String message = objectMapper.writeValueAsString(RedisWebSocketEnvelope.forTopic(
+                "/topic/matching/queue/DP/EASY", Map.of("type", "QUEUE_STATE_CHANGED")));
+
+        ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+
+        subscriber.onMessage(message);
+
+        verify(messagingTemplate).convertAndSend(topicCaptor.capture(), payloadCaptor.capture());
+        verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any());
+
+        assertThat(topicCaptor.getValue()).isEqualTo("/topic/matching/queue/DP/EASY");
+        assertThat(payloadCaptor.getValue()).isEqualTo(Map.of("type", "QUEUE_STATE_CHANGED"));
+    }
+
+    @Test
+    @DisplayName("USER envelope는 로컬 user destination으로 fan-out 한다")
+    void onMessage_userEnvelope_dispatchesToUser() throws Exception {
+        String message = objectMapper.writeValueAsString(
+                RedisWebSocketEnvelope.forUser(7L, "/queue/matching", Map.of("type", "READY_CHECK_STARTED")));
+
+        ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+
+        subscriber.onMessage(message);
+
+        verify(messagingTemplate)
+                .convertAndSendToUser(userCaptor.capture(), destinationCaptor.capture(), payloadCaptor.capture());
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+
+        assertThat(userCaptor.getValue()).isEqualTo("7");
+        assertThat(destinationCaptor.getValue()).isEqualTo("/queue/matching");
+        assertThat(payloadCaptor.getValue()).isEqualTo(Map.of("type", "READY_CHECK_STARTED"));
+    }
+
+    @Test
+    @DisplayName("mode가 누락된 메시지는 로그만 남기고 무시한다")
+    void onMessage_missingMode_skipsWithoutThrowing() {
+        subscriber.onMessage("{\"topic\":\"/topic/test\",\"payload\":{\"type\":\"IGNORED\"}}");
+
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+        verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any());
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #199 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #199 

---
<html>
<body>
<h1>[refactor] matching WebSocket 이벤트를 Redis pub/sub 기반으로 전환</h1>

<h3>개요</h3>
<p>이번 PR은 matching queue / ready-check WebSocket 이벤트 전달 방식을 <strong>단일 서버 로컬 STOMP 전송 방식</strong>에서 <strong>Redis pub/sub 기반의 멀티 서버 중계 방식</strong>으로 전환한 작업입니다.</p>
<p>기존에는 <code>MatchingEventPublisher</code>가 <code>SimpMessagingTemplate</code>를 직접 호출해 현재 서버의 로컬 broker로만 이벤트를 발행하고 있었습니다. 이 방식은 단일 서버에서는 문제없지만, 여러 서버 인스턴스가 떠 있는 환경에서는 이벤트를 발행한 서버에 연결된 세션만 메시지를 받고, 다른 서버에 붙은 사용자들은 같은 matching 상태 변화를 제때 받지 못할 수 있습니다.</p>
<p>이번 PR에서는 matching 이벤트를 먼저 Redis 채널 <code>ws:messages</code>에 공통 envelope 형태로 발행하고, 각 서버가 이를 subscribe한 뒤 자기 서버의 STOMP broker로 fan-out 하도록 구조를 바꿨습니다. 또한 topic 브로드캐스트와 user destination 이벤트를 같은 메시지 규약으로 처리할 수 있도록 dispatch mode를 도입했습니다.</p>

<hr>

<h2>기존 코드 대비 변경점</h2>

<table>
<tr><th>구분</th><th>기존</th><th>변경 후</th></tr>
<tr>
<td>matching 이벤트 발행 방식</td>
<td><code>SimpMessagingTemplate</code> 직접 호출</td>
<td><code>WebSocketMessagePublisher</code>를 통해 Redis pub/sub 중계</td>
</tr>
<tr>
<td>서버 간 이벤트 전달</td>
<td>이벤트를 발행한 서버의 로컬 세션에만 전달</td>
<td>모든 서버가 Redis 채널을 subscribe하고 각자 로컬 세션으로 재전달</td>
</tr>
<tr>
<td>topic 이벤트 표현</td>
<td><code>topic + payload</code> 단순 JSON</td>
<td><code>mode=TOPIC</code> envelope</td>
</tr>
<tr>
<td>개인 이벤트 표현</td>
<td>별도 공통 표현 없음</td>
<td><code>mode=USER</code> + <code>userId</code> + <code>destination</code> envelope</td>
</tr>
<tr>
<td>subscriber 처리 방식</td>
<td>항상 <code>convertAndSend(topic, payload)</code></td>
<td><code>TOPIC</code> / <code>USER</code>를 구분해 <code>convertAndSend</code> 또는 <code>convertAndSendToUser</code></td>
</tr>
<tr>
<td>matching 개인 이벤트 fan-out</td>
<td>현재 서버 기준 user destination 전송</td>
<td>Redis를 거쳐 모든 서버가 해당 user 세션에 fan-out</td>
</tr>
<tr>
<td>테스트 범위</td>
<td>publisher 호출 위주</td>
<td>publisher + subscriber envelope 처리 테스트 추가</td>
</tr>
</table>

<hr>

<h2>📝 작업 내용</h2>

<h3>1) MatchingEventPublisher가 로컬 broker 직접 호출을 중단</h3>
<p>기존 <code>MatchingEventPublisher</code>는 아래처럼 <code>SimpMessagingTemplate</code>를 직접 주입받아 즉시 STOMP broker로 이벤트를 보내고 있었습니다.</p>

<pre><code class="language-java">private final SimpMessagingTemplate messagingTemplate;
</code></pre>

<p>이번 PR에서는 이를 제거하고, Redis pub/sub 발행기인 <code>WebSocketMessagePublisher</code>를 사용하도록 변경했습니다.</p>

<pre><code class="language-java">private final WebSocketMessagePublisher webSocketMessagePublisher;
</code></pre>

<p>즉, matching 도메인 서비스는 이제 “어떤 이벤트를 누구에게 보낼지”만 결정하고, 실제 서버 간 중계와 로컬 WebSocket fan-out은 global pub/sub 계층이 담당합니다.</p>

<h3>2) queue 공용 이벤트도 Redis pub/sub을 통해 발행하도록 변경</h3>
<p><code>publishQueueStateChanged()</code>는 기존에 로컬 broker로 바로 보내던 queue topic 이벤트를, 이제 Redis pub/sub으로 발행하도록 바뀌었습니다.</p>

<pre><code class="language-java">webSocketMessagePublisher.publish(
        toQueueTopic(queueKey),
        new MatchingEventResponse(MatchingEventType.QUEUE_STATE_CHANGED, queueState, null));
</code></pre>

<p>이 이벤트의 STOMP topic 구조는 기존과 동일합니다.</p>

<pre><code class="language-text">/topic/matching/queue/{category}/{difficulty}
</code></pre>

<p>차이는 이제 이벤트를 만든 서버가 직접 브로드캐스트하지 않고, Redis 채널을 통해 모든 서버가 동일한 topic 이벤트를 받아 각자 연결된 queue 구독자에게 fan-out 한다는 점입니다.</p>

<h3>3) ready-check 개인 이벤트도 Redis 경유 방식으로 통일</h3>
<p><code>READY_CHECK_STARTED</code>, <code>READY_DECISION_CHANGED</code>, <code>MATCH_CANCELLED</code>, <code>MATCH_EXPIRED</code>, <code>ROOM_READY</code> 같은 개인 matching 이벤트들도 이제 직접 <code>convertAndSendToUser</code> 하지 않고 Redis envelope로 중계합니다.</p>

<pre><code class="language-java">webSocketMessagePublisher.publishToUser(
        userId,
        USER_MATCHING_DESTINATION,
        new MatchingEventResponse(type, null, matchState));
</code></pre>

<p>즉, matched 사용자가 어느 서버 인스턴스에 붙어 있든, Redis를 구독한 각 서버가 자기 서버의 해당 user session에만 안전하게 재전달할 수 있게 됩니다.</p>

<h3>4) Redis 전송용 공통 envelope 추가</h3>
<p>Redis 채널에 실리는 메시지 형식을 통일하기 위해 <code>RedisWebSocketEnvelope</code>를 새로 추가했습니다.</p>

<pre><code class="language-java">public record RedisWebSocketEnvelope(
        WebSocketDispatchMode mode,
        String topic,
        Long userId,
        String destination,
        Object payload) {
</code></pre>

<p>그리고 아래 정적 팩토리를 제공합니다.</p>

<pre><code class="language-java">public static RedisWebSocketEnvelope forTopic(String topic, Object payload)
public static RedisWebSocketEnvelope forUser(Long userId, String destination, Object payload)
</code></pre>

<p>즉, Redis Pub/Sub 메시지는 이제 아래 두 형태를 공통 규약으로 가집니다.</p>
<ul>
<li><code>TOPIC</code> : 공용 topic 브로드캐스트</li>
<li><code>USER</code> : 특정 사용자 개인 destination 전송</li>
</ul>

<h3>5) dispatch mode enum 추가</h3>
<p>subscriber가 Redis 메시지를 다시 STOMP broker로 재전달할 때 방식을 구분할 수 있도록 <code>WebSocketDispatchMode</code> enum을 추가했습니다.</p>

<pre><code class="language-java">public enum WebSocketDispatchMode {
    TOPIC,
    USER
}
</code></pre>

<p>즉, “이 메시지가 topic용인지, user용인지”를 envelope 자체가 표현하도록 바꾼 것입니다.</p>

<h3>6) WebSocketMessagePublisher가 envelope 직렬화 후 Redis 채널에 발행</h3>
<p>기존 <code>WebSocketMessagePublisher</code>는 단순히 <code>Map.of("topic", ..., "payload", ...)</code> 구조를 JSON으로 만들어 Redis 채널에 발행하고 있었습니다. 이번 PR에서는 이를 envelope 기반 직렬화로 변경했습니다.</p>

<pre><code class="language-java">String json = objectMapper.writeValueAsString(envelope);
redisTemplate.convertAndSend(CHANNEL, json);
</code></pre>

<p>Redis channel은 그대로 아래 키를 사용합니다.</p>

<pre><code class="language-text">ws:messages
</code></pre>

<p>즉, 전송 경로는 유지하면서도 메시지 표현은 topic-only 구조에서 topic/user 공통 구조로 확장한 것입니다.</p>

<h3>7) WebSocketMessagePublisher에 publishToUser 추가</h3>
<p>이번 PR에서 퍼블리셔에 아래 메서드가 새로 추가됐습니다.</p>

<pre><code class="language-java">public void publishToUser(Long userId, String destination, Object payload)
</code></pre>

<p>이제 global WebSocket pub/sub 계층은 아래 두 가지를 모두 지원합니다.</p>
<ul>
<li><code>publish(topic, payload)</code></li>
<li><code>publishToUser(userId, destination, payload)</code></li>
</ul>

<p>즉, matching 도메인은 queue 공용 이벤트와 ready-check 개인 이벤트를 같은 인프라 계층으로 일관되게 발행할 수 있습니다.</p>

<h3>8) WebSocketMessageSubscriber가 TOPIC / USER를 구분해서 로컬 broker로 fan-out</h3>
<p>기존 subscriber는 Redis 메시지를 JSON tree로 읽은 뒤, 항상 <code>topic</code>과 <code>payload</code>를 꺼내 <code>convertAndSend</code>만 호출하고 있었습니다. 이번 PR에서는 envelope를 deserialize한 뒤 mode에 따라 분기하도록 변경했습니다.</p>

<pre><code class="language-java">RedisWebSocketEnvelope envelope = objectMapper.readValue(message, RedisWebSocketEnvelope.class);
</code></pre>

<p><strong>TOPIC 모드</strong>일 때는:</p>

<pre><code class="language-java">messagingTemplate.convertAndSend(envelope.topic(), envelope.payload());
</code></pre>

<p><strong>USER 모드</strong>일 때는:</p>

<pre><code class="language-java">messagingTemplate.convertAndSendToUser(
        String.valueOf(envelope.userId()),
        envelope.destination(),
        envelope.payload());
</code></pre>

<p>즉, 이제 subscriber는 Redis로 들어온 matching 이벤트를 “공용 브로드캐스트”와 “개인 전송”으로 나눠 정확한 STOMP 방식으로 재전달합니다.</p>

<h3>9) malformed 메시지에 대한 방어 로직 추가</h3>
<p>subscriber에는 envelope가 불완전하거나 잘못된 경우를 안전하게 무시하는 방어 로직도 추가됐습니다.</p>

<p>아래 경우에는 로그만 남기고 메시지를 건너뜁니다.</p>
<ul>
<li><code>mode</code> 누락</li>
<li><code>TOPIC</code>인데 topic이 비어 있음</li>
<li><code>USER</code>인데 userId 또는 destination이 누락됨</li>
<li>지원하지 않는 mode 값</li>
</ul>

<p>즉, Redis 채널에 예기치 않은 메시지가 흘러들어오더라도 subscriber가 전체 흐름을 망가뜨리지 않도록 방어했습니다.</p>

<h3>10) MatchingEventPublisher 테스트를 Redis 발행 구조에 맞게 갱신</h3>
<p><code>MatchingEventPublisherTest</code>는 기존에 <code>SimpMessagingTemplate</code> 호출 여부를 검증했다면, 이번 PR에서는 <code>WebSocketMessagePublisher</code> 호출 여부를 검증하도록 변경됐습니다.</p>

<p>주요 검증 포인트는 아래와 같습니다.</p>
<ul>
<li><code>QUEUE_STATE_CHANGED</code>는 <code>publish(topic, payload)</code>로 발행되는지 확인</li>
<li><code>READY_CHECK_STARTED</code>는 <code>publishToUser(userId, "/queue/matching", payload)</code>로 발행되는지 확인</li>
<li><code>READY_DECISION_CHANGED</code>, <code>MATCH_CANCELLED</code>, <code>MATCH_EXPIRED</code>, <code>ROOM_READY</code>도 모두 개인 채널 발행인지 확인</li>
</ul>

<p>즉, matching 도메인 입장에서는 “로컬 broker로 바로 보낸다”가 아니라 “Redis pub/sub 계층에 위임한다”는 계약이 테스트로 고정됩니다.</p>

<h3>11) WebSocketMessageSubscriber 전용 테스트 추가</h3>
<p>이번 PR에서는 subscriber가 envelope를 올바르게 해석하는지를 검증하는 <code>WebSocketMessageSubscriberTest</code>를 새로 추가했습니다.</p>

<p>검증 시나리오는 아래와 같습니다.</p>
<ul>
<li><code>TOPIC</code> envelope를 받으면 <code>convertAndSend(topic, payload)</code>가 호출되는지 확인</li>
<li><code>USER</code> envelope를 받으면 <code>convertAndSendToUser(userId, destination, payload)</code>가 호출되는지 확인</li>
<li><code>mode</code>가 빠진 malformed 메시지는 예외 없이 무시되는지 확인</li>
</ul>

<p>즉, Redis pub/sub 구조에서 가장 중요한 “서버 간 중계 이후 로컬 STOMP fan-out” 동작을 별도 테스트로 보강한 것입니다.</p>

<h3>12) matching 도메인 이벤트 스펙 자체는 유지</h3>
<p>이번 PR은 이벤트 전달 경로를 바꾼 것이지, matching 도메인이 사용하는 이벤트 종류나 STOMP 목적지 자체를 바꾸는 작업은 아닙니다.</p>

<p>즉, 아래 이벤트들은 그대로 유지됩니다.</p>
<ul>
<li><code>QUEUE_STATE_CHANGED</code></li>
<li><code>READY_CHECK_STARTED</code></li>
<li><code>READY_DECISION_CHANGED</code></li>
<li><code>MATCH_CANCELLED</code></li>
<li><code>MATCH_EXPIRED</code></li>
<li><code>ROOM_READY</code></li>
</ul>

<p>그리고 목적지도 그대로 유지됩니다.</p>
<ul>
<li>공용 queue topic: <code>/topic/matching/queue/{category}/{difficulty}</code></li>
<li>개인 matching destination: <code>/queue/matching</code></li>
</ul>

<p>즉, 프론트 입장에서는 구독 규약을 바꿀 필요 없이, 멀티 서버 환경에서 이벤트 전달 안정성만 좋아지는 형태입니다.</p>

<hr>

<h2>전체 흐름</h2>
<pre><code class="language-text">[기존]
MatchingEventPublisher
  ↓
SimpMessagingTemplate.convertAndSend / convertAndSendToUser
  ↓
이벤트를 발행한 현재 서버의 로컬 broker로만 전송
  ↓
다른 서버에 붙은 세션은 이벤트를 못 받을 수 있음

[변경 후]
MatchingEventPublisher
  ↓
WebSocketMessagePublisher.publish / publishToUser
  ↓
Redis 채널 ws:messages 에 envelope(JSON) 발행
  ↓
모든 서버의 WebSocketMessageSubscriber 가 Redis 메시지 수신
  ↓
mode=TOPIC 이면 convertAndSend(topic, payload)
mode=USER 이면 convertAndSendToUser(userId, destination, payload)
  ↓
각 서버가 자기 서버에 연결된 WebSocket 세션으로 fan-out
</code></pre>

<hr>

<h2>정리된 효과</h2>
<ul>
<li>matching queue / ready-check 이벤트가 멀티 서버 환경에서도 안정적으로 전달될 수 있습니다.</li>
<li>queue 공용 topic 이벤트와 개인 user destination 이벤트를 같은 Redis envelope 규약으로 처리할 수 있습니다.</li>
<li>subscriber가 TOPIC / USER fan-out을 구분해 처리하므로, 개인 matching 이벤트도 서버 간 중계가 가능해집니다.</li>
<li>malformed Redis 메시지에 대한 방어 로직과 테스트가 추가되어 운영 안정성이 좋아집니다.</li>
</ul>

<h2>확인 포인트</h2>
<ol>
<li>같은 queueKey를 구독 중인 사용자가 서로 다른 서버에 붙어 있어도 <code>QUEUE_STATE_CHANGED</code>를 모두 받는지 확인</li>
<li>matched 사용자가 다른 서버 인스턴스에 붙어 있어도 <code>READY_CHECK_STARTED</code>, <code>READY_DECISION_CHANGED</code>, <code>MATCH_CANCELLED</code>, <code>MATCH_EXPIRED</code>, <code>ROOM_READY</code>를 정상 수신하는지 확인</li>
<li>subscriber가 <code>TOPIC</code> envelope는 <code>convertAndSend</code>, <code>USER</code> envelope는 <code>convertAndSendToUser</code>로 정확히 fan-out 하는지 확인</li>
<li>Redis Pub/Sub 채널 <code>ws:messages</code>에 malformed 메시지가 들어가도 서버가 안전하게 무시하는지 확인</li>
</ol>
</body>
</html>

