### PR TITLE
feat: 태그 응답에 난이도 목록 포함

### DIFF
--- a/src/main/java/com/back/domain/tag/tag/dto/TagResponse.java
+++ b/src/main/java/com/back/domain/tag/tag/dto/TagResponse.java
@@ -1,3 +1,5 @@
 package com.back.domain.tag.tag.dto;
 
-public record TagResponse(String code, String label) {}
+import java.util.List;
+
+public record TagResponse(String code, String label, List<String> difficulties) {}

--- a/src/main/java/com/back/domain/tag/tag/repository/TagRepository.java
+++ b/src/main/java/com/back/domain/tag/tag/repository/TagRepository.java
@@ -4,11 +4,32 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.tag.tag.entity.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    interface TagDifficultyView {
+        String getTagName();
+
+        DifficultyLevel getDifficulty();
+    }
+
     List<Tag> findAllByOrderByNameAsc();
 
     Optional<Tag> findByName(String name);
+
+    @Query(
+            """
+            select t.name as tagName, p.difficulty as difficulty
+            from ProblemTagConnect ptc
+            join ptc.tag t
+            join ptc.problem p
+            where t.name is not null
+              and trim(t.name) <> ''
+            group by t.name, p.difficulty
+            order by t.name asc
+            """)
+    List<TagDifficultyView> findTagDifficulties();
 }

--- a/src/main/java/com/back/domain/tag/tag/repository/TagRepository.java
+++ b/src/main/java/com/back/domain/tag/tag/repository/TagRepository.java
@@ -20,8 +20,7 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 
     Optional<Tag> findByName(String name);
 
-    @Query(
-            """
+    @Query("""
             select t.name as tagName, p.difficulty as difficulty
             from ProblemTagConnect ptc
             join ptc.tag t

--- a/src/main/java/com/back/domain/tag/tag/service/TagService.java
+++ b/src/main/java/com/back/domain/tag/tag/service/TagService.java
@@ -1,10 +1,14 @@
 package com.back.domain.tag.tag.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.tag.tag.dto.TagResponse;
 import com.back.domain.tag.tag.repository.TagRepository;
 
@@ -15,14 +19,35 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class TagService {
 
+    private static final List<DifficultyLevel> DIFFICULTY_ORDER =
+            List.of(DifficultyLevel.EASY, DifficultyLevel.MEDIUM, DifficultyLevel.HARD);
+
     private final TagRepository tagRepository;
 
     public List<TagResponse> getTags() {
+        Map<String, Set<DifficultyLevel>> difficultyByTag = tagRepository.findTagDifficulties().stream()
+                .filter(row -> row.getTagName() != null && row.getDifficulty() != null)
+                .filter(row -> !row.getTagName().trim().isBlank())
+                .collect(Collectors.groupingBy(
+                        row -> row.getTagName().trim(),
+                        Collectors.mapping(TagRepository.TagDifficultyView::getDifficulty, Collectors.toSet())));
+
         return tagRepository.findAllByOrderByNameAsc().stream()
                 .map(tag -> tag.getName() == null ? null : tag.getName().trim())
                 .filter(name -> name != null && !name.isBlank())
                 .distinct()
-                .map(name -> new TagResponse(name, name))
+                .map(name -> new TagResponse(name, name, toDifficultyNames(difficultyByTag.get(name))))
+                .toList();
+    }
+
+    private List<String> toDifficultyNames(Set<DifficultyLevel> levels) {
+        if (levels == null || levels.isEmpty()) {
+            return List.of();
+        }
+
+        return DIFFICULTY_ORDER.stream()
+                .filter(levels::contains)
+                .map(DifficultyLevel::name)
                 .toList();
     }
 }

--- a/src/test/java/com/back/domain/tag/tag/controller/TagControllerTest.java
+++ b/src/test/java/com/back/domain/tag/tag/controller/TagControllerTest.java
@@ -21,7 +21,9 @@ class TagControllerTest {
     @Test
     @DisplayName("태그 컨트롤러는 서비스 결과를 그대로 반환한다")
     void getTags_returnsServiceResult() {
-        List<TagResponse> response = List.of(new TagResponse("array", "array"), new TagResponse("graph", "graph"));
+        List<TagResponse> response = List.of(
+                new TagResponse("array", "array", List.of("EASY")),
+                new TagResponse("graph", "graph", List.of("MEDIUM", "HARD")));
 
         when(tagService.getTags()).thenReturn(response);
 

--- a/src/test/java/com/back/domain/tag/tag/service/TagServiceTest.java
+++ b/src/test/java/com/back/domain/tag/tag/service/TagServiceTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.back.domain.problem.problem.enums.DifficultyLevel;
 import com.back.domain.tag.tag.dto.TagResponse;
 import com.back.domain.tag.tag.entity.Tag;
 import com.back.domain.tag.tag.repository.TagRepository;
@@ -19,20 +20,33 @@ class TagServiceTest {
     private final TagService tagService = new TagService(tagRepository);
 
     @Test
-    @DisplayName("태그 목록 조회 시 code/label을 태그 이름으로 반환한다")
+    @DisplayName("태그 목록 조회 시 code/label과 난이도 목록을 함께 반환한다")
     void getTags_returnsTagList() {
         Tag arrayTag = mock(Tag.class);
         Tag graphTag = mock(Tag.class);
         Tag blankTag = mock(Tag.class);
+        TagRepository.TagDifficultyView arrayEasy = mock(TagRepository.TagDifficultyView.class);
+        TagRepository.TagDifficultyView arrayHard = mock(TagRepository.TagDifficultyView.class);
+        TagRepository.TagDifficultyView graphMedium = mock(TagRepository.TagDifficultyView.class);
 
         when(arrayTag.getName()).thenReturn("array");
         when(graphTag.getName()).thenReturn("graph");
         when(blankTag.getName()).thenReturn("  ");
+        when(arrayEasy.getTagName()).thenReturn("array");
+        when(arrayEasy.getDifficulty()).thenReturn(DifficultyLevel.EASY);
+        when(arrayHard.getTagName()).thenReturn("array");
+        when(arrayHard.getDifficulty()).thenReturn(DifficultyLevel.HARD);
+        when(graphMedium.getTagName()).thenReturn("graph");
+        when(graphMedium.getDifficulty()).thenReturn(DifficultyLevel.MEDIUM);
 
         when(tagRepository.findAllByOrderByNameAsc()).thenReturn(List.of(arrayTag, graphTag, blankTag));
+        when(tagRepository.findTagDifficulties()).thenReturn(List.of(arrayEasy, arrayHard, graphMedium));
 
         List<TagResponse> response = tagService.getTags();
 
-        assertThat(response).containsExactly(new TagResponse("array", "array"), new TagResponse("graph", "graph"));
+        assertThat(response)
+                .containsExactly(
+                        new TagResponse("array", "array", List.of("EASY", "HARD")),
+                        new TagResponse("graph", "graph", List.of("MEDIUM")));
     }
 }


### PR DESCRIPTION
## 작업 내용
- 태그 조회 응답(`TagResponse`)에 `difficulties` 필드를 추가
- 태그별로 연결된 문제 난이도 목록(EASY/MEDIUM/HARD)을 함께 반환하도록 서비스/레포지토리 로직 보강
- 태그 컨트롤러/서비스 테스트를 새 응답 구조에 맞게 갱신

## 변경 파일
- `src/main/java/com/back/domain/tag/tag/dto/TagResponse.java`
- `src/main/java/com/back/domain/tag/tag/repository/TagRepository.java`
- `src/main/java/com/back/domain/tag/tag/service/TagService.java`
- `src/test/java/com/back/domain/tag/tag/controller/TagControllerTest.java`
- `src/test/java/com/back/domain/tag/tag/service/TagServiceTest.java`