### PR TITLE
[refactor] 순위 공정성 문제 해결

### DIFF
--- a/src/main/java/com/back/global/judge/BattleAcService.java
+++ b/src/main/java/com/back/global/judge/BattleAcService.java
@@ -33,7 +33,7 @@ public class BattleAcService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public void handleAc(Long roomId, Long memberId) {
+    public void handleAc(Long roomId, Long memberId, LocalDateTime submittedAt) {
         BattleRoom room = battleRoomRepository
                 .findById(roomId)
                 .orElseThrow(() -> new IllegalStateException("BattleRoom not found: " + roomId));
@@ -45,7 +45,7 @@ public class BattleAcService {
                 .findByBattleRoomAndMember(room, member)
                 .orElseThrow(() -> new IllegalStateException("Participant not found"));
 
-        participant.complete(LocalDateTime.now());
+        participant.complete(submittedAt);
         battleParticipantRepository.save(participant);
 
         List<BattleParticipant> allParticipants = battleParticipantRepository.findByBattleRoom(room);

--- a/src/main/java/com/back/global/judge/JudgeService.java
+++ b/src/main/java/com/back/global/judge/JudgeService.java
@@ -91,7 +91,7 @@ public class JudgeService {
                         "totalCount", totalCount));
 
         if (judgeResult == SubmissionResult.AC) {
-            battleAcService.handleAc(roomId, memberId);
+            battleAcService.handleAc(roomId, memberId, submission.getCreatedAt());
         }
     }
 

--- a/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
+++ b/src/test/java/com/back/domain/battle/result/service/BattleResultServiceTest.java
@@ -32,7 +32,9 @@ import com.back.domain.battle.battleroom.entity.BattleRoomStatus;
 import com.back.domain.battle.battleroom.repository.BattleRoomRepository;
 import com.back.domain.battle.result.dto.ActiveRoomResponse;
 import com.back.domain.battle.result.dto.MyBattleResultsResponse;
+import com.back.domain.member.member.entity.Member;
 import com.back.domain.problem.problem.entity.Problem;
+import com.back.domain.problem.submission.entity.SubmissionResult;
 import com.back.domain.problem.submission.repository.SubmissionRepository;
 import com.back.domain.rating.profile.service.RatingProfileService;
 import com.back.global.exception.ServiceException;
@@ -219,6 +221,239 @@ class BattleResultServiceTest {
         withAfterCommit(() -> battleResultService.settle(2L));
 
         verify(participant).applyResult(1, -10L);
+    }
+
+    // -----------------------------------------------------------------------
+    // 순위 산정 공정성 테스트
+    // calcScore = 배틀 시작부터 finishTime까지의 초 + WA 횟수 * 20초 패널티
+    // 미통과(TIMEOUT/ABANDONED/QUIT) 참여자는 Long.MAX_VALUE → 항상 AC 뒤
+    // 동점이면 finishTime 빠른 사람이 앞 순위
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("AC 참여자는 미통과 참여자보다 앞 순위를 받는다")
+    void settle_acRanksBeforeNonAc() {
+        BattleRoom room = mock(BattleRoom.class);
+        Problem problem = mock(Problem.class);
+        Member memberA = mock(Member.class);
+        Member memberB = mock(Member.class);
+        BattleParticipant participantA = mock(BattleParticipant.class);
+        BattleParticipant participantB = mock(BattleParticipant.class);
+
+        LocalDateTime startedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0);
+
+        when(battleRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        when(room.getProblem()).thenReturn(problem);
+        when(room.getStartedAt()).thenReturn(startedAt);
+        when(problem.getDifficultyRating()).thenReturn(1200);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participantA, participantB));
+
+        when(participantA.getId()).thenReturn(1L);
+        when(participantA.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantA.getFinishTime()).thenReturn(startedAt.plusMinutes(10));
+        when(participantA.getMember()).thenReturn(memberA);
+        when(memberA.getId()).thenReturn(101L);
+
+        when(participantB.getId()).thenReturn(2L);
+        when(participantB.getStatus()).thenReturn(BattleParticipantStatus.TIMEOUT);
+        when(participantB.getMember()).thenReturn(memberB);
+        when(memberB.getId()).thenReturn(102L);
+
+        when(submissionRepository.countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+                        eq(room), eq(memberA), eq(SubmissionResult.WA), any()))
+                .thenReturn(0L);
+        when(ratingProfileService.applyBattlePlacements(any(), eq(1200))).thenReturn(Map.of());
+
+        withAfterCommit(() -> battleResultService.settle(1L));
+
+        verify(participantA).applyResult(1, 0L);
+        verify(participantB).applyResult(2, 0L);
+    }
+
+    @Test
+    @DisplayName("AC 참여자 간에는 finishTime 빠른 순으로 순위를 받는다")
+    void settle_earlierFinishTimeWinsAmongAc() {
+        BattleRoom room = mock(BattleRoom.class);
+        Problem problem = mock(Problem.class);
+        Member memberA = mock(Member.class);
+        Member memberB = mock(Member.class);
+        BattleParticipant participantA = mock(BattleParticipant.class); // 15분 - 늦게 풀음
+        BattleParticipant participantB = mock(BattleParticipant.class); // 10분 - 먼저 풀음
+
+        LocalDateTime startedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0);
+
+        when(battleRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        when(room.getProblem()).thenReturn(problem);
+        when(room.getStartedAt()).thenReturn(startedAt);
+        when(problem.getDifficultyRating()).thenReturn(1200);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participantA, participantB));
+
+        when(participantA.getId()).thenReturn(1L);
+        when(participantA.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantA.getFinishTime()).thenReturn(startedAt.plusMinutes(15)); // score = 900
+        when(participantA.getMember()).thenReturn(memberA);
+        when(memberA.getId()).thenReturn(101L);
+
+        when(participantB.getId()).thenReturn(2L);
+        when(participantB.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantB.getFinishTime()).thenReturn(startedAt.plusMinutes(10)); // score = 600
+        when(participantB.getMember()).thenReturn(memberB);
+        when(memberB.getId()).thenReturn(102L);
+
+        when(submissionRepository.countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+                        eq(room), any(), eq(SubmissionResult.WA), any()))
+                .thenReturn(0L);
+        when(ratingProfileService.applyBattlePlacements(any(), eq(1200))).thenReturn(Map.of());
+
+        withAfterCommit(() -> battleResultService.settle(1L));
+
+        verify(participantB).applyResult(1, 0L); // 10분 → 1등
+        verify(participantA).applyResult(2, 0L); // 15분 → 2등
+    }
+
+    @Test
+    @DisplayName("WA 패널티(1회당 20초)가 score에 반영되어 순위가 바뀐다")
+    void settle_waPenaltyAppliedToScore() {
+        BattleRoom room = mock(BattleRoom.class);
+        Problem problem = mock(Problem.class);
+        Member memberA = mock(Member.class);
+        Member memberB = mock(Member.class);
+        BattleParticipant participantA = mock(BattleParticipant.class); // 9분 + WA 1회 = 540 + 20 = 560초
+        BattleParticipant participantB = mock(BattleParticipant.class); // 10분 + WA 0회 = 600초
+
+        LocalDateTime startedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0);
+        LocalDateTime finishA = startedAt.plusSeconds(540); // 9분
+        LocalDateTime finishB = startedAt.plusSeconds(600); // 10분
+
+        when(battleRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        when(room.getProblem()).thenReturn(problem);
+        when(room.getStartedAt()).thenReturn(startedAt);
+        when(problem.getDifficultyRating()).thenReturn(1200);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participantA, participantB));
+
+        when(participantA.getId()).thenReturn(1L);
+        when(participantA.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantA.getFinishTime()).thenReturn(finishA);
+        when(participantA.getMember()).thenReturn(memberA);
+        when(memberA.getId()).thenReturn(101L);
+
+        when(participantB.getId()).thenReturn(2L);
+        when(participantB.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantB.getFinishTime()).thenReturn(finishB);
+        when(participantB.getMember()).thenReturn(memberB);
+        when(memberB.getId()).thenReturn(102L);
+
+        // A: WA 1회 → score = 540 + 20 = 560
+        when(submissionRepository.countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+                        eq(room), eq(memberA), eq(SubmissionResult.WA), eq(finishA)))
+                .thenReturn(1L);
+        // B: WA 0회 → score = 600
+        when(submissionRepository.countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+                        eq(room), eq(memberB), eq(SubmissionResult.WA), eq(finishB)))
+                .thenReturn(0L);
+        when(ratingProfileService.applyBattlePlacements(any(), eq(1200))).thenReturn(Map.of());
+
+        withAfterCommit(() -> battleResultService.settle(1L));
+
+        verify(participantA).applyResult(1, 0L); // 560초 → 1등
+        verify(participantB).applyResult(2, 0L); // 600초 → 2등
+    }
+
+    @Test
+    @DisplayName("WA 패널티가 누적되면 더 빨리 푼 사람도 순위가 밀릴 수 있다")
+    void settle_heavyWaPenaltyCanFlipRanking() {
+        BattleRoom room = mock(BattleRoom.class);
+        Problem problem = mock(Problem.class);
+        Member memberA = mock(Member.class);
+        Member memberB = mock(Member.class);
+        BattleParticipant participantA = mock(BattleParticipant.class); // 10분 + WA 3회 = 600 + 60 = 660초
+        BattleParticipant participantB = mock(BattleParticipant.class); // 10분 50초 + WA 0회 = 650초
+
+        LocalDateTime startedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0);
+        LocalDateTime finishA = startedAt.plusSeconds(600); // 10분
+        LocalDateTime finishB = startedAt.plusSeconds(650); // 10분 50초
+
+        when(battleRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        when(room.getProblem()).thenReturn(problem);
+        when(room.getStartedAt()).thenReturn(startedAt);
+        when(problem.getDifficultyRating()).thenReturn(1200);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participantA, participantB));
+
+        when(participantA.getId()).thenReturn(1L);
+        when(participantA.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantA.getFinishTime()).thenReturn(finishA);
+        when(participantA.getMember()).thenReturn(memberA);
+        when(memberA.getId()).thenReturn(101L);
+
+        when(participantB.getId()).thenReturn(2L);
+        when(participantB.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantB.getFinishTime()).thenReturn(finishB);
+        when(participantB.getMember()).thenReturn(memberB);
+        when(memberB.getId()).thenReturn(102L);
+
+        // A: WA 3회 → score = 600 + 60 = 660
+        when(submissionRepository.countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+                        eq(room), eq(memberA), eq(SubmissionResult.WA), eq(finishA)))
+                .thenReturn(3L);
+        // B: WA 0회 → score = 650
+        when(submissionRepository.countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+                        eq(room), eq(memberB), eq(SubmissionResult.WA), eq(finishB)))
+                .thenReturn(0L);
+        when(ratingProfileService.applyBattlePlacements(any(), eq(1200))).thenReturn(Map.of());
+
+        withAfterCommit(() -> battleResultService.settle(1L));
+
+        verify(participantB).applyResult(1, 0L); // 650초 → 1등
+        verify(participantA).applyResult(2, 0L); // 660초 → 2등
+    }
+
+    @Test
+    @DisplayName("score가 같으면 finishTime이 빠른 참여자가 앞 순위를 받는다")
+    void settle_tieScoreBreaksByFinishTime() {
+        BattleRoom room = mock(BattleRoom.class);
+        Problem problem = mock(Problem.class);
+        Member memberA = mock(Member.class);
+        Member memberB = mock(Member.class);
+        BattleParticipant participantA = mock(BattleParticipant.class);
+        BattleParticipant participantB = mock(BattleParticipant.class);
+
+        LocalDateTime startedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0);
+        // 둘 다 정확히 600초 경과 → elapsedSeconds 동일, finishTime 차이로 순위 결정
+        LocalDateTime finishA = startedAt.plusSeconds(600);
+        LocalDateTime finishB = startedAt.plusSeconds(600).plusNanos(500_000_000); // 0.5초 늦음
+
+        when(battleRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(room.getStatus()).thenReturn(BattleRoomStatus.PLAYING);
+        when(room.getProblem()).thenReturn(problem);
+        when(room.getStartedAt()).thenReturn(startedAt);
+        when(problem.getDifficultyRating()).thenReturn(1200);
+        when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participantA, participantB));
+
+        when(participantA.getId()).thenReturn(1L);
+        when(participantA.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantA.getFinishTime()).thenReturn(finishA);
+        when(participantA.getMember()).thenReturn(memberA);
+        when(memberA.getId()).thenReturn(101L);
+
+        when(participantB.getId()).thenReturn(2L);
+        when(participantB.getStatus()).thenReturn(BattleParticipantStatus.SOLVED);
+        when(participantB.getFinishTime()).thenReturn(finishB);
+        when(participantB.getMember()).thenReturn(memberB);
+        when(memberB.getId()).thenReturn(102L);
+
+        when(submissionRepository.countByBattleRoomAndMemberAndResultAndCreatedAtBefore(
+                        eq(room), any(), eq(SubmissionResult.WA), any()))
+                .thenReturn(0L);
+        when(ratingProfileService.applyBattlePlacements(any(), eq(1200))).thenReturn(Map.of());
+
+        withAfterCommit(() -> battleResultService.settle(1L));
+
+        verify(participantA).applyResult(1, 0L); // finishTime 빠름 → 1등
+        verify(participantB).applyResult(2, 0L); // finishTime 0.5초 늦음 → 2등
     }
 
     private void withAfterCommit(Runnable action) {

--- a/src/test/java/com/back/global/judge/BattleAcServiceTest.java
+++ b/src/test/java/com/back/global/judge/BattleAcServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,9 +65,11 @@ class BattleAcServiceTest {
                 .thenReturn(Optional.of(participant));
         when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, solvedOther));
 
-        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));
+        LocalDateTime submittedAt = LocalDateTime.now();
+        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID, submittedAt));
 
         assertThat(participant.getStatus()).isEqualTo(BattleParticipantStatus.SOLVED);
+        assertThat(participant.getFinishTime()).isEqualTo(submittedAt);
         verify(battleParticipantRepository).save(participant);
         verify(publisher, times(2)).publish(eq("/topic/room/" + ROOM_ID), any());
         verify(publisher)
@@ -103,7 +106,7 @@ class BattleAcServiceTest {
                 .thenReturn(Optional.of(participant));
         when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, quitOther));
 
-        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));
+        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID, LocalDateTime.now()));
 
         verify(eventPublisher).publishEvent(new BattleSettlementRequestedEvent(ROOM_ID));
     }
@@ -126,7 +129,7 @@ class BattleAcServiceTest {
                 .thenReturn(Optional.of(participant));
         when(battleParticipantRepository.findByBattleRoom(room)).thenReturn(List.of(participant, abandonedOther));
 
-        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));
+        withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID, LocalDateTime.now()));
 
         verify(eventPublisher, never()).publishEvent(any(BattleSettlementRequestedEvent.class));
     }

--- a/src/test/java/com/back/global/judge/JudgeServiceTest.java
+++ b/src/test/java/com/back/global/judge/JudgeServiceTest.java
@@ -3,6 +3,7 @@ package com.back.global.judge;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -162,7 +163,7 @@ class JudgeServiceTest {
 
         judgeService.onJudgeRequested(event(List.of(tc)));
 
-        verify(battleAcService, never()).handleAc(any(), any());
+        verify(battleAcService, never()).handleAc(any(), any(), any());
     }
 
     @Test
@@ -173,7 +174,7 @@ class JudgeServiceTest {
 
         judgeService.onJudgeRequested(event(List.of(tc)));
 
-        verify(battleAcService).handleAc(ROOM_ID, MEMBER_ID);
+        verify(battleAcService).handleAc(eq(ROOM_ID), eq(MEMBER_ID), isNull());
     }
 
     @Test


### PR DESCRIPTION
현재 `BattleAcService.handleAc()`에서 finishTime을 `LocalDateTime.now()`로 기록한다.
이 시각은 Judge0 결과를 polling으로 감지한 시각이므로, 아래 두 가지 노이즈가 포함된다:
 - Judge0 큐 대기 시간 (서버 부하에 따라 사용자마다 다름)
 - 1초 polling 간격 오차 (최대 1초 랜덤 지연)

 결과적으로 "더 빨리 맞는 코드를 제출한 사람"이 아닌 "Judge0가 더 빨리 처리해준 사람"이 유리해질 수 있다.

 목표: finishTime 기준을 Judge0 결과 감지 시각 → AC 제출 요청 시각(Submission.createdAt)으로 변경

---

### 변경 파일 목록

| 파일 | 변경 내용 |
|---|---|
| `src/main/java/com/back/global/judge/BattleAcService.java` | 메서드 시그니처 변경, `LocalDateTime.now()` 제거 |
| `src/main/java/com/back/global/judge/JudgeService.java` | `handleAc()` 호출 시 `submission.getCreatedAt()` 전달 |
| `src/test/java/com/back/global/judge/BattleAcServiceTest.java` | 테스트 `handleAc()` 호출부 파라미터 추가 |
| `src/test/java/com/back/global/judge/JudgeServiceTest.java` | Mock verify 파라미터 수정 |

---

### 상세 변경 계획

1. BattleAcService.java
```java
// 변경 전
public void handleAc(Long roomId, Long memberId) {
    ...
    participant.complete(LocalDateTime.now());
    ...
}

// 변경 후
public void handleAc(Long roomId, Long memberId, LocalDateTime submittedAt) {
    ...
    participant.complete(submittedAt);
    ...
}
```
- import java.time.LocalDateTime 이미 존재하므로 추가 불필요

---

 2. JudgeService.java

submission은 라인 78에서 이미 조회된 상태 → 추가 DB 쿼리 없음
```java
// 변경 전 (라인 94)
if (judgeResult == SubmissionResult.AC) {
    battleAcService.handleAc(roomId, memberId);
}

// 변경 후
if (judgeResult == SubmissionResult.AC) {
    battleAcService.handleAc(roomId, memberId, submission.getCreatedAt());
}
```
---

3. BattleAcServiceTest.java

테스트에서는 JPA Auditing이 동작하지 않으므로 LocalDateTime.now()를 직접 생성해서 전달
```java
// 변경 전 (라인 67, 106, 129)
withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID));

// 변경 후
LocalDateTime submittedAt = LocalDateTime.now();
withAfterCommit(() -> battleAcService.handleAc(ROOM_ID, MEMBER_ID, submittedAt));

- finishTime이 submittedAt으로 기록되는지 검증하는 assertion 추가 가능
assertThat(participant.getFinishTime()).isEqualTo(submittedAt);
```
---
4. JudgeServiceTest.java
```java
// 변경 전 (라인 165)
verify(battleAcService, never()).handleAc(any(), any());

// 변경 후
verify(battleAcService, never()).handleAc(any(), any(), any());

// 변경 전 (라인 176)
verify(battleAcService).handleAc(ROOM_ID, MEMBER_ID);

// 변경 후 — 테스트에서 submission.getCreatedAt()은 null (JPA Auditing 미동작)
verify(battleAcService).handleAc(eq(ROOM_ID), eq(MEMBER_ID), isNull());
```
- isNull() import: import static org.mockito.ArgumentMatchers.isNull;

---
검증 방법

1. ./gradlew test --tests "*.BattleAcServiceTest" 통과 확인
2. ./gradlew test --tests "*.JudgeServiceTest" 통과 확인
3. 로컬 배틀 시나리오 수동 테스트:
   - 두 유저가 동시에 AC 제출
   - finishTime이 제출 시각 기준으로 기록되는지 DB 직접 확인
   - 더 빨리 제출한 유저가 더 낮은 score를 받는지 확인